### PR TITLE
827 overuse of atsource boolean var and more

### DIFF
--- a/src/app/data-structures/technical.data.structures.ts
+++ b/src/app/data-structures/technical.data.structures.ts
@@ -27,6 +27,14 @@ export enum TrainrunSectionText {
 }
 
 /**
+ * Classifies which anchor (node) of a TrainrunSection is being evaluated.
+ */
+export enum TrainrunSectionNodeAnchor {
+  Source = "source",
+  Target = "target",
+}
+
+/**
  * Represents a mapping of TrainrunSectionText and PointDTO used in the "cached" path : PathDto.
  * The PathDto is used in the TrainrunSectionDto. The application (editor) recalculates after each
  * position update the path and stores the positions of the text in this mapping.

--- a/src/app/perlenkette/perlenkette-section/perlenkette-section.component.ts
+++ b/src/app/perlenkette/perlenkette-section/perlenkette-section.component.ts
@@ -23,7 +23,10 @@ import {FilterService} from "../../services/ui/filter.service";
 import {LoadPerlenketteService} from "../service/load-perlenkette.service";
 import {EditorMode} from "../../view/editor-menu/editor-mode";
 import {Vec2D} from "../../utils/vec2D";
-import {PortAlignment} from "../../data-structures/technical.data.structures";
+import {
+  PortAlignment,
+  TrainrunSectionNodeAnchor,
+} from "../../data-structures/technical.data.structures";
 import {
   TRAINRUN_SECTION_PORT_SPAN_HORIZONTAL,
   TRAINRUN_SECTION_PORT_SPAN_VERTICAL,
@@ -527,8 +530,14 @@ export class PerlenketteSectionComponent implements OnInit, AfterContentInit, On
 
   getTravelTime() {
     if (
-      TrainrunSectionsView.getNode(this.trainrunSection, true).isNonStop(this.trainrunSection) ||
-      TrainrunSectionsView.getNode(this.trainrunSection, false).isNonStop(this.trainrunSection)
+      TrainrunSectionsView.getNode(
+        this.trainrunSection,
+        TrainrunSectionNodeAnchor.Source,
+      ).isNonStop(this.trainrunSection) ||
+      TrainrunSectionsView.getNode(
+        this.trainrunSection,
+        TrainrunSectionNodeAnchor.Target,
+      ).isNonStop(this.trainrunSection)
     ) {
       const cumulativeTravelTime = this.trainrunService.getCumulativeTravelTime(
         this.trainrunSection,

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.spec.ts
@@ -20,7 +20,11 @@ import {LoadPerlenketteService} from "../../../perlenkette/service/load-perlenke
 import {NetzgrafikUnitTesting} from "../../../../integration-testing/netzgrafik.unit.testing";
 import {EditorView} from "./editor.view";
 import {EditorMainViewComponent} from "../editor-main-view.component";
-import {TimeLockDto, TrainrunSectionText} from "../../../data-structures/technical.data.structures";
+import {
+  TimeLockDto,
+  TrainrunSectionNodeAnchor,
+  TrainrunSectionText,
+} from "../../../data-structures/technical.data.structures";
 import {TrainrunSectionsView} from "./trainrunsections.view";
 import {Vec2D} from "../../../utils/vec2D";
 import {LevelOfDetailService} from "../../../services/ui/level.of.detail.service";
@@ -321,7 +325,7 @@ describe("TrainrunSection-View", () => {
   it("TrainrunSectionsView.getPosition - 001", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
     const ts = trainrunSectionService.getTrainrunSectionFromId(4);
-    const v = TrainrunSectionsView.getPosition(ts, false);
+    const v = TrainrunSectionsView.getPosition(ts, TrainrunSectionNodeAnchor.Target);
     expect(v.getX()).toBe(734);
     expect(v.getY()).toBe(144);
   });
@@ -329,7 +333,7 @@ describe("TrainrunSection-View", () => {
   it("TrainrunSectionsView.getPosition - 002", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
     const ts = trainrunSectionService.getTrainrunSectionFromId(4);
-    const v = TrainrunSectionsView.getPosition(ts, true);
+    const v = TrainrunSectionsView.getPosition(ts, TrainrunSectionNodeAnchor.Source);
     expect(v.getX()).toBe(418);
     expect(v.getY()).toBe(112);
   });
@@ -337,14 +341,14 @@ describe("TrainrunSection-View", () => {
   it("TrainrunSectionsView.getNode - 001", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
     const ts = trainrunSectionService.getTrainrunSectionFromId(4);
-    const v = TrainrunSectionsView.getNode(ts, false);
+    const v = TrainrunSectionsView.getNode(ts, TrainrunSectionNodeAnchor.Target);
     expect(v.getId()).toBe(2);
   });
 
   it("TrainrunSectionsView.getNode - 002", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
     const ts = trainrunSectionService.getTrainrunSectionFromId(4);
-    const v = TrainrunSectionsView.getNode(ts, true);
+    const v = TrainrunSectionsView.getNode(ts, TrainrunSectionNodeAnchor.Source);
     expect(v.getId()).toBe(1);
   });
 
@@ -964,42 +968,42 @@ describe("TrainrunSection-View", () => {
   it("TrainrunSectionsView.enforceStartTextAnchor - 001", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
     const ts = trainrunSectionService.getTrainrunSectionFromId(4);
-    const v1 = TrainrunSectionsView.enforceStartTextAnchor(ts, false);
+    const v1 = TrainrunSectionsView.enforceStartTextAnchor(ts, TrainrunSectionNodeAnchor.Target);
     expect(v1).toBe(false);
   });
 
   it("TrainrunSectionsView.enforceStartTextAnchor - 002", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
     const ts = trainrunSectionService.getTrainrunSectionFromId(4);
-    const v1 = TrainrunSectionsView.enforceStartTextAnchor(ts, true);
+    const v1 = TrainrunSectionsView.enforceStartTextAnchor(ts, TrainrunSectionNodeAnchor.Source);
     expect(v1).toBe(true);
   });
 
   it("TrainrunSectionsView.enforceStartTextAnchor - 003", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
     const ts = trainrunSectionService.getTrainrunSectionFromId(2);
-    const v1 = TrainrunSectionsView.enforceStartTextAnchor(ts, false);
+    const v1 = TrainrunSectionsView.enforceStartTextAnchor(ts, TrainrunSectionNodeAnchor.Target);
     expect(v1).toBe(false);
   });
 
   it("TrainrunSectionsView.enforceStartTextAnchor - 004", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
     const ts = trainrunSectionService.getTrainrunSectionFromId(2);
-    const v1 = TrainrunSectionsView.enforceStartTextAnchor(ts, true);
+    const v1 = TrainrunSectionsView.enforceStartTextAnchor(ts, TrainrunSectionNodeAnchor.Source);
     expect(v1).toBe(true);
   });
 
   it("TrainrunSectionsView.enforceStartTextAnchor - 005", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
     const ts = trainrunSectionService.getTrainrunSectionFromId(6);
-    const v1 = TrainrunSectionsView.enforceStartTextAnchor(ts, true);
+    const v1 = TrainrunSectionsView.enforceStartTextAnchor(ts, TrainrunSectionNodeAnchor.Source);
     expect(v1).toBe(false);
   });
 
   it("TrainrunSectionsView.enforceStartTextAnchor - 006", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
     const ts = trainrunSectionService.getTrainrunSectionFromId(6);
-    const v1 = TrainrunSectionsView.enforceStartTextAnchor(ts, false);
+    const v1 = TrainrunSectionsView.enforceStartTextAnchor(ts, TrainrunSectionNodeAnchor.Target);
     expect(v1).toBe(true);
   });
 
@@ -1007,7 +1011,7 @@ describe("TrainrunSection-View", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
     const ts = trainrunSectionService.getTrainrunSectionFromId(7);
     ts.getPath()[1].setY(-1);
-    const v1 = TrainrunSectionsView.enforceStartTextAnchor(ts, true);
+    const v1 = TrainrunSectionsView.enforceStartTextAnchor(ts, TrainrunSectionNodeAnchor.Source);
     expect(v1).toBe(true);
   });
 
@@ -1016,21 +1020,27 @@ describe("TrainrunSection-View", () => {
     const ts = trainrunSectionService.getTrainrunSectionFromId(7);
     ts.getPath()[3].setX(ts.getPath()[2].getX());
     ts.getPath()[3].setY(ts.getPath()[2].getY() + 1000);
-    const v1 = TrainrunSectionsView.enforceStartTextAnchor(ts, false);
+    const v1 = TrainrunSectionsView.enforceStartTextAnchor(ts, TrainrunSectionNodeAnchor.Target);
     expect(v1).toBe(true);
   });
 
   it("TrainrunSectionsView.getAdditionTextCloseToNodePositioningValue - 001", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
     const ts = trainrunSectionService.getTrainrunSectionFromId(2);
-    const v1 = TrainrunSectionsView.getAdditionTextCloseToNodePositioningValue(ts, true);
+    const v1 = TrainrunSectionsView.getAdditionTextCloseToNodePositioningValue(
+      ts,
+      TrainrunSectionNodeAnchor.Source,
+    );
     expect(v1).toBe("translate(498,80) rotate(0)");
   });
 
   it("TrainrunSectionsView.getAdditionTextCloseToNodePositioningValue - 002", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
     const ts = trainrunSectionService.getTrainrunSectionFromId(2);
-    const v1 = TrainrunSectionsView.getAdditionTextCloseToNodePositioningValue(ts, false);
+    const v1 = TrainrunSectionsView.getAdditionTextCloseToNodePositioningValue(
+      ts,
+      TrainrunSectionNodeAnchor.Target,
+    );
     expect(v1).toBe("translate(654,112) rotate(0)");
   });
 
@@ -1039,7 +1049,10 @@ describe("TrainrunSection-View", () => {
     const ts = trainrunSectionService.getTrainrunSectionFromId(6);
     ts.getPath()[3].setX(ts.getPath()[2].getX());
     ts.getPath()[3].setY(ts.getPath()[2].getY() + 1000);
-    const v1 = TrainrunSectionsView.getAdditionTextCloseToNodePositioningValue(ts, false);
+    const v1 = TrainrunSectionsView.getAdditionTextCloseToNodePositioningValue(
+      ts,
+      TrainrunSectionNodeAnchor.Target,
+    );
     expect(v1).toBe("translate(898,96) rotate(-90)");
   });
 
@@ -1048,7 +1061,10 @@ describe("TrainrunSection-View", () => {
     const ts = trainrunSectionService.getTrainrunSectionFromId(6);
     ts.getPath()[1].setX(ts.getPath()[0].getX());
     ts.getPath()[1].setY(ts.getPath()[0].getY());
-    const v1 = TrainrunSectionsView.getAdditionTextCloseToNodePositioningValue(ts, true);
+    const v1 = TrainrunSectionsView.getAdditionTextCloseToNodePositioningValue(
+      ts,
+      TrainrunSectionNodeAnchor.Source,
+    );
     expect(v1).toBe("translate(1054,272) rotate(-90)");
   });
 
@@ -1526,13 +1542,13 @@ describe("TrainrunSection-View", () => {
     const v0 = TrainrunSectionsView.getTrainrunSectionNextAndDestinationNodeToShow(
       trainrunSectionService.getTrainrunSectionFromId(0),
       editorView,
-      false,
+      TrainrunSectionNodeAnchor.Target,
     );
     expect(v0).toBe("BN");
     const v1 = TrainrunSectionsView.getTrainrunSectionNextAndDestinationNodeToShow(
       trainrunSectionService.getTrainrunSectionFromId(0),
       editorView,
-      true,
+      TrainrunSectionNodeAnchor.Source,
     );
     expect(v1).toBe("ZUE");
   });

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -1257,12 +1257,7 @@ export class TrainrunSectionsView {
       .attr(StaticDomTags.EDGE_NODE_ID, (d: TrainrunSectionViewObject) =>
         TrainrunSectionsView.getNode(d.trainrunSection, anchorNode).getId(),
       )
-      .classed(
-        StaticDomTags.EDGE_IS_TARGET,
-        anchorNode === TrainrunSectionNodeAnchor.Source
-          ? TrainrunSectionNodeAnchor.Target
-          : TrainrunSectionNodeAnchor.Source,
-      )
+      .classed(StaticDomTags.EDGE_IS_TARGET, anchorNode !== TrainrunSectionNodeAnchor.Source)
       .classed(StaticDomTags.TAG_HIDDEN, (d: TrainrunSectionViewObject) =>
         TrainrunSectionsView.getNode(d.trainrunSection, anchorNode).isNonStop(d.trainrunSection),
       )

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -943,9 +943,6 @@ export class TrainrunSectionsView {
     const atSource =
       lineTextElement === TrainrunSectionText.SourceArrival ||
       lineTextElement === TrainrunSectionText.SourceDeparture;
-    const isArrival =
-      lineTextElement === TrainrunSectionText.SourceArrival ||
-      lineTextElement === TrainrunSectionText.TargetArrival;
 
     const isOneWayText =
       lineTextElement === TrainrunSectionText.SourceDeparture ||
@@ -956,7 +953,7 @@ export class TrainrunSectionsView {
         const displayTextBackground = d.trainrunSection.getTrainrun().isRoundTrip() || isOneWayText;
         return (
           this.filterTrainrunsectionAtNode(d.trainrunSection, atSource) &&
-          this.filterTimeTrainrunsectionNonStop(d.trainrunSection, atSource, isArrival) &&
+          this.filterTimeTrainrunsectionNonStop(d.trainrunSection, lineTextElement) &&
           displayTextBackground
         );
       })
@@ -1356,9 +1353,6 @@ export class TrainrunSectionsView {
     const atSource =
       textElement === TrainrunSectionText.SourceArrival ||
       textElement === TrainrunSectionText.SourceDeparture;
-    const isArrival =
-      textElement === TrainrunSectionText.SourceArrival ||
-      textElement === TrainrunSectionText.TargetArrival;
 
     const isOneWayText =
       textElement === TrainrunSectionText.SourceDeparture ||
@@ -1371,7 +1365,7 @@ export class TrainrunSectionsView {
 
         return (
           this.filterTrainrunsectionAtNode(d.trainrunSection, atSource) &&
-          this.filterTimeTrainrunsectionNonStop(d.trainrunSection, atSource, isArrival) &&
+          this.filterTimeTrainrunsectionNonStop(d.trainrunSection, textElement) &&
           TrainrunSectionsView.hasWarning(d.trainrunSection, textElement) === hasWarning &&
           displayTextElement
         );
@@ -2021,16 +2015,16 @@ export class TrainrunSectionsView {
 
   private filterTimeTrainrunsectionNonStop(
     trainrunSection: TrainrunSection,
-    atSource: boolean,
-    isArrival: boolean,
+    lineTextElement: TrainrunSectionText,
   ): boolean {
-    if (!isArrival) {
-      return true;
+    switch (lineTextElement) {
+      case TrainrunSectionText.SourceDeparture:
+        return !trainrunSection.getSourceNode().isNonStop(trainrunSection);
+      case TrainrunSectionText.TargetDeparture:
+        return !trainrunSection.getTargetNode().isNonStop(trainrunSection);
+      default:
+        return true;
     }
-    if (atSource) {
-      return !trainrunSection.getSourceNode().isNonStop(trainrunSection);
-    }
-    return !trainrunSection.getTargetNode().isNonStop(trainrunSection);
   }
 
   private filterTrainrunsectionAtNode(

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -143,15 +143,15 @@ export class TrainrunSectionsView {
 
   static getPosition(
     trainrunSection: TrainrunSection,
-    nodeAnchor: TrainrunSectionNodeAnchor,
+    anchorNode: TrainrunSectionNodeAnchor,
   ): Vec2D {
-    return nodeAnchor === TrainrunSectionNodeAnchor.Source
+    return anchorNode === TrainrunSectionNodeAnchor.Source
       ? trainrunSection.getPositionAtSourceNode()
       : trainrunSection.getPositionAtTargetNode();
   }
 
-  static getNode(trainrunSection: TrainrunSection, nodeAnchor: TrainrunSectionNodeAnchor): Node {
-    return nodeAnchor === TrainrunSectionNodeAnchor.Source
+  static getNode(trainrunSection: TrainrunSection, anchorNode: TrainrunSectionNodeAnchor): Node {
+    return anchorNode === TrainrunSectionNodeAnchor.Source
       ? trainrunSection.getSourceNode()
       : trainrunSection.getTargetNode();
   }
@@ -275,10 +275,10 @@ export class TrainrunSectionsView {
 
   static enforceStartTextAnchor(
     trainrunSection: TrainrunSection,
-    nodeAnchor: TrainrunSectionNodeAnchor,
+    anchorNode: TrainrunSectionNodeAnchor,
   ): boolean {
     const path = trainrunSection.getPath();
-    if (nodeAnchor === TrainrunSectionNodeAnchor.Source) {
+    if (anchorNode === TrainrunSectionNodeAnchor.Source) {
       if (Math.floor(path[1].getX() - path[0].getX()) > 0) {
         return true;
       }
@@ -298,18 +298,18 @@ export class TrainrunSectionsView {
 
   static getAdditionTextCloseToNodePositioningValue(
     trainrunSection: TrainrunSection,
-    nodeAnchor: TrainrunSectionNodeAnchor,
+    anchorNode: TrainrunSectionNodeAnchor,
   ): string {
     const path = trainrunSection.getPath();
     let pos: Vec2D;
-    if (nodeAnchor === TrainrunSectionNodeAnchor.Source) {
+    if (anchorNode === TrainrunSectionNodeAnchor.Source) {
       pos = Vec2D.add(path[1], Vec2D.scale(Vec2D.normalize(Vec2D.sub(path[1], path[0])), 16));
     } else {
       pos = Vec2D.add(path[2], Vec2D.scale(Vec2D.normalize(Vec2D.sub(path[2], path[3])), 16));
     }
 
     const retPos = "translate(" + pos.getX() + "," + pos.getY() + ") ";
-    if (nodeAnchor === TrainrunSectionNodeAnchor.Source) {
+    if (anchorNode === TrainrunSectionNodeAnchor.Source) {
       if (Math.abs(path[0].getX() - path[1].getX()) > 1) {
         return retPos + "rotate(0)";
       }
@@ -832,10 +832,10 @@ export class TrainrunSectionsView {
   static getTrainrunSectionNextAndDestinationNodeToShow(
     trainrunSection: TrainrunSection,
     editorView: EditorView,
-    nodeAnchor: TrainrunSectionNodeAnchor,
+    anchorNode: TrainrunSectionNodeAnchor,
   ): string {
     let startNode: Node;
-    if (nodeAnchor === TrainrunSectionNodeAnchor.Source) {
+    if (anchorNode === TrainrunSectionNodeAnchor.Source) {
       startNode = trainrunSection.getSourceNode();
     } else {
       startNode = trainrunSection.getTargetNode();
@@ -975,7 +975,7 @@ export class TrainrunSectionsView {
     selectedTrainrun: Trainrun,
     connectedTrainIds: any,
   ) {
-    const nodeAnchor =
+    const anchorNode =
       lineTextElement === TrainrunSectionText.SourceArrival ||
       lineTextElement === TrainrunSectionText.SourceDeparture
         ? TrainrunSectionNodeAnchor.Source
@@ -989,7 +989,7 @@ export class TrainrunSectionsView {
       .filter((d: TrainrunSectionViewObject) => {
         const displayTextBackground = d.trainrunSection.getTrainrun().isRoundTrip() || isOneWayText;
         return (
-          this.filterTrainrunsectionAtNode(d.trainrunSection, nodeAnchor) &&
+          this.filterTrainrunsectionAtNode(d.trainrunSection, anchorNode) &&
           this.filterTimeTrainrunsectionNonStop(d.trainrunSection, lineTextElement) &&
           displayTextBackground
         );
@@ -1207,14 +1207,14 @@ export class TrainrunSectionsView {
     groupEnter: d3.Selector,
     selectedTrainrun: Trainrun,
     connectedTrainIds: any,
-    nodeAnchor: TrainrunSectionNodeAnchor,
+    anchorNode: TrainrunSectionNodeAnchor,
   ) {
     groupEnter
       .filter((d: TrainrunSectionViewObject) =>
-        this.filterTrainrunsectionAtNode(d.trainrunSection, nodeAnchor),
+        this.filterTrainrunsectionAtNode(d.trainrunSection, anchorNode),
       )
       .filter((d: TrainrunSectionViewObject) => {
-        const trans = TrainrunSectionsView.getNode(d.trainrunSection, nodeAnchor).getTransition(
+        const trans = TrainrunSectionsView.getNode(d.trainrunSection, anchorNode).getTransition(
           d.trainrunSection.getId(),
         );
         if (trans === undefined) {
@@ -1242,29 +1242,29 @@ export class TrainrunSectionsView {
       .attr("d", (d: TrainrunSectionViewObject) =>
         TrainrunSectionsView.createSemicircle(
           d.trainrunSection,
-          TrainrunSectionsView.getPosition(d.trainrunSection, nodeAnchor),
+          TrainrunSectionsView.getPosition(d.trainrunSection, anchorNode),
         ),
       )
       .attr(
         "transform",
         (d: TrainrunSectionViewObject) =>
           "translate(" +
-          TrainrunSectionsView.getPosition(d.trainrunSection, nodeAnchor).getX() +
+          TrainrunSectionsView.getPosition(d.trainrunSection, anchorNode).getX() +
           "," +
-          TrainrunSectionsView.getPosition(d.trainrunSection, nodeAnchor).getY() +
+          TrainrunSectionsView.getPosition(d.trainrunSection, anchorNode).getY() +
           ")",
       )
       .attr(StaticDomTags.EDGE_NODE_ID, (d: TrainrunSectionViewObject) =>
-        TrainrunSectionsView.getNode(d.trainrunSection, nodeAnchor).getId(),
+        TrainrunSectionsView.getNode(d.trainrunSection, anchorNode).getId(),
       )
       .classed(
         StaticDomTags.EDGE_IS_TARGET,
-        nodeAnchor === TrainrunSectionNodeAnchor.Source
+        anchorNode === TrainrunSectionNodeAnchor.Source
           ? TrainrunSectionNodeAnchor.Target
           : TrainrunSectionNodeAnchor.Source,
       )
       .classed(StaticDomTags.TAG_HIDDEN, (d: TrainrunSectionViewObject) =>
-        TrainrunSectionsView.getNode(d.trainrunSection, nodeAnchor).isNonStop(d.trainrunSection),
+        TrainrunSectionsView.getNode(d.trainrunSection, anchorNode).isNonStop(d.trainrunSection),
       )
       .classed(StaticDomTags.TAG_MUTED, (d: TrainrunSectionViewObject) =>
         TrainrunSectionsView.isMuted(d.trainrunSection, selectedTrainrun, connectedTrainIds),
@@ -1303,7 +1303,7 @@ export class TrainrunSectionsView {
     groupEnter: d3.Selector,
     selectedTrainrun: Trainrun,
     connectedTrainIds: any,
-    nodeAnchor: TrainrunSectionNodeAnchor,
+    anchorNode: TrainrunSectionNodeAnchor,
   ) {
     if (!this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable()) {
       return;
@@ -1316,21 +1316,21 @@ export class TrainrunSectionsView {
         d.trainrunSection.getTrainrunId(),
       )
       .attr("cx", (d: TrainrunSectionViewObject) =>
-        TrainrunSectionsView.getPosition(d.trainrunSection, nodeAnchor).getX(),
+        TrainrunSectionsView.getPosition(d.trainrunSection, anchorNode).getX(),
       )
       .attr("cy", (d: TrainrunSectionViewObject) =>
-        TrainrunSectionsView.getPosition(d.trainrunSection, nodeAnchor).getY(),
+        TrainrunSectionsView.getPosition(d.trainrunSection, anchorNode).getY(),
       )
       .attr("r", DEFAULT_PIN_RADIUS)
       .attr(StaticDomTags.EDGE_NODE_ID, (d: TrainrunSectionViewObject) =>
-        TrainrunSectionsView.getNode(d.trainrunSection, nodeAnchor).getId(),
+        TrainrunSectionsView.getNode(d.trainrunSection, anchorNode).getId(),
       )
       .classed(
         StaticDomTags.TAG_HIDDEN,
         (d: TrainrunSectionViewObject) =>
           !this.editorView.isTemporaryDisableFilteringOfItemsInViewEnabled() &&
           !this.editorView.checkFilterNonStopNode(
-            TrainrunSectionsView.getNode(d.trainrunSection, nodeAnchor),
+            TrainrunSectionsView.getNode(d.trainrunSection, anchorNode),
           ),
       )
       .classed(
@@ -1338,18 +1338,18 @@ export class TrainrunSectionsView {
         (d: TrainrunSectionViewObject) =>
           !this.editorView.isTemporaryDisableFilteringOfItemsInViewEnabled() &&
           !this.editorView.checkFilterNonStopNode(
-            TrainrunSectionsView.getNode(d.trainrunSection, nodeAnchor),
+            TrainrunSectionsView.getNode(d.trainrunSection, anchorNode),
           ),
       )
       .classed(
-        nodeAnchor === TrainrunSectionNodeAnchor.Source
+        anchorNode === TrainrunSectionNodeAnchor.Source
           ? StaticDomTags.EDGE_IS_SOURCE
           : StaticDomTags.EDGE_IS_TARGET,
         true,
       )
       .classed(StaticDomTags.EDGE_IS_END_NODE, (d: TrainrunSectionViewObject) => {
         let node = d.trainrunSection.getTargetNode();
-        if (nodeAnchor === TrainrunSectionNodeAnchor.Source) {
+        if (anchorNode === TrainrunSectionNodeAnchor.Source) {
           node = d.trainrunSection.getSourceNode();
         }
         const port = node.getPortOfTrainrunSection(d.trainrunSection.getId());
@@ -1358,7 +1358,7 @@ export class TrainrunSectionsView {
       })
       .classed(StaticDomTags.EDGE_IS_NOT_END_NODE, (d: TrainrunSectionViewObject) => {
         let node = d.trainrunSection.getTargetNode();
-        if (nodeAnchor === TrainrunSectionNodeAnchor.Source) {
+        if (anchorNode === TrainrunSectionNodeAnchor.Source) {
           node = d.trainrunSection.getSourceNode();
         }
         const port = node.getPortOfTrainrunSection(d.trainrunSection.getId());
@@ -1374,17 +1374,17 @@ export class TrainrunSectionsView {
       )
       .on("mouseover", (d: TrainrunSectionViewObject, i, a) =>
         this.onTrainrunSectionMouseoverPin(
-          TrainrunSectionsView.getNode(d.trainrunSection, nodeAnchor),
+          TrainrunSectionsView.getNode(d.trainrunSection, anchorNode),
           a[i],
         ),
       )
       .on("mouseout", (d: TrainrunSectionViewObject, i, a) =>
-        this.onTrainrunSectionMouseoutPin(d.trainrunSection, a[i], nodeAnchor),
+        this.onTrainrunSectionMouseoutPin(d.trainrunSection, a[i], anchorNode),
       )
       .on("mousedown", () => this.onTrainrunSectionMousedownPin())
       .on("mousemove", () => this.onTrainrunSectionMousemovePin())
       .on("mouseup", (d: TrainrunSectionViewObject) =>
-        this.onTrainrunSectionMouseupPin(d.trainrunSection, nodeAnchor),
+        this.onTrainrunSectionMouseupPin(d.trainrunSection, anchorNode),
       );
   }
 
@@ -1399,7 +1399,7 @@ export class TrainrunSectionsView {
     const isDefaultText =
       textElement === TrainrunSectionText.TrainrunSectionName ||
       textElement === TrainrunSectionText.TrainrunSectionTravelTime;
-    const nodeAnchor =
+    const anchorNode =
       textElement === TrainrunSectionText.SourceArrival ||
       textElement === TrainrunSectionText.SourceDeparture
         ? TrainrunSectionNodeAnchor.Source
@@ -1415,7 +1415,7 @@ export class TrainrunSectionsView {
           d.trainrunSection.getTrainrun().isRoundTrip() || isDefaultText || isOneWayText;
 
         return (
-          this.filterTrainrunsectionAtNode(d.trainrunSection, nodeAnchor) &&
+          this.filterTrainrunsectionAtNode(d.trainrunSection, anchorNode) &&
           this.filterTimeTrainrunsectionNonStop(d.trainrunSection, textElement) &&
           TrainrunSectionsView.hasWarning(d.trainrunSection, textElement) === hasWarning &&
           displayTextElement
@@ -1525,12 +1525,12 @@ export class TrainrunSectionsView {
     groupEnter: d3.Selector,
     selectedTrainrun: Trainrun,
     connectedTrainIds: any,
-    nodeAnchor: TrainrunSectionNodeAnchor,
+    anchorNode: TrainrunSectionNodeAnchor,
   ) {
     const textElement = TrainrunSectionText.TrainrunSectionName;
     groupEnter
       .filter((d: TrainrunSectionViewObject) =>
-        this.filterTrainrunsectionAtNode(d.trainrunSection, nodeAnchor),
+        this.filterTrainrunsectionAtNode(d.trainrunSection, anchorNode),
       )
       .append(StaticDomTags.EDGE_LINE_TEXT_SVG)
       .attr("class", (d: TrainrunSectionViewObject) =>
@@ -1551,7 +1551,7 @@ export class TrainrunSectionsView {
       .attr("transform", (d: TrainrunSectionViewObject) =>
         TrainrunSectionsView.getAdditionTextCloseToNodePositioningValue(
           d.trainrunSection,
-          nodeAnchor,
+          anchorNode,
         ),
       )
       .classed(StaticDomTags.TAG_SELECTED, (d: TrainrunSectionViewObject) =>
@@ -1565,13 +1565,13 @@ export class TrainrunSectionsView {
       )
       .classed(StaticDomTags.TAG_EVENT_DISABLED, true)
       .classed(StaticDomTags.TAG_START_TEXT_ANCHOR, (d: TrainrunSectionViewObject) =>
-        TrainrunSectionsView.enforceStartTextAnchor(d.trainrunSection, nodeAnchor),
+        TrainrunSectionsView.enforceStartTextAnchor(d.trainrunSection, anchorNode),
       )
       .text((d: TrainrunSectionViewObject) =>
         TrainrunSectionsView.getTrainrunSectionNextAndDestinationNodeToShow(
           d.trainrunSection,
           this.editorView,
-          nodeAnchor,
+          anchorNode,
         ),
       );
   }
@@ -1962,7 +1962,7 @@ export class TrainrunSectionsView {
   onTrainrunSectionMouseoutPin(
     trainrunSection: TrainrunSection,
     domObj: any,
-    nodeAnchor: TrainrunSectionNodeAnchor,
+    anchorNode: TrainrunSectionNodeAnchor,
   ) {
     d3.select(domObj).classed(StaticDomTags.TAG_HOVER, false);
     if (this.editorView.trainrunSectionPreviewLineView.getMode() !== PreviewLineMode.NotDragging) {
@@ -1975,7 +1975,7 @@ export class TrainrunSectionsView {
       .selectAll(
         StaticDomTags.EDGE_LINE_PIN_DOM_REF +
           "." +
-          (nodeAnchor === TrainrunSectionNodeAnchor.Source
+          (anchorNode === TrainrunSectionNodeAnchor.Source
             ? StaticDomTags.EDGE_IS_TARGET
             : StaticDomTags.EDGE_IS_SOURCE),
       )
@@ -1988,7 +1988,7 @@ export class TrainrunSectionsView {
     this.editorView.trainrunSectionPreviewLineView.startPreviewLineAtPosition(
       TrainrunSectionsView.getNode(
         trainrunSection,
-        nodeAnchor === TrainrunSectionNodeAnchor.Source
+        anchorNode === TrainrunSectionNodeAnchor.Source
           ? TrainrunSectionNodeAnchor.Target
           : TrainrunSectionNodeAnchor.Source,
       ),
@@ -1996,7 +1996,7 @@ export class TrainrunSectionsView {
     );
 
     const hasTrans =
-      TrainrunSectionsView.getNode(trainrunSection, nodeAnchor).getTransition(
+      TrainrunSectionsView.getNode(trainrunSection, anchorNode).getTransition(
         trainrunSection.getId(),
       ) !== undefined;
 
@@ -2018,7 +2018,7 @@ export class TrainrunSectionsView {
 
   onTrainrunSectionMouseupPin(
     trainrunSection: TrainrunSection,
-    nodeAnchor: TrainrunSectionNodeAnchor,
+    anchorNode: TrainrunSectionNodeAnchor,
   ) {
     if (this.editorView.editorMode === EditorMode.MultiNodeMoving) {
       this.handleMultiNodeMovingTrainrunSectionMouseUp(trainrunSection);
@@ -2029,7 +2029,7 @@ export class TrainrunSectionsView {
       false,
     );
     this.createNewTrainrunSectionAfterPinDropped(
-      TrainrunSectionsView.getNode(trainrunSection, nodeAnchor),
+      TrainrunSectionsView.getNode(trainrunSection, anchorNode),
       trainrunSection,
     );
     this.editorView.trainrunSectionPreviewLineView.stopPreviewLine();
@@ -2094,13 +2094,13 @@ export class TrainrunSectionsView {
 
   private filterTrainrunsectionAtNode(
     trainrunSection: TrainrunSection,
-    nodeAnchor: TrainrunSectionNodeAnchor,
+    anchorNode: TrainrunSectionNodeAnchor,
   ): boolean {
     if (this.editorView.isTemporaryDisableFilteringOfItemsInViewEnabled()) {
       return true;
     }
     return this.editorView.checkFilterNode(
-      TrainrunSectionsView.getNode(trainrunSection, nodeAnchor),
+      TrainrunSectionsView.getNode(trainrunSection, anchorNode),
     );
   }
 


### PR DESCRIPTION
This refactoring replaces the ambiguous `atSource: boolean` parameter with the explicit
`TrainrunSectionNodeAnchor` enum. This improves readability, reduces boolean ambiguity,
and makes the intent of each method call clearer. Several methods in
`TrainrunSectionsView`, `PerlenketteSectionComponent`, and related view logic were updated
accordingly to use the new enum-based API.
