### PR TITLE
470 bug export features bugged png svg

### DIFF
--- a/src/app/streckengrafik/components/streckengrafik.component.html
+++ b/src/app/streckengrafik/components/streckengrafik.component.html
@@ -124,126 +124,135 @@
         <!---   new line  --->
         <div class="footer_1 background"></div>
         <div class="footer_2 background">
-          <button
-            type="button"
-            [class]="getZoomButtonClassTag('SimpleButton', 41.6)"
-            title="1/4h"
-            (click)="onFixZoom(41.6)"
-          >
-            15'
-          </button>
-          <button
-            type="button"
-            [class]="getZoomButtonClassTag('SimpleButton', 20.8)"
-            title="1/2h"
-            (click)="onFixZoom(20.8)"
-          >
-            30'
-          </button>
-
-          <button
-            type="button"
-            [class]="getZoomButtonClassTag('SimpleButton', 10.4)"
-            title="1h"
-            (click)="onFixZoom(10.4)"
-          >
-            1h
-          </button>
-          <button
-            type="button"
-            [class]="getZoomButtonClassTag('SimpleButton', 5.2)"
-            title="2h"
-            (click)="onFixZoom(5.2)"
-          >
-            2h
-          </button>
-          <button
-            type="button"
-            [class]="getZoomButtonClassTag('SimpleButton', 2.6)"
-            title="4h"
-            (click)="onFixZoom(2.6)"
-          >
-            4h
-          </button>
-
-          <ng-container *ngIf="disabledDisplayTools">
+          <p>
             <button
               type="button"
-              class="SimpleButton Empty"
-              (click)="toggleDisplayTools()"
-              [title]="'app.streckengrafik.components.show-advanced-display-functions' | translate"
+              [class]="getZoomButtonClassTag('SimpleButton', 41.6)"
+              title="1/4h"
+              (click)="onFixZoom(41.6)"
             >
-              &#8942;
+              15'
             </button>
-          </ng-container>
 
+            <button
+              type="button"
+              [class]="getZoomButtonClassTag('SimpleButton', 20.8)"
+              title="1/2h"
+              (click)="onFixZoom(20.8)"
+            >
+              30'
+            </button>
+
+            <button
+              type="button"
+              [class]="getZoomButtonClassTag('SimpleButton', 10.4)"
+              title="1h"
+              (click)="onFixZoom(10.4)"
+            >
+              1h
+            </button>
+
+            <button
+              type="button"
+              [class]="getZoomButtonClassTag('SimpleButton', 5.2)"
+              title="2h"
+              (click)="onFixZoom(5.2)"
+            >
+              2h
+            </button>
+
+            <button
+              type="button"
+              [class]="getZoomButtonClassTag('SimpleButton', 2.6)"
+              title="4h"
+              (click)="onFixZoom(2.6)"
+            >
+              4h
+            </button>
+
+            <ng-container *ngIf="disabledDisplayTools">
+              <button
+                type="button"
+                class="SimpleButton Empty"
+                (click)="toggleDisplayTools()"
+                [title]="
+                  'app.streckengrafik.components.show-advanced-display-functions' | translate
+                "
+              >
+                &#8942;
+              </button>
+            </ng-container>
+          </p>
           <ng-container *ngIf="!disabledDisplayTools">
-            <br />
-            <button
-              type="button"
-              [class]="getStreckengrafikTimeNotFocusNorEnabledButtonClassTag('SimpleButton Time')"
-              [title]="
-                'app.streckengrafik.components.show-or-hide-time-for-non-selected-trainruns'
-                  | translate
-              "
-              (click)="toggleStreckengrafikTimeNotFocusNorEnabledButton()"
-              [attr.title]="
-                'app.streckengrafik.components.show-or-hide'
-                  | translate: {component: getTimeButtonText()}
-              "
-            >
-              {{ getTimeButtonText() }}
-            </button>
+            <p>
+              <button
+                type="button"
+                [class]="getStreckengrafikTimeNotFocusNorEnabledButtonClassTag('SimpleButton Time')"
+                [title]="
+                  'app.streckengrafik.components.show-or-hide-time-for-non-selected-trainruns'
+                    | translate
+                "
+                (click)="toggleStreckengrafikTimeNotFocusNorEnabledButton()"
+                [attr.title]="
+                  'app.streckengrafik.components.show-or-hide'
+                    | translate: {component: getTimeButtonText()}
+                "
+              >
+                {{ getTimeButtonText() }}
+              </button>
 
-            <button
-              type="button"
-              [class]="getStreckengrafikNameNotFocusNorEnabledButtonClassTag('SimpleButton Name')"
-              [title]="
-                'app.streckengrafik.components.show-or-hide-name-for-non-selected-trains'
-                  | translate
-              "
-              (click)="toggleStreckengrafikNameNotFocusNorEnabledButton()"
-              [attr.title]="
-                'app.streckengrafik.components.show-or-hide'
-                  | translate: {component: getNameButtonText()}
-              "
-            >
-              {{ getNameButtonText() }}
-            </button>
+              <button
+                type="button"
+                [class]="getStreckengrafikNameNotFocusNorEnabledButtonClassTag('SimpleButton Name')"
+                [title]="
+                  'app.streckengrafik.components.show-or-hide-name-for-non-selected-trains'
+                    | translate
+                "
+                (click)="toggleStreckengrafikNameNotFocusNorEnabledButton()"
+                [attr.title]="
+                  'app.streckengrafik.components.show-or-hide'
+                    | translate: {component: getNameButtonText()}
+                "
+              >
+                {{ getNameButtonText() }}
+              </button>
 
