### PR TITLE
fix: Highlight entire trainrun when hovering a trainrun section line

### DIFF
--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.edgeline.scss
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.edgeline.scss
@@ -76,57 +76,57 @@
 }
 
 /// HOVER
-::ng-deep g.edge.Lines:hover {
-  /// FREQ_120:hover
-  ::ng-deep path.edge_line.layer_1.Freq_120 {
-    stroke-width: 3.25px;
-  }
-
-  /// FREQ_60:hover
-  ::ng-deep path.edge_line.layer_1.Freq_60 {
-    stroke-width: 3.25px;
-  }
-
-  /// FREQ_30:hover
-  ::ng-deep path.edge_line.layer_2.Freq_30 {
-    stroke-width: 7.5px;
-  }
-
-  ::ng-deep path.edge_line.layer_3.Freq_30 {
-    stroke-width: 2.5px;
-  }
-
-  /// FREQ_20:hover
-  ::ng-deep path.edge_line.layer_1.Freq_20 {
-    stroke-width: 6.25px;
-  }
-
-  ::ng-deep path.edge_line.layer_2.Freq_20 {
-    stroke-width: 3.75px;
-  }
-
-  ::ng-deep path.edge_line.layer_3.Freq_20 {
-    stroke-width: 1.25px;
-  }
-
-  /// FREQ_15:hover
-  path.edge_line.layer_0.Freq_15 {
-    stroke-width: 8.75px;
-    stroke-opacity: 1;
-  }
-
-  path.edge_line.layer_1.Freq_15 {
-    stroke-width: 6.25px;
-  }
-
-  path.edge_line.layer_2.Freq_15 {
-    stroke-width: 3.75px;
-  }
-
-  path.edge_line.layer_3.Freq_15 {
-    stroke-width: 1.25px;
-  }
+/// -------------------------------------------------------------
+/// FREQ_120:hover
+::ng-deep path.edge_line.layer_1.Freq_120.hover {
+  stroke-width: 3.25px;
 }
+
+/// FREQ_60:hover
+::ng-deep path.edge_line.layer_1.Freq_60.hover {
+  stroke-width: 3.25px;
+}
+
+/// FREQ_30:hover
+::ng-deep path.edge_line.layer_2.Freq_30.hover {
+  stroke-width: 7.5px;
+}
+
+::ng-deep path.edge_line.layer_3.Freq_30.hover {
+  stroke-width: 2.5px;
+}
+
+/// FREQ_20:hover
+::ng-deep path.edge_line.layer_1.Freq_20.hover {
+  stroke-width: 6.25px;
+}
+
+::ng-deep path.edge_line.layer_2.Freq_20.hover {
+  stroke-width: 3.75px;
+}
+
+::ng-deep path.edge_line.layer_3.Freq_20.hover {
+  stroke-width: 1.25px;
+}
+
+/// FREQ_15:hover
+path.edge_line.layer_0.Freq_15.hover {
+  stroke-width: 8.75px;
+  stroke-opacity: 1;
+}
+
+path.edge_line.layer_1.Freq_15.hover {
+  stroke-width: 6.25px;
+}
+
+path.edge_line.layer_2.Freq_15.hover {
+  stroke-width: 3.75px;
+}
+
+path.edge_line.layer_3.Freq_15.hover {
+  stroke-width: 1.25px;
+}
+/// -------------------------------------------------------------
 
 ::ng-deep path.edge_line.no_event {
   pointer-events: none;

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.edgeline.scss
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.edgeline.scss
@@ -75,6 +75,59 @@
   stroke-width: 1px;
 }
 
+/// HOVER
+::ng-deep g.edge.Lines:hover {
+  /// FREQ_120:hover
+  ::ng-deep path.edge_line.layer_1.Freq_120 {
+    stroke-width: 3.25px;
+  }
+
+  /// FREQ_60:hover
+  ::ng-deep path.edge_line.layer_1.Freq_60 {
+    stroke-width: 3.25px;
+  }
+
+  /// FREQ_30:hover
+  ::ng-deep path.edge_line.layer_2.Freq_30 {
+    stroke-width: 7.5px;
+  }
+
+  ::ng-deep path.edge_line.layer_3.Freq_30 {
+    stroke-width: 2.5px;
+  }
+
+  /// FREQ_20:hover
+  ::ng-deep path.edge_line.layer_1.Freq_20 {
+    stroke-width: 6.25px;
+  }
+
+  ::ng-deep path.edge_line.layer_2.Freq_20 {
+    stroke-width: 3.75px;
+  }
+
+  ::ng-deep path.edge_line.layer_3.Freq_20 {
+    stroke-width: 1.25px;
+  }
+
+  /// FREQ_15:hover
+  path.edge_line.layer_0.Freq_15 {
+    stroke-width: 8.75px;
+    stroke-opacity: 1;
+  }
+
+  path.edge_line.layer_1.Freq_15 {
+    stroke-width: 6.25px;
+  }
+
+  path.edge_line.layer_2.Freq_15 {
+    stroke-width: 3.75px;
+  }
+
+  path.edge_line.layer_3.Freq_15 {
+    stroke-width: 1.25px;
+  }
+}
+
 ::ng-deep path.edge_line.no_event {
   pointer-events: none;
 }

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.edgeline.scss
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.edgeline.scss
@@ -115,20 +115,20 @@
 }
 
 /// FREQ_15:hover
