### PR TITLE
fix: Incorrect Handling of One-Way Train Runs in Track Data Assignment

### DIFF
--- a/src/app/streckengrafik/services/sg-6-track.service.ts
+++ b/src/app/streckengrafik/services/sg-6-track.service.ts
@@ -1107,10 +1107,31 @@ export class Sg6TrackService implements OnDestroy {
           }
         }
         if (path.isSection()) {
-          if (
-            path.getPathSection().arrivalNodeId + ":" + path.getPathSection().departureNodeId ===
-            key
-          ) {
+          // This code checks if the current path section matches a specified key
+          // before copying track data to it. There are two main conditions:
+          //
+          // 1. **Common Behavior**:
+          //    - We copy the track data if the arrival and departure node IDs of the
+          //      path section match the key in the correct order (arrival:departure).
+          //
+          // 2. **One-Way Check**:
+          //    - For one-way train runs (non-round trips), we also check if the
+          //      section's departure and arrival node IDs match the key in reverse
+          //      order (departure:arrival). This allows us to handle one-way
+          //      template train runs correctly.
+          //
+          // If either condition is satisfied, the track data will be assigned to
+          // the path section.
+          const checkCommonBehavior =
+            path.getPathSection().arrivalNodeId + ":" + path.getPathSection().departureNodeId === key;
+
+          const ts =
+            this.trainrunSectionService.getTrainrunSectionFromId(path.getPathSection().trainrunSectionId);
+          const checkOneWayOppositeDirection =
+            (!ts.getTrainrun().isRoundTrip()) &&
+            (path.getPathSection().departureNodeId + ":" + path.getPathSection().arrivalNodeId === key);
+
+          if (checkCommonBehavior || checkOneWayOppositeDirection) {
             path.getPathSection().trackData = trackData;
           }
         }


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->

# Description

Fix Implemented:

The logic for the checkOneWayOppositeDirection condition was revised to ensure it accurately checks for the correct key format for one-way train runs. This ensures that track data is copied even when the section is in the opposite direction of the defined key.



- [ ] This PR contains a description of the changes I'm making
- [ ] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
- [ ] I've added tests for changes or features I've introduced
- [ ] I documented any high-level concepts I'm introducing in `documentation/`
- [ ] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