-            <button
-              type="button"
-              [class]="getHeadwayVisibleButtonClassTag('SimpleButton HeadwayBand')"
-              (click)="toggleHeadwayBandVisbility()"
-              [attr.title]="
-                'app.streckengrafik.components.show-or-hide'
-                  | translate: {component: getHeadwayBandButtonText()}
-              "
-            >
-              {{ getHeadwayBandButtonText() }}
-            </button>
+              <button
+                type="button"
+                [class]="getHeadwayVisibleButtonClassTag('SimpleButton HeadwayBand')"
+                (click)="toggleHeadwayBandVisbility()"
+                [attr.title]="
+                  'app.streckengrafik.components.show-or-hide'
+                    | translate: {component: getHeadwayBandButtonText()}
+                "
+              >
+                {{ getHeadwayBandButtonText() }}
+              </button>
 
-            <button
-              type="button"
-              [class]="getRailTrackSliderVisibleButtonClassTag('SimpleButton RailTrackSlider')"
-              (click)="toggleRailTrackSliderVisbility()"
-              [attr.title]="
-                'app.streckengrafik.components.show-or-hide'
-                  | translate: {component: getRailTrackSliderButtonText()}
-              "
-            >
-              {{ getRailTrackSliderButtonText() }}
-            </button>
+              <button
+                type="button"
+                [class]="getRailTrackSliderVisibleButtonClassTag('SimpleButton RailTrackSlider')"
+                (click)="toggleRailTrackSliderVisbility()"
+                [attr.title]="
+                  'app.streckengrafik.components.show-or-hide'
+                    | translate: {component: getRailTrackSliderButtonText()}
+                "
+              >
+                {{ getRailTrackSliderButtonText() }}
+              </button>
 