-path.edge_line.layer_0.Freq_15.hover {
+::ng-deep path.edge_line.layer_0.Freq_15.hover {
   stroke-width: 8.75px;
   stroke-opacity: 1;
 }
 
-path.edge_line.layer_1.Freq_15.hover {
+::ng-deep path.edge_line.layer_1.Freq_15.hover {
   stroke-width: 6.25px;
 }
 
-path.edge_line.layer_2.Freq_15.hover {
+::ng-deep path.edge_line.layer_2.Freq_15.hover {
   stroke-width: 3.75px;
 }
 
-path.edge_line.layer_3.Freq_15.hover {
+::ng-deep path.edge_line.layer_3.Freq_15.hover {
   stroke-width: 1.25px;
 }
 /// -------------------------------------------------------------

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.edgeline.scss
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.edgeline.scss
@@ -26,6 +26,11 @@
 }
 
 /// FREQ_120
+::ng-deep path.edge_line.layer_0.Freq_120 {
+  stroke-width: 32px;
+  stroke-dasharray: none;
+}
+
 ::ng-deep path.edge_line.layer_1.Freq_120 {
   stroke-width: 2px;
 }

--- a/src/app/view/editor-main-view/data-views/transition.view.scss
+++ b/src/app/view/editor-main-view/data-views/transition.view.scss
@@ -125,20 +125,20 @@
 }
 
 /// FREQ_15:hover
-path.transition_line.layer_0.Freq_15.hover {
+::ng-deep path.transition_line.layer_0.Freq_15.hover {
   stroke-width: 8.75px;
   stroke-opacity: 1;
 }
 
-path.transition_line.layer_1.Freq_15.hover {
+::ng-deep path.transition_line.layer_1.Freq_15.hover {
   stroke-width: 6.25px;
 }
 
-path.transition_line.layer_2.Freq_15.hover {
+::ng-deep path.transition_line.layer_2.Freq_15.hover {
   stroke-width: 3.75px;
 }
 
-path.transition_line.layer_3.Freq_15.hover {
+::ng-deep path.transition_line.layer_3.Freq_15.hover {
   stroke-width: 1.25px;
 }
 /// -------------------------------------------------------------

--- a/src/app/view/editor-main-view/data-views/transition.view.scss
+++ b/src/app/view/editor-main-view/data-views/transition.view.scss
@@ -90,6 +90,59 @@
   stroke-opacity: 1;
 }
 
+/// HOVER
+/// -------------------------------------------------------------
+/// FREQ_120:hover
+::ng-deep path.transition_line.layer_1.Freq_120.hover {
+  stroke-width: 3.25px;
+}
+
+/// FREQ_60:hover
+::ng-deep path.transition_line.layer_1.Freq_60.hover {
+  stroke-width: 3.25px;
+}
+
+/// FREQ_30:hover
+::ng-deep path.transition_line.layer_2.Freq_30.hover {
+  stroke-width: 7.5px;
+}
+
+::ng-deep path.transition_line.layer_3.Freq_30.hover {
+  stroke-width: 2.5px;
+}
+
+/// FREQ_20:hover
+::ng-deep path.transition_line.layer_1.Freq_20.hover {
+  stroke-width: 6.25px;
+}
+
+::ng-deep path.transition_line.layer_2.Freq_20.hover {
+  stroke-width: 3.75px;
+}
+
+::ng-deep path.transition_line.layer_3.Freq_20.hover {
+  stroke-width: 1.25px;
+}
+
+/// FREQ_15:hover
+path.transition_line.layer_0.Freq_15.hover {
+  stroke-width: 8.75px;
+  stroke-opacity: 1;
+}
+
+path.transition_line.layer_1.Freq_15.hover {
+  stroke-width: 6.25px;
+}
+
+path.transition_line.layer_2.Freq_15.hover {
+  stroke-width: 3.75px;
+}
+
+path.transition_line.layer_3.Freq_15.hover {
+  stroke-width: 1.25px;
+}
+/// -------------------------------------------------------------
+
 ::ng-deep polygon.transition_pin {
   opacity: 0.01;
   stroke: $NODE_DOCKABLE;


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->

# Description

When the user is moving the mouse pointer over a trainrun section, the trainrun sections stroke-width gets wider. 

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [x] This PR contains a description of the changes I'm making
- [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
- [x] I've added tests for changes or features I've introduced
- [x] I documented any high-level concepts I'm introducing in `documentation/`
- [x] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