-            <button
-              type="button"
-              class="SimpleButton Empty"
-              style="background: none"
-              (click)="toggleDisplayTools()"
-              [title]="'app.streckengrafik.components.hide-advanced-display-functions' | translate"
-            >
-              &#x2715;
-            </button>
+              <button
+                type="button"
+                class="SimpleButton Empty"
+                style="background: none"
+                (click)="toggleDisplayTools()"
+                [title]="
+                  'app.streckengrafik.components.hide-advanced-display-functions' | translate
+                "
+              >
+                &#x2715;
+              </button>
+            </p>
           </ng-container>
         </div>
         <div class="footer_3 background"></div>

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -124,7 +124,7 @@ export class EditorToolsViewComponent {
     this.levelOfDetailService.disableLevelOfDetailRendering();
     this.viewportCullService.onViewportChangeUpdateRendering(false);
 
-    const containerInfo = this.getContainertoExport();
+    const containerInfo = this.getContainerToExport();
 
     const element2export = containerInfo.documentToExport;
     const elements = element2export.querySelectorAll("*");
@@ -165,7 +165,7 @@ export class EditorToolsViewComponent {
     this.levelOfDetailService.disableLevelOfDetailRendering();
     this.viewportCullService.onViewportChangeUpdateRendering(false);
 
-    const containerInfo = this.getContainertoExport();
+    const containerInfo = this.getContainerToExport();
 
     const element2export = containerInfo.documentToExport;
 
@@ -384,103 +384,111 @@ export class EditorToolsViewComponent {
     return this.buildCSVString(headers, rows);
   }
 
-  private getContainertoExport(): ContainertoExportData {
-    let htmlElementToExport: HTMLElement | null = null;
-    let param = {};
+  private getStreckengrafikEditingContainerToExport(): ContainertoExportData {
+    const htmlElementToExport = document.getElementById("main-streckengrafik-container");
+    const param = {
+      encoderOptions: 1.0,
+      scale: 1.0,
+      left: 0,
+      top: 0,
+      width: htmlElementToExport.offsetWidth,
+      height: htmlElementToExport.offsetHeight,
+      backgroundColor: this.uiInteractionService.getActiveTheme().backgroundColor,
+    };
 
-    const editorMode = this.uiInteractionService.getEditorMode();
-    let essentialProps: string[] = undefined;
+    return {
+      documentToExport: htmlElementToExport,
+      exportParameter: param,
+      essentialProps: undefined,
+    };
+  }
 
-    switch (editorMode) {
-      case EditorMode.StreckengrafikEditing: {
-        htmlElementToExport = document.getElementById("main-streckengrafik-container");
-        param = {
-          encoderOptions: 1.0,
-          scale: 1.0,
-          left: 0,
-          top: 0,
-          width: htmlElementToExport.offsetWidth,
-          height: htmlElementToExport.offsetHeight,
-          backgroundColor: this.uiInteractionService.getActiveTheme().backgroundColor,
-        };
-        break;
-      }
-      case EditorMode.OriginDestination: {
-        htmlElementToExport = document.getElementById("main-origin-destination-container");
-        if (htmlElementToExport === null) {
-          return undefined;
-        }
-        const bbox = (htmlElementToExport as unknown as SVGGElement).getBBox();
-        const padding = 10;
-        param = {
-          encoderOptions: 1.0,
-          scale: 1.0,
-          left: bbox.x - padding,
-          top: bbox.y - padding,
-          width: bbox.width + 2 * padding,
-          height: bbox.height + 2 * padding,
-          backgroundColor: this.uiInteractionService.getActiveTheme().backgroundColor,
-        };
-
-        essentialProps = [
-          "fill",
-          "stroke",
-          "stroke-width",
-          "stroke-dasharray",
-          "font-family",
-          "font-size",
-          "font-weight",
-          "opacity",
-          "text-anchor",
-          "dominant-baseline",
-        ];
-
-        break;
-      }
-      default: {
-        htmlElementToExport = document.getElementById("graphContainer");
-        if (htmlElementToExport === null) {
-          return undefined;
-        }
-        const boundingBox = this.nodeService.getNetzgrafikBoundingBox();
-        param = {
-          encoderOptions: 1.0,
-          scale: 2.0,
-          left: boundingBox.minCoordX - 2.0 * RASTERING_BASIC_GRID_SIZE,
-          top: boundingBox.minCoordY - 2.0 * RASTERING_BASIC_GRID_SIZE,
-          width: boundingBox.maxCoordX - boundingBox.minCoordX + 4.0 * RASTERING_BASIC_GRID_SIZE,
-          height:
-            boundingBox.maxCoordY -
-            boundingBox.minCoordY +
-            4.0 * RASTERING_BASIC_GRID_SIZE +
-            NODE_TEXT_AREA_HEIGHT,
-          backgroundColor: this.uiInteractionService.getActiveTheme().backgroundColor,
-        };
-
-        essentialProps = [
-          "fill",
-          "stroke",
-          "stroke-width",
-          "stroke-dasharray",
-          "font-family",
-          "font-size",
-          "font-weight",
-          "opacity",
-          "text-anchor",
-          "dominant-baseline",
-        ];
-        break;
-      }
+  private getOriginDestinationContainerToExport(): ContainertoExportData {
+    const htmlElementToExport = document.getElementById("main-origin-destination-container");
+    if (htmlElementToExport === null) {
+      return undefined;
     }
+    const bbox = (htmlElementToExport as unknown as SVGGElement).getBBox();
+    const padding = 10;
+    const param = {
+      encoderOptions: 1.0,
+      scale: 1.0,
+      left: bbox.x - padding,
+      top: bbox.y - padding,
+      width: bbox.width + 2 * padding,
+      height: bbox.height + 2 * padding,
+      backgroundColor: this.uiInteractionService.getActiveTheme().backgroundColor,
+    };
 
-    const htmlRoot = document.getElementById("NetzgrafikRootHtml");
-    htmlElementToExport.setAttribute("style", htmlRoot.getAttribute("style"));
+    const essentialProps = [
+      "fill",
+      "stroke",
+      "stroke-width",
+      "stroke-dasharray",
+      "font-family",
+      "font-size",
+      "font-weight",
+      "opacity",
+      "text-anchor",
+      "dominant-baseline",
+    ];
 
     return {
       documentToExport: htmlElementToExport,
       exportParameter: param,
       essentialProps: essentialProps,
     };
+  }
+
+  private getNetzgrafikEditingContainerToExport(): ContainertoExportData {
+    const htmlElementToExport = document.getElementById("graphContainer");
+    if (htmlElementToExport === null) {
+      return undefined;
+    }
+    const boundingBox = this.nodeService.getNetzgrafikBoundingBox();
+    const param = {
+      encoderOptions: 1.0,
+      scale: 2.0,
+      left: boundingBox.minCoordX - 2.0 * RASTERING_BASIC_GRID_SIZE,
+      top: boundingBox.minCoordY - 2.0 * RASTERING_BASIC_GRID_SIZE,
+      width: boundingBox.maxCoordX - boundingBox.minCoordX + 4.0 * RASTERING_BASIC_GRID_SIZE,
+      height:
+        boundingBox.maxCoordY -
+        boundingBox.minCoordY +
+        4.0 * RASTERING_BASIC_GRID_SIZE +
+        NODE_TEXT_AREA_HEIGHT,
+      backgroundColor: this.uiInteractionService.getActiveTheme().backgroundColor,
+    };
+
+    const essentialProps = [
+      "fill",
+      "stroke",
+      "stroke-width",
+      "stroke-dasharray",
+      "font-family",
+      "font-size",
+      "font-weight",
+      "opacity",
+      "text-anchor",
+      "dominant-baseline",
+    ];
+
+    return {
+      documentToExport: htmlElementToExport,
+      exportParameter: param,
+      essentialProps: essentialProps,
+    };
+  }
+
+  private getContainerToExport(): ContainertoExportData {
+    const editorMode = this.uiInteractionService.getEditorMode();
+    if (editorMode === EditorMode.StreckengrafikEditing) {
+      return this.getStreckengrafikEditingContainerToExport();
+    }
+    if (editorMode === EditorMode.OriginDestination) {
+      return this.getOriginDestinationContainerToExport();
+    }
+    return this.getNetzgrafikEditingContainerToExport();
   }
 
   private convertToZuglaufCSV(): string {

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -410,6 +410,7 @@ export class EditorToolsViewComponent {
       "border-bottom",
       "border",
       "box-sizing",
+      "paint-order",
     ];
 
     return {

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -136,8 +136,8 @@ export class EditorToolsViewComponent {
 
     // SVG scaling does not affect resolution since SVGs are rendered as vector graphics.
     // To ensure a good initial scale, we define the target width as 2000 pixels.
-    const scaleToTargetWidth  = 2000 / containerInfo.exportParameter.width;
-    containerInfo.exportParameter.scale = scaleToTargetWidth ;
+    const scaleToTargetWidth = 2000 / containerInfo.exportParameter.width;
+    containerInfo.exportParameter.scale = scaleToTargetWidth;
 
     svg.svgAsDataUri(containerInfo.documentToExport, containerInfo.exportParameter).then((uri) => {
       const a = document.createElement("a");
@@ -392,6 +392,10 @@ export class EditorToolsViewComponent {
       "min-height",
       "max-height",
       "overflow",
+      "margin-bottom",
+      "margin-top",
+      "margin-left",
+      "margin-right",
       "margin",
       "padding",
       "display",
@@ -399,6 +403,7 @@ export class EditorToolsViewComponent {
       "grid-template-rows",
       "grid-gap",
       "background",
+      "background-color",
       "border-right",
       "border-left",
       "border-top",

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -24,16 +24,13 @@ import {NetzgrafikColoringService} from "../../services/data/netzgrafikColoring.
 import {ViewportCullService} from "../../services/ui/viewport.cull.service";
 import {LevelOfDetailService} from "../../services/ui/level.of.detail.service";
 import {TrainrunSectionValidator} from "../../services/util/trainrunsection.validator";
-import {
-  OriginDestinationService
-} from "src/app/services/analytics/origin-destination/components/origin-destination.service";
+import {OriginDestinationService} from "src/app/services/analytics/origin-destination/components/origin-destination.service";
 import {EditorMode} from "../editor-menu/editor-mode";
 import {NODE_TEXT_AREA_HEIGHT, RASTERING_BASIC_GRID_SIZE} from "../rastering/definitions";
 
 interface ContainertoExportData {
   documentToExport: HTMLElement;
   exportParameter: any;
-  documentSavedStyle: string;
 }
 
 @Component({
@@ -116,7 +113,7 @@ export class EditorToolsViewComponent {
     downloadBlob(
       blob,
       $localize`:@@app.view.editor-side-view.editor-tools-view-component.netzgrafikFile:netzgrafik` +
-      ".json",
+        ".json",
     );
   }
 
@@ -127,7 +124,18 @@ export class EditorToolsViewComponent {
     this.viewportCullService.onViewportChangeUpdateRendering(false);
 
     const containerInfo = this.getContainertoExport();
-    svg.svgAsDataUri(containerInfo.documentToExport, containerInfo.exportParameter).then((uri) => {
+
+    const element2export = containerInfo.documentToExport;
+    const elements = element2export.querySelectorAll("*");
+    elements.forEach((el) => {
+      const style = window.getComputedStyle(el);
+      const inlineStyle = Array.from(style)
+        .map((key) => `${key}:${style.getPropertyValue(key)};`)
+        .join(" ");
+      el.setAttribute("style", inlineStyle);
+    });
+
+    svg.svgAsDataUri(element2export, containerInfo.exportParameter).then((uri) => {
       const a = document.createElement("a");
       document.body.appendChild(a);
       a.href = uri;
@@ -135,7 +143,6 @@ export class EditorToolsViewComponent {
       a.click();
       URL.revokeObjectURL(a.href);
       a.remove();
-      containerInfo.documentToExport.setAttribute("style", containerInfo.documentSavedStyle);
       this.levelOfDetailService.enableLevelOfDetailRendering();
     });
   }
@@ -154,12 +161,23 @@ export class EditorToolsViewComponent {
     this.viewportCullService.onViewportChangeUpdateRendering(false);
 
     const containerInfo = this.getContainertoExport();
+
+    const element2export = containerInfo.documentToExport;
+    const elements = element2export.querySelectorAll("*");
+    elements.forEach((el) => {
+      const style = window.getComputedStyle(el);
+      const inlineStyle = Array.from(style)
+        .map((key) => `${key}:${style.getPropertyValue(key)};`)
+        .join(" ");
+      el.setAttribute("style", inlineStyle);
+    });
+
     svg.saveSvgAsPng(
-      containerInfo.documentToExport,
+      element2export,
       this.getFilenameToExport() + ".png",
       containerInfo.exportParameter,
     );
-    //containerInfo.documentToExport.setAttribute('style', containerInfo.documentSavedStyle);
+
     this.levelOfDetailService.enableLevelOfDetailRendering();
   }
 
@@ -306,33 +324,33 @@ export class EditorToolsViewComponent {
       row.push(regions.map((reg) => "" + reg).join(comma));
       row.push(
         "" +
-        (trainrunCategoryHaltezeit[HaltezeitFachCategories.IPV].no_halt
-          ? 0
-          : trainrunCategoryHaltezeit[HaltezeitFachCategories.IPV].haltezeit - zaz),
+          (trainrunCategoryHaltezeit[HaltezeitFachCategories.IPV].no_halt
+            ? 0
+            : trainrunCategoryHaltezeit[HaltezeitFachCategories.IPV].haltezeit - zaz),
       );
       row.push(
         "" +
-        (trainrunCategoryHaltezeit[HaltezeitFachCategories.A].no_halt
-          ? 0
-          : trainrunCategoryHaltezeit[HaltezeitFachCategories.A].haltezeit - zaz),
+          (trainrunCategoryHaltezeit[HaltezeitFachCategories.A].no_halt
+            ? 0
+            : trainrunCategoryHaltezeit[HaltezeitFachCategories.A].haltezeit - zaz),
       );
       row.push(
         "" +
-        (trainrunCategoryHaltezeit[HaltezeitFachCategories.B].no_halt
-          ? 0
-          : trainrunCategoryHaltezeit[HaltezeitFachCategories.B].haltezeit - zaz),
+          (trainrunCategoryHaltezeit[HaltezeitFachCategories.B].no_halt
+            ? 0
+            : trainrunCategoryHaltezeit[HaltezeitFachCategories.B].haltezeit - zaz),
       );
       row.push(
         "" +
-        (trainrunCategoryHaltezeit[HaltezeitFachCategories.C].no_halt
-          ? 0
-          : trainrunCategoryHaltezeit[HaltezeitFachCategories.C].haltezeit - zaz),
+          (trainrunCategoryHaltezeit[HaltezeitFachCategories.C].no_halt
+            ? 0
+            : trainrunCategoryHaltezeit[HaltezeitFachCategories.C].haltezeit - zaz),
       );
       row.push(
         "" +
-        (trainrunCategoryHaltezeit[HaltezeitFachCategories.D].no_halt
-          ? 0
-          : trainrunCategoryHaltezeit[HaltezeitFachCategories.D].haltezeit - zaz),
+          (trainrunCategoryHaltezeit[HaltezeitFachCategories.D].no_halt
+            ? 0
+            : trainrunCategoryHaltezeit[HaltezeitFachCategories.D].haltezeit - zaz),
       );
       row.push("" + zaz);
       row.push("" + nodeElement.getConnectionTime());
@@ -417,28 +435,12 @@ export class EditorToolsViewComponent {
       }
     }
 
-    const oldStyle = htmlElementToExport.getAttribute("style");
     const htmlRoot = document.getElementById("NetzgrafikRootHtml");
     htmlElementToExport.setAttribute("style", htmlRoot.getAttribute("style"));
-
-    const styles = this.netzgrafikColoringService.generateGlobalStyles(
-      this.dataService.getTrainrunCategories(),
-      this.trainrunSectionService.getTrainrunSections(),
-    );
-
-    styles.forEach((s) => {
-      const docStyles = htmlRoot.ownerDocument.styleSheets;
-      for (let i = 0; i < s.cssRules.length; i++) {
-        htmlRoot.ownerDocument.styleSheets[docStyles.length - 1].insertRule(
-          s.cssRules[i].cssText,
-        );
-      }
-    });
 
     return {
       documentToExport: htmlElementToExport,
       exportParameter: param,
-      documentSavedStyle: oldStyle,
     };
   }
 
@@ -639,7 +641,7 @@ export class EditorToolsViewComponent {
     return (
       netzgrafikDto.nodes.find((n: NodeDto) => n.ports === undefined) !== undefined ||
       netzgrafikDto.nodes.filter((n: NodeDto) => n.ports?.length === 0).length ===
-      netzgrafikDto.nodes.length ||
+        netzgrafikDto.nodes.length ||
       netzgrafikDto.trainrunSections.find(
         (ts: TrainrunSectionDto) =>
           ts.path === undefined || ts.path?.path === undefined || ts.path?.path?.length === 0,

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -125,23 +125,6 @@ export class EditorToolsViewComponent {
     }, 1500); // to allow cd-layout-filter to close
   }
 
-  private prepareStyleForExport(containerInfo: ContainertoExportData) {
-    const element2export = containerInfo.documentToExport;
-
-    const elements = element2export.querySelectorAll("*");
-    elements.forEach((el) => {
-      const style = window.getComputedStyle(el);
-      const essentialPropsArray =
-        containerInfo.essentialProps !== undefined
-          ? containerInfo.essentialProps
-          : Array.from(style);
-      const inlineStyle = essentialPropsArray
-        .map((key) => `${key}:${style.getPropertyValue(key)};`)
-        .join(" ");
-      el.setAttribute("style", inlineStyle);
-    });
-  }
-
   onExportContainerAsSVG() {
     // option 2: save svg as svg
     // https://www.npmjs.com/package/save-svg-as-png
@@ -468,6 +451,23 @@ export class EditorToolsViewComponent {
       exportParameter: param,
       essentialProps: essentialProps,
     };
+  }
+
+  private prepareStyleForExport(containerInfo: ContainertoExportData) {
+    const element2export = containerInfo.documentToExport;
+
+    const elements = element2export.querySelectorAll("*");
+    elements.forEach((el) => {
+      const style = window.getComputedStyle(el);
+      const essentialPropsArray =
+        containerInfo.essentialProps !== undefined
+          ? containerInfo.essentialProps
+          : Array.from(style);
+      const inlineStyle = essentialPropsArray
+        .map((key) => `${key}:${style.getPropertyValue(key)};`)
+        .join(" ");
+      el.setAttribute("style", inlineStyle);
+    });
   }
 
   private getContainerToExport(): ContainertoExportData {

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -118,15 +118,16 @@ export class EditorToolsViewComponent {
     );
   }
 
-  onExportContainerAsSVG() {
-    // option 2: save svg as svg
-    // https://www.npmjs.com/package/save-svg-as-png
-    this.levelOfDetailService.disableLevelOfDetailRendering();
-    this.viewportCullService.onViewportChangeUpdateRendering(false);
+  onPrintContainer() {
+    this.uiInteractionService.closeFilter();
+    setTimeout(() => {
+      this.uiInteractionService.print();
+    }, 1500); // to allow cd-layout-filter to close
+  }
 
-    const containerInfo = this.getContainerToExport();
-
+  private prepareStyleForExport(containerInfo: ContainertoExportData) {
     const element2export = containerInfo.documentToExport;
+
     const elements = element2export.querySelectorAll("*");
     elements.forEach((el) => {
       const style = window.getComputedStyle(el);
@@ -139,8 +140,18 @@ export class EditorToolsViewComponent {
         .join(" ");
       el.setAttribute("style", inlineStyle);
     });
+  }
 
-    svg.svgAsDataUri(element2export, containerInfo.exportParameter).then((uri) => {
+  onExportContainerAsSVG() {
+    // option 2: save svg as svg
+    // https://www.npmjs.com/package/save-svg-as-png
+    this.levelOfDetailService.disableLevelOfDetailRendering();
+    this.viewportCullService.onViewportChangeUpdateRendering(false);
+
+    const containerInfo = this.getContainerToExport();
+    this.prepareStyleForExport(containerInfo);
+
+    svg.svgAsDataUri(containerInfo.documentToExport, containerInfo.exportParameter).then((uri) => {
       const a = document.createElement("a");
       document.body.appendChild(a);
       a.href = uri;
@@ -152,13 +163,6 @@ export class EditorToolsViewComponent {
     });
   }
 
-  onPrintContainer() {
-    this.uiInteractionService.closeFilter();
-    setTimeout(() => {
-      this.uiInteractionService.print();
-    }, 1500); // to allow cd-layout-filter to close
-  }
-
   onExportContainerAsPNG() {
     // option 1: save svg as png
     // https://www.npmjs.com/package/save-svg-as-png
@@ -166,24 +170,10 @@ export class EditorToolsViewComponent {
     this.viewportCullService.onViewportChangeUpdateRendering(false);
 
     const containerInfo = this.getContainerToExport();
-
-    const element2export = containerInfo.documentToExport;
-
-    const elements = element2export.querySelectorAll("*");
-    elements.forEach((el) => {
-      const style = window.getComputedStyle(el);
-      const essentialPropsArray =
-        containerInfo.essentialProps !== undefined
-          ? containerInfo.essentialProps
-          : Array.from(style);
-      const inlineStyle = essentialPropsArray
-        .map((key) => `${key}:${style.getPropertyValue(key)};`)
-        .join(" ");
-      el.setAttribute("style", inlineStyle);
-    });
+    this.prepareStyleForExport(containerInfo);
 
     svg.saveSvgAsPng(
-      element2export,
+      containerInfo.documentToExport,
       this.getFilenameToExport() + ".png",
       containerInfo.exportParameter,
     );

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -24,8 +24,11 @@ import {NetzgrafikColoringService} from "../../services/data/netzgrafikColoring.
 import {ViewportCullService} from "../../services/ui/viewport.cull.service";
 import {LevelOfDetailService} from "../../services/ui/level.of.detail.service";
 import {TrainrunSectionValidator} from "../../services/util/trainrunsection.validator";
-import {OriginDestinationService} from "src/app/services/analytics/origin-destination/components/origin-destination.service";
+import {
+  OriginDestinationService
+} from "src/app/services/analytics/origin-destination/components/origin-destination.service";
 import {EditorMode} from "../editor-menu/editor-mode";
+import {NODE_TEXT_AREA_HEIGHT, RASTERING_BASIC_GRID_SIZE} from "../rastering/definitions";
 
 interface ContainertoExportData {
   documentToExport: HTMLElement;
@@ -113,7 +116,7 @@ export class EditorToolsViewComponent {
     downloadBlob(
       blob,
       $localize`:@@app.view.editor-side-view.editor-tools-view-component.netzgrafikFile:netzgrafik` +
-        ".json",
+      ".json",
     );
   }
 
@@ -303,33 +306,33 @@ export class EditorToolsViewComponent {
       row.push(regions.map((reg) => "" + reg).join(comma));
       row.push(
         "" +
-          (trainrunCategoryHaltezeit[HaltezeitFachCategories.IPV].no_halt
-            ? 0
-            : trainrunCategoryHaltezeit[HaltezeitFachCategories.IPV].haltezeit - zaz),
+        (trainrunCategoryHaltezeit[HaltezeitFachCategories.IPV].no_halt
+          ? 0
+          : trainrunCategoryHaltezeit[HaltezeitFachCategories.IPV].haltezeit - zaz),
       );
       row.push(
         "" +
-          (trainrunCategoryHaltezeit[HaltezeitFachCategories.A].no_halt
-            ? 0
-            : trainrunCategoryHaltezeit[HaltezeitFachCategories.A].haltezeit - zaz),
+        (trainrunCategoryHaltezeit[HaltezeitFachCategories.A].no_halt
+          ? 0
+          : trainrunCategoryHaltezeit[HaltezeitFachCategories.A].haltezeit - zaz),
       );
       row.push(
         "" +
-          (trainrunCategoryHaltezeit[HaltezeitFachCategories.B].no_halt
-            ? 0
-            : trainrunCategoryHaltezeit[HaltezeitFachCategories.B].haltezeit - zaz),
+        (trainrunCategoryHaltezeit[HaltezeitFachCategories.B].no_halt
+          ? 0
+          : trainrunCategoryHaltezeit[HaltezeitFachCategories.B].haltezeit - zaz),
       );
       row.push(
         "" +
-          (trainrunCategoryHaltezeit[HaltezeitFachCategories.C].no_halt
-            ? 0
-            : trainrunCategoryHaltezeit[HaltezeitFachCategories.C].haltezeit - zaz),
+        (trainrunCategoryHaltezeit[HaltezeitFachCategories.C].no_halt
+          ? 0
+          : trainrunCategoryHaltezeit[HaltezeitFachCategories.C].haltezeit - zaz),
       );
       row.push(
         "" +
-          (trainrunCategoryHaltezeit[HaltezeitFachCategories.D].no_halt
-            ? 0
-            : trainrunCategoryHaltezeit[HaltezeitFachCategories.D].haltezeit - zaz),
+        (trainrunCategoryHaltezeit[HaltezeitFachCategories.D].no_halt
+          ? 0
+          : trainrunCategoryHaltezeit[HaltezeitFachCategories.D].haltezeit - zaz),
       );
       row.push("" + zaz);
       row.push("" + nodeElement.getConnectionTime());
@@ -361,17 +364,16 @@ export class EditorToolsViewComponent {
 
     switch (editorMode) {
       case EditorMode.StreckengrafikEditing: {
-        const boundingBox = this.nodeService.getNetzgrafikBoundingBox();
+        htmlElementToExport = document.getElementById("main-streckengrafik-container");
         param = {
           encoderOptions: 1.0,
-          scale: 2.0,
-          left: boundingBox.minCoordX - 32,
-          top: boundingBox.minCoordY - 32,
-          width: boundingBox.maxCoordX - boundingBox.minCoordX + 64,
-          height: boundingBox.maxCoordY - boundingBox.minCoordY + 64,
+          scale: 1.0,
+          left: 0,
+          top: 0,
+          width: htmlElementToExport.offsetWidth,
+          height: htmlElementToExport.offsetHeight,
           backgroundColor: this.uiInteractionService.getActiveTheme().backgroundColor,
         };
-        htmlElementToExport = document.getElementById("main-streckengrafik-container");
         break;
       }
       case EditorMode.OriginDestination: {
@@ -397,13 +399,18 @@ export class EditorToolsViewComponent {
         if (htmlElementToExport === null) {
           return undefined;
         }
+        const boundingBox = this.nodeService.getNetzgrafikBoundingBox();
         param = {
           encoderOptions: 1.0,
           scale: 1.0,
-          left: htmlElementToExport.offsetWidth / 3,
-          top: 80,
-          width: htmlElementToExport.offsetWidth,
-          height: htmlElementToExport.offsetHeight,
+          left: boundingBox.minCoordX - 2.0 * RASTERING_BASIC_GRID_SIZE,
+          top: boundingBox.minCoordY - 2.0 * RASTERING_BASIC_GRID_SIZE,
+          width: boundingBox.maxCoordX - boundingBox.minCoordX + 4.0 * RASTERING_BASIC_GRID_SIZE,
+          height:
+            boundingBox.maxCoordY -
+            boundingBox.minCoordY +
+            4.0 * RASTERING_BASIC_GRID_SIZE +
+            NODE_TEXT_AREA_HEIGHT,
           backgroundColor: this.uiInteractionService.getActiveTheme().backgroundColor,
         };
         break;
@@ -411,25 +418,23 @@ export class EditorToolsViewComponent {
     }
 
     const oldStyle = htmlElementToExport.getAttribute("style");
-    const htmlsTagCollection = document.getElementsByTagName("html");
-    if (htmlsTagCollection.length > 0) {
-      const htmlRoot = htmlsTagCollection[0];
-      htmlElementToExport.setAttribute("style", htmlRoot.getAttribute("style"));
+    const htmlRoot = document.getElementById("NetzgrafikRootHtml");
+    htmlElementToExport.setAttribute("style", htmlRoot.getAttribute("style"));
 
-      const styles = this.netzgrafikColoringService.generateGlobalStyles(
-        this.dataService.getTrainrunCategories(),
-        this.trainrunSectionService.getTrainrunSections(),
-      );
+    const styles = this.netzgrafikColoringService.generateGlobalStyles(
+      this.dataService.getTrainrunCategories(),
+      this.trainrunSectionService.getTrainrunSections(),
+    );
 
-      styles.forEach((s) => {
-        const docStyles = htmlRoot.ownerDocument.styleSheets;
-        for (let i = 0; i < s.cssRules.length; i++) {
-          htmlRoot.ownerDocument.styleSheets[docStyles.length - 1].insertRule(
-            s.cssRules[i].cssText,
-          );
-        }
-      });
-    }
+    styles.forEach((s) => {
+      const docStyles = htmlRoot.ownerDocument.styleSheets;
+      for (let i = 0; i < s.cssRules.length; i++) {
+        htmlRoot.ownerDocument.styleSheets[docStyles.length - 1].insertRule(
+          s.cssRules[i].cssText,
+        );
+      }
+    });
+
     return {
       documentToExport: htmlElementToExport,
       exportParameter: param,
@@ -634,7 +639,7 @@ export class EditorToolsViewComponent {
     return (
       netzgrafikDto.nodes.find((n: NodeDto) => n.ports === undefined) !== undefined ||
       netzgrafikDto.nodes.filter((n: NodeDto) => n.ports?.length === 0).length ===
-        netzgrafikDto.nodes.length ||
+      netzgrafikDto.nodes.length ||
       netzgrafikDto.trainrunSections.find(
         (ts: TrainrunSectionDto) =>
           ts.path === undefined || ts.path?.path === undefined || ts.path?.path?.length === 0,

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -374,10 +374,43 @@ export class EditorToolsViewComponent {
       backgroundColor: this.uiInteractionService.getActiveTheme().backgroundColor,
     };
 
+    const essentialProps = [
+      "fill",
+      "stroke",
+      "stroke-width",
+      "stroke-dasharray",
+      "font-family",
+      "font-size",
+      "font-weight",
+      "opacity",
+      "text-anchor",
+      "dominant-baseline",
+      "width",
+      "min-width",
+      "max-width",
+      "height",
+      "min-height",
+      "max-height",
+      "overflow",
+      "margin",
+      "padding",
+      "display",
+      "grid-template-columns",
+      "grid-template-rows",
+      "grid-gap",
+      "background",
+      "border-right",
+      "border-left",
+      "border-top",
+      "border-bottom",
+      "border",
+      "box-sizing",
+    ];
+
     return {
       documentToExport: htmlElementToExport,
       exportParameter: param,
-      essentialProps: undefined,
+      essentialProps: essentialProps,
     };
   }
 

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -31,6 +31,7 @@ import {NODE_TEXT_AREA_HEIGHT, RASTERING_BASIC_GRID_SIZE} from "../rastering/def
 interface ContainertoExportData {
   documentToExport: HTMLElement;
   exportParameter: any;
+  essentialProps: string[];
 }
 
 @Component({
@@ -129,7 +130,11 @@ export class EditorToolsViewComponent {
     const elements = element2export.querySelectorAll("*");
     elements.forEach((el) => {
       const style = window.getComputedStyle(el);
-      const inlineStyle = Array.from(style)
+      const essentialPropsArray =
+        containerInfo.essentialProps !== undefined
+          ? containerInfo.essentialProps
+          : Array.from(style);
+      const inlineStyle = essentialPropsArray
         .map((key) => `${key}:${style.getPropertyValue(key)};`)
         .join(" ");
       el.setAttribute("style", inlineStyle);
@@ -163,10 +168,15 @@ export class EditorToolsViewComponent {
     const containerInfo = this.getContainertoExport();
 
     const element2export = containerInfo.documentToExport;
+
     const elements = element2export.querySelectorAll("*");
     elements.forEach((el) => {
       const style = window.getComputedStyle(el);
-      const inlineStyle = Array.from(style)
+      const essentialPropsArray =
+        containerInfo.essentialProps !== undefined
+          ? containerInfo.essentialProps
+          : Array.from(style);
+      const inlineStyle = essentialPropsArray
         .map((key) => `${key}:${style.getPropertyValue(key)};`)
         .join(" ");
       el.setAttribute("style", inlineStyle);
@@ -379,6 +389,7 @@ export class EditorToolsViewComponent {
     let param = {};
 
     const editorMode = this.uiInteractionService.getEditorMode();
+    let essentialProps: string[] = undefined;
 
     switch (editorMode) {
       case EditorMode.StreckengrafikEditing: {
@@ -410,6 +421,20 @@ export class EditorToolsViewComponent {
           height: bbox.height + 2 * padding,
           backgroundColor: this.uiInteractionService.getActiveTheme().backgroundColor,
         };
+
+        essentialProps = [
+          "fill",
+          "stroke",
+          "stroke-width",
+          "stroke-dasharray",
+          "font-family",
+          "font-size",
+          "font-weight",
+          "opacity",
+          "text-anchor",
+          "dominant-baseline",
+        ];
+
         break;
       }
       default: {
@@ -420,7 +445,7 @@ export class EditorToolsViewComponent {
         const boundingBox = this.nodeService.getNetzgrafikBoundingBox();
         param = {
           encoderOptions: 1.0,
-          scale: 1.0,
+          scale: 2.0,
           left: boundingBox.minCoordX - 2.0 * RASTERING_BASIC_GRID_SIZE,
           top: boundingBox.minCoordY - 2.0 * RASTERING_BASIC_GRID_SIZE,
           width: boundingBox.maxCoordX - boundingBox.minCoordX + 4.0 * RASTERING_BASIC_GRID_SIZE,
@@ -431,6 +456,19 @@ export class EditorToolsViewComponent {
             NODE_TEXT_AREA_HEIGHT,
           backgroundColor: this.uiInteractionService.getActiveTheme().backgroundColor,
         };
+
+        essentialProps = [
+          "fill",
+          "stroke",
+          "stroke-width",
+          "stroke-dasharray",
+          "font-family",
+          "font-size",
+          "font-weight",
+          "opacity",
+          "text-anchor",
+          "dominant-baseline",
+        ];
         break;
       }
     }
@@ -441,6 +479,7 @@ export class EditorToolsViewComponent {
     return {
       documentToExport: htmlElementToExport,
       exportParameter: param,
+      essentialProps: essentialProps,
     };
   }
 

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -134,6 +134,11 @@ export class EditorToolsViewComponent {
     const containerInfo = this.getContainerToExport();
     this.prepareStyleForExport(containerInfo);
 
+    // SVG scaling does not affect resolution since SVGs are rendered as vector graphics.
+    // To ensure a good initial scale, we define the target width as 2000 pixels.
+    const scaleToTargetWidth  = 2000 / containerInfo.exportParameter.width;
+    containerInfo.exportParameter.scale = scaleToTargetWidth ;
+
     svg.svgAsDataUri(containerInfo.documentToExport, containerInfo.exportParameter).then((uri) => {
       const a = document.createElement("a");
       document.body.appendChild(a);

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -482,13 +482,14 @@ export class EditorToolsViewComponent {
 
   private getContainerToExport(): ContainertoExportData {
     const editorMode = this.uiInteractionService.getEditorMode();
-    if (editorMode === EditorMode.StreckengrafikEditing) {
-      return this.getStreckengrafikEditingContainerToExport();
+    switch (editorMode) {
+      case EditorMode.StreckengrafikEditing:
+        return this.getStreckengrafikEditingContainerToExport();
+      case EditorMode.OriginDestination:
+        return this.getOriginDestinationContainerToExport();
+      default:
+        return this.getNetzgrafikEditingContainerToExport();
     }
-    if (editorMode === EditorMode.OriginDestination) {
-      return this.getOriginDestinationContainerToExport();
-    }
-    return this.getNetzgrafikEditingContainerToExport();
   }
 
   private convertToZuglaufCSV(): string {


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->

# Description

### 🛠 Inline CSS for SVG PNG Export

I located the problem. It's the classic CSS style loss problem with saveSvgAsPng when exporting, especially if your SVG relies on external stylesheets or scoped component styles. The root cause: saveSvgAsPng only serializes inline styles by default, so anything coming from external CSS or Angular’s component encapsulation can get dropped.

This approach helps preserve visual fidelity, especially for dynamic styles such as media queries, fonts, and layout-specific rules.

### ⚠️ Disclaimer

This solution is still **in progress**. While it improves style retention, performance is currently **very poor** esspecially for Graphical Timetable — the inlining process takes too long for large or complex SVGs. Further optimization is needed before it can be used in production.

- Netzgrafik export : ok.
- O/D Matrix export: ok.
- Graphical timetable export: performance poor.
 

```typescript
const svgElement = document.getElementById("mySvg");
const allElements = svgElement.querySelectorAll("*");

allElements.forEach(el => {
  const computedStyle = window.getComputedStyle(el);
  const styleString = Array.from(computedStyle)
    .map(key => `${key}:${computedStyle.getPropertyValue(key)};`)
    .join(" ");
  el.setAttribute("style", styleString);
});
```
# Summary

## Elements to Export to SVG or PNG

### Export Graphical Timetable (Streckengrafik)
Users can export the Graphical Timetable, but they should expect a delay. The export preparation—especially styling, layout, and rendering—takes considerable time. However, the final result is acceptable.  
**Workaround:** Users can just take a screenshot of the timetable take  

### Export Origin/Destination Matrix
Works well and is quite fast.

### Export Netzgrafik
Works well and is quite fast.

## Conclusion
Since the export of the Netzgrafik and Origin/Destination Matrix is essential and users have no alternative, this fix is sufficient to merge.  
The reported issue with exporting the Graphical Timetable (Streckengrafik) is a minor problem. It would be nice to resolve it, but for milestone **2.10**, it is not a critical requirement.


---- 
The https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/issues/542 address the problem with the Graphical Timetable (Streckengrafik) export into png/svg


--- 
| Before fix | After fix |
|---|---| 
|<img width="1920" height="919" alt="netzgrafik" src="https://github.com/user-attachments/assets/bf5debfa-0e8f-4836-b99d-00239ee2d345" /> | <img width="19904" height="11640" alt="netzgrafik" src="https://github.com/user-attachments/assets/bd92ead4-9b4b-48cd-acd7-105645b1260a" /> |
| <img width="1605" height="1597" alt="originDestination" src="https://github.com/user-attachments/assets/3a79ad05-cbf4-4cd1-9778-1586e26821b0" />|  <img width="1605" height="1597" alt="originDestination" src="https://github.com/user-attachments/assets/cac64a06-0e53-4b09-b2a3-c449147e5c02" /> |
| <img width="19776" height="11456" alt="streckengrafik" src="https://github.com/user-attachments/assets/5a768aa2-1038-440c-ba54-9e39bdc82f2e" />| <img width="1390" height="866" alt="streckengrafik" src="https://github.com/user-attachments/assets/cd9d5d27-4f17-4bc0-8fde-b89048e7ae42" /> |
