### PR TITLE
feat: add more details to trainrun events

### DIFF
--- a/src/app/models/operation.model.ts
+++ b/src/app/models/operation.model.ts
@@ -41,9 +41,26 @@ abstract class TrainrunOperation extends Operation {
   }
 }
 
+type TrainrunUpdateTag =
+  | "nodes"
+  | "times"
+  | "numberOfStops"
+  | "name"
+  | "categoryId"
+  | "frequencyId"
+  | "timeCategoryId"
+  | "labelIds"
+  | "direction";
+
 class TrainrunUpdateOperation extends TrainrunOperation {
-  constructor(trainrun: Trainrun) {
+  readonly tags: TrainrunUpdateTag[];
+  constructor(
+    trainrun: Trainrun,
+    tags: TrainrunUpdateTag[],
+    oneWayDirection?: "forward" | "backward",
+  ) {
     super(OperationType.update, trainrun);
+    this.tags = tags;
   }
 }
 

--- a/src/app/models/operation.model.ts
+++ b/src/app/models/operation.model.ts
@@ -32,12 +32,30 @@ abstract class Operation {
   }
 }
 
-class TrainrunOperation extends Operation {
+abstract class TrainrunOperation extends Operation {
   readonly trainrun: TrainrunDto;
 
   constructor(operationType: OperationType, trainrun: Trainrun) {
     super(operationType, OperationObjectType.trainrun);
     this.trainrun = trainrun.getDto();
+  }
+}
+
+class TrainrunUpdateOperation extends TrainrunOperation {
+  constructor(trainrun: Trainrun) {
+    super(OperationType.update, trainrun);
+  }
+}
+
+class TrainrunCreateOperation extends TrainrunOperation {
+  constructor(trainrun: Trainrun) {
+    super(OperationType.create, trainrun);
+  }
+}
+
+class TrainrunDeleteOperation extends TrainrunOperation {
+  constructor(trainrun: Trainrun) {
+    super(OperationType.delete, trainrun);
   }
 }
 
@@ -68,4 +86,13 @@ class NoteOperation extends Operation {
   }
 }
 
-export {OperationType, Operation, TrainrunOperation, NodeOperation, LabelOperation, NoteOperation};
+export {
+  OperationType,
+  Operation,
+  TrainrunUpdateOperation,
+  TrainrunCreateOperation,
+  TrainrunDeleteOperation,
+  NodeOperation,
+  LabelOperation,
+  NoteOperation,
+};

--- a/src/app/models/operation.model.ts
+++ b/src/app/models/operation.model.ts
@@ -54,6 +54,7 @@ type TrainrunUpdateTag =
 
 class TrainrunUpdateOperation extends TrainrunOperation {
   readonly tags: TrainrunUpdateTag[];
+  readonly oneWayDirection?: "forward" | "backward";
   constructor(
     trainrun: Trainrun,
     tags: TrainrunUpdateTag[],
@@ -61,6 +62,7 @@ class TrainrunUpdateOperation extends TrainrunOperation {
   ) {
     super(OperationType.update, trainrun);
     this.tags = tags;
+    this.oneWayDirection = oneWayDirection;
   }
 }
 

--- a/src/app/models/operation.model.ts
+++ b/src/app/models/operation.model.ts
@@ -48,8 +48,10 @@ class TrainrunUpdateOperation extends TrainrunOperation {
 }
 
 class TrainrunCreateOperation extends TrainrunOperation {
-  constructor(trainrun: Trainrun) {
+  readonly duplicatedTrainrunId?: number;
+  constructor(trainrun: Trainrun, duplicatedTrainrunId?: number) {
     super(OperationType.create, trainrun);
+    this.duplicatedTrainrunId = duplicatedTrainrunId;
   }
 }
 

--- a/src/app/models/operation.model.ts
+++ b/src/app/models/operation.model.ts
@@ -43,13 +43,31 @@ abstract class BaseOperation<O extends OperationObjectType> {
   }
 }
 
-class TrainrunOperation extends BaseOperation<OperationObjectType.trainrun> {
+abstract class TrainrunOperation extends BaseOperation<OperationObjectType.trainrun> {
   readonly trainrun: TrainrunDto;
 
   /** @internal */
   constructor(operationType: OperationType, trainrun: Trainrun) {
     super(operationType, OperationObjectType.trainrun);
     this.trainrun = trainrun.getDto();
+  }
+}
+
+class TrainrunUpdateOperation extends TrainrunOperation {
+  constructor(trainrun: Trainrun) {
+    super(OperationType.update, trainrun);
+  }
+}
+
+class TrainrunCreateOperation extends TrainrunOperation {
+  constructor(trainrun: Trainrun) {
+    super(OperationType.create, trainrun);
+  }
+}
+
+class TrainrunDeleteOperation extends TrainrunOperation {
+  constructor(trainrun: Trainrun) {
+    super(OperationType.delete, trainrun);
   }
 }
 
@@ -114,7 +132,9 @@ type Operation =
 export {
   OperationType,
   Operation,
-  TrainrunOperation,
+  TrainrunUpdateOperation,
+  TrainrunCreateOperation,
+  TrainrunDeleteOperation,
   NodeOperation,
   LabelOperation,
   NoteOperation,

--- a/src/app/models/operation.model.ts
+++ b/src/app/models/operation.model.ts
@@ -66,6 +66,7 @@ type TrainrunUpdateTag =
 
 class TrainrunUpdateOperation extends TrainrunOperation {
   readonly tags: TrainrunUpdateTag[];
+  readonly oneWayDirection?: "forward" | "backward";
   constructor(
     trainrun: Trainrun,
     tags: TrainrunUpdateTag[],
@@ -73,6 +74,7 @@ class TrainrunUpdateOperation extends TrainrunOperation {
   ) {
     super(OperationType.update, trainrun);
     this.tags = tags;
+    this.oneWayDirection = oneWayDirection;
   }
 }
 

--- a/src/app/models/operation.model.ts
+++ b/src/app/models/operation.model.ts
@@ -53,9 +53,26 @@ abstract class TrainrunOperation extends BaseOperation<OperationObjectType.train
   }
 }
 
+type TrainrunUpdateTag =
+  | "nodes"
+  | "times"
+  | "numberOfStops"
+  | "name"
+  | "categoryId"
+  | "frequencyId"
+  | "timeCategoryId"
+  | "labelIds"
+  | "direction";
+
 class TrainrunUpdateOperation extends TrainrunOperation {
-  constructor(trainrun: Trainrun) {
+  readonly tags: TrainrunUpdateTag[];
+  constructor(
+    trainrun: Trainrun,
+    tags: TrainrunUpdateTag[],
+    oneWayDirection?: "forward" | "backward",
+  ) {
     super(OperationType.update, trainrun);
+    this.tags = tags;
   }
 }
 

--- a/src/app/models/operation.model.ts
+++ b/src/app/models/operation.model.ts
@@ -60,8 +60,10 @@ class TrainrunUpdateOperation extends TrainrunOperation {
 }
 
 class TrainrunCreateOperation extends TrainrunOperation {
-  constructor(trainrun: Trainrun) {
+  readonly duplicatedTrainrunId?: number;
+  constructor(trainrun: Trainrun, duplicatedTrainrunId?: number) {
     super(OperationType.create, trainrun);
+    this.duplicatedTrainrunId = duplicatedTrainrunId;
   }
 }
 

--- a/src/app/models/operation.model.ts
+++ b/src/app/models/operation.model.ts
@@ -32,22 +32,25 @@ type MetadataDto = {
   trafficSide?: TrafficSide;
 };
 
-abstract class BaseOperation<O extends OperationObjectType> {
-  readonly type: OperationType;
+abstract class BaseOperation<O extends OperationObjectType, T extends OperationType> {
+  readonly type: T;
   readonly objectType: O;
 
   /** @internal */
-  constructor(type: OperationType, objectType: O) {
+  constructor(type: T, objectType: O) {
     this.type = type;
     this.objectType = objectType;
   }
 }
 
-abstract class TrainrunOperation extends BaseOperation<OperationObjectType.trainrun> {
+abstract class TrainrunOperation<T extends OperationType> extends BaseOperation<
+  OperationObjectType.trainrun,
+  T
+> {
   readonly trainrun: TrainrunDto;
 
   /** @internal */
-  constructor(operationType: OperationType, trainrun: Trainrun) {
+  constructor(operationType: T, trainrun: Trainrun) {
     super(operationType, OperationObjectType.trainrun);
     this.trainrun = trainrun.getDto();
   }
@@ -64,7 +67,7 @@ type TrainrunUpdateTag =
   | "labelIds"
   | "direction";
 
-class TrainrunUpdateOperation extends TrainrunOperation {
+class TrainrunUpdateOperation extends TrainrunOperation<OperationType.update> {
   readonly tags: TrainrunUpdateTag[];
   readonly oneWayDirection?: "forward" | "backward";
   constructor(
@@ -78,7 +81,7 @@ class TrainrunUpdateOperation extends TrainrunOperation {
   }
 }
 
-class TrainrunCreateOperation extends TrainrunOperation {
+class TrainrunCreateOperation extends TrainrunOperation<OperationType.create> {
   readonly duplicatedTrainrunId?: number;
   constructor(trainrun: Trainrun, duplicatedTrainrunId?: number) {
     super(OperationType.create, trainrun);
@@ -86,13 +89,13 @@ class TrainrunCreateOperation extends TrainrunOperation {
   }
 }
 
-class TrainrunDeleteOperation extends TrainrunOperation {
+class TrainrunDeleteOperation extends TrainrunOperation<OperationType.delete> {
   constructor(trainrun: Trainrun) {
     super(OperationType.delete, trainrun);
   }
 }
 
-class NodeOperation extends BaseOperation<OperationObjectType.node> {
+class NodeOperation extends BaseOperation<OperationObjectType.node, OperationType> {
   readonly node: NodeDto;
 
   /** @internal */
@@ -102,7 +105,7 @@ class NodeOperation extends BaseOperation<OperationObjectType.node> {
   }
 }
 
-class LabelOperation extends BaseOperation<OperationObjectType.label> {
+class LabelOperation extends BaseOperation<OperationObjectType.label, OperationType> {
   readonly label: LabelDto;
 
   /** @internal */
@@ -112,7 +115,7 @@ class LabelOperation extends BaseOperation<OperationObjectType.label> {
   }
 }
 
-class NoteOperation extends BaseOperation<OperationObjectType.note> {
+class NoteOperation extends BaseOperation<OperationObjectType.note, OperationType> {
   readonly note: FreeFloatingTextDto;
 
   /** @internal */
@@ -122,7 +125,7 @@ class NoteOperation extends BaseOperation<OperationObjectType.note> {
   }
 }
 
-class MetadataOperation extends BaseOperation<OperationObjectType.metadata> {
+class MetadataOperation extends BaseOperation<OperationObjectType.metadata, OperationType> {
   readonly metadata: MetadataDto;
 
   /** @internal */
@@ -132,7 +135,10 @@ class MetadataOperation extends BaseOperation<OperationObjectType.metadata> {
   }
 }
 
-class FilterSettingOperation extends BaseOperation<OperationObjectType.filterSetting> {
+class FilterSettingOperation extends BaseOperation<
+  OperationObjectType.filterSetting,
+  OperationType
+> {
   readonly filterSetting: FilterSettingDto;
 
   /** @internal */
@@ -143,7 +149,9 @@ class FilterSettingOperation extends BaseOperation<OperationObjectType.filterSet
 }
 
 type Operation =
-  | TrainrunOperation
+  | TrainrunUpdateOperation
+  | TrainrunCreateOperation
+  | TrainrunDeleteOperation
   | NodeOperation
   | LabelOperation
   | NoteOperation

--- a/src/app/services/data/node.service.ts
+++ b/src/app/services/data/node.service.ts
@@ -488,6 +488,13 @@ export class NodeService implements OnDestroy {
       this.transitionsUpdated();
       this.nodesUpdated();
     }
+    this.operation.emit(
+      new TrainrunUpdateOperation(trainrunSection1.getTrainrun(), [
+        "nodes",
+        "times",
+        "numberOfStops",
+      ]),
+    );
 
     return trainrunSection1;
   }

--- a/src/app/services/data/node.service.ts
+++ b/src/app/services/data/node.service.ts
@@ -35,7 +35,7 @@ import {
   NodeOperation,
   Operation,
   OperationType,
-  TrainrunOperation,
+  TrainrunUpdateOperation,
 } from "../../models/operation.model";
 
 @Injectable({
@@ -571,7 +571,7 @@ export class NodeService implements OnDestroy {
     this.transitionsUpdated();
     this.nodesUpdated();
     this.operation.emit(
-      new TrainrunOperation(OperationType.update, trainrunSections.trainrunSection1.getTrainrun()),
+      new TrainrunUpdateOperation(trainrunSections.trainrunSection1.getTrainrun()),
     );
   }
 

--- a/src/app/services/data/node.service.ts
+++ b/src/app/services/data/node.service.ts
@@ -571,7 +571,10 @@ export class NodeService implements OnDestroy {
     this.transitionsUpdated();
     this.nodesUpdated();
     this.operation.emit(
-      new TrainrunUpdateOperation(trainrunSections.trainrunSection1.getTrainrun()),
+      new TrainrunUpdateOperation(trainrunSections.trainrunSection1.getTrainrun(), [
+        "times",
+        "numberOfStops",
+      ]),
     );
   }
 

--- a/src/app/services/data/node.service.ts
+++ b/src/app/services/data/node.service.ts
@@ -599,7 +599,7 @@ export class NodeService implements OnDestroy {
     this.transitionsUpdated();
     this.nodesUpdated();
     this.operation.emit(
-      new TrainrunUpdateOperation(trainrunSections.trainrunSection1.getTrainrun()),
+      new TrainrunUpdateOperation(trainrunSections.trainrunSection1.getTrainrun(), ["times"]),
     );
   }
 

--- a/src/app/services/data/node.service.ts
+++ b/src/app/services/data/node.service.ts
@@ -35,7 +35,7 @@ import {
   NodeOperation,
   Operation,
   OperationType,
-  TrainrunOperation,
+  TrainrunUpdateOperation,
 } from "../../models/operation.model";
 
 @Injectable({
@@ -599,7 +599,7 @@ export class NodeService implements OnDestroy {
     this.transitionsUpdated();
     this.nodesUpdated();
     this.operation.emit(
-      new TrainrunOperation(OperationType.update, trainrunSections.trainrunSection1.getTrainrun()),
+      new TrainrunUpdateOperation(trainrunSections.trainrunSection1.getTrainrun()),
     );
   }
 

--- a/src/app/services/data/node.service.ts
+++ b/src/app/services/data/node.service.ts
@@ -517,6 +517,13 @@ export class NodeService implements OnDestroy {
       this.transitionsUpdated();
       this.nodesUpdated();
     }
+    this.operation.emit(
+      new TrainrunUpdateOperation(trainrunSection1.getTrainrun(), [
+        "nodes",
+        "times",
+        "numberOfStops",
+      ]),
+    );
 
     return trainrunSection1;
   }

--- a/src/app/services/data/trainrun.service.ts
+++ b/src/app/services/data/trainrun.service.ts
@@ -270,12 +270,14 @@ export class TrainrunService {
     this.operation.emit(new TrainrunUpdateOperation(trainrun, ["name"]));
   }
 
-  updateDirection(trainrun: Trainrun, direction: Direction) {
+  updateDirection(trainrun: Trainrun, direction: Direction, isTrainInverted?: boolean) {
     const trainrunSection = this.getTrainrunFromId(trainrun.getId());
     trainrunSection.setDirection(direction);
     this.trainrunsUpdated();
+    let oneWayDirection = undefined;
+    if (direction === Direction.ONE_WAY) oneWayDirection = isTrainInverted ? "backward" : "forward";
     this.operation.emit(
-      new TrainrunUpdateOperation(trainrun, ["direction", "nodes", "times"]),
+      new TrainrunUpdateOperation(trainrun, ["direction", "nodes", "times"], oneWayDirection),
     );
   }
 

--- a/src/app/services/data/trainrun.service.ts
+++ b/src/app/services/data/trainrun.service.ts
@@ -236,7 +236,7 @@ export class TrainrunService {
     this.nodeService.reorderPortsOnNodesForTrainrun(trainrun, false);
     this.propagateTrainrunInitialConsecutiveTimes(trainrun);
     this.trainrunsUpdated();
-    this.operation.emit(new TrainrunUpdateOperation(trainrun));
+    this.operation.emit(new TrainrunUpdateOperation(trainrun, ["times", "frequencyId"]));
     return freqOffset;
   }
 
@@ -248,7 +248,7 @@ export class TrainrunService {
     this.getTrainrunFromId(trainrun.getId()).setTrainrunCategory(category);
     this.nodeService.reorderPortsOnNodesForTrainrun(trainrun, false);
     this.trainrunsUpdated();
-    this.operation.emit(new TrainrunUpdateOperation(trainrun));
+    this.operation.emit(new TrainrunUpdateOperation(trainrun, ["categoryId"]));
   }
 
   updateTrainrunTimeCategory(trainrun: Trainrun, timeCategory: TrainrunTimeCategory) {
@@ -260,21 +260,23 @@ export class TrainrunService {
     this.getTrainrunFromId(trainrun.getId()).setTrainrunTimeCategory(timeCategory);
     this.nodeService.reorderPortsOnNodesForTrainrun(trainrun, false);
     this.trainrunsUpdated();
-    this.operation.emit(new TrainrunUpdateOperation(trainrun));
+    this.operation.emit(new TrainrunUpdateOperation(trainrun, ["timeCategoryId"]));
   }
 
   updateTrainrunTitle(trainrun: Trainrun, title: string) {
     this.getTrainrunFromId(trainrun.getId()).setTitle(title);
     this.nodeService.reorderPortsOnNodesForTrainrun(trainrun, false);
     this.trainrunsUpdated();
-    this.operation.emit(new TrainrunUpdateOperation(trainrun));
+    this.operation.emit(new TrainrunUpdateOperation(trainrun, ["name"]));
   }
 
   updateDirection(trainrun: Trainrun, direction: Direction) {
     const trainrunSection = this.getTrainrunFromId(trainrun.getId());
     trainrunSection.setDirection(direction);
     this.trainrunsUpdated();
-    this.operation.emit(new TrainrunUpdateOperation(trainrun));
+    this.operation.emit(
+      new TrainrunUpdateOperation(trainrun, ["direction", "nodes", "times"]),
+    );
   }
 
   getTrainruns(): Trainrun[] {
@@ -558,7 +560,7 @@ export class TrainrunService {
     trainrun.setLabelIds(labelIds);
     this.trainrunsUpdated();
     if (uniqueLabels.length === labels.length) {
-      this.operation.emit(new TrainrunUpdateOperation(trainrun));
+      this.operation.emit(new TrainrunUpdateOperation(trainrun, ["labelIds"]));
     }
   }
 

--- a/src/app/services/data/trainrun.service.ts
+++ b/src/app/services/data/trainrun.service.ts
@@ -29,7 +29,13 @@ import {FilterService} from "../ui/filter.service";
 import {Transition} from "../../models/transition.model";
 import {Port} from "../../models/port.model";
 import {Connection} from "../../models/connection.model";
-import {Operation, OperationType, TrainrunOperation} from "../../models/operation.model";
+import {
+  Operation,
+  OperationType,
+  TrainrunCreateOperation,
+  TrainrunDeleteOperation,
+  TrainrunUpdateOperation,
+} from "../../models/operation.model";
 import {TrainrunsectionHelper} from "../util/trainrunsection.helper";
 
 @Injectable({
@@ -158,7 +164,7 @@ export class TrainrunService {
     if (enforceUpdate) {
       this.trainrunsUpdated();
     }
-    this.operation.emit(new TrainrunOperation(OperationType.delete, trainrun));
+    this.operation.emit(new TrainrunDeleteOperation(trainrun));
   }
 
   getSelectedTrainrun(): Trainrun {
@@ -230,7 +236,7 @@ export class TrainrunService {
     this.nodeService.reorderPortsOnNodesForTrainrun(trainrun, false);
     this.propagateTrainrunInitialConsecutiveTimes(trainrun);
     this.trainrunsUpdated();
-    this.operation.emit(new TrainrunOperation(OperationType.update, trainrun));
+    this.operation.emit(new TrainrunUpdateOperation(trainrun));
     return freqOffset;
   }
 
@@ -242,7 +248,7 @@ export class TrainrunService {
     this.getTrainrunFromId(trainrun.getId()).setTrainrunCategory(category);
     this.nodeService.reorderPortsOnNodesForTrainrun(trainrun, false);
     this.trainrunsUpdated();
-    this.operation.emit(new TrainrunOperation(OperationType.update, trainrun));
+    this.operation.emit(new TrainrunUpdateOperation(trainrun));
   }
 
   updateTrainrunTimeCategory(trainrun: Trainrun, timeCategory: TrainrunTimeCategory) {
@@ -254,21 +260,21 @@ export class TrainrunService {
     this.getTrainrunFromId(trainrun.getId()).setTrainrunTimeCategory(timeCategory);
     this.nodeService.reorderPortsOnNodesForTrainrun(trainrun, false);
     this.trainrunsUpdated();
-    this.operation.emit(new TrainrunOperation(OperationType.update, trainrun));
+    this.operation.emit(new TrainrunUpdateOperation(trainrun));
   }
 
   updateTrainrunTitle(trainrun: Trainrun, title: string) {
     this.getTrainrunFromId(trainrun.getId()).setTitle(title);
     this.nodeService.reorderPortsOnNodesForTrainrun(trainrun, false);
     this.trainrunsUpdated();
-    this.operation.emit(new TrainrunOperation(OperationType.update, trainrun));
+    this.operation.emit(new TrainrunUpdateOperation(trainrun));
   }
 
   updateDirection(trainrun: Trainrun, direction: Direction) {
     const trainrunSection = this.getTrainrunFromId(trainrun.getId());
     trainrunSection.setDirection(direction);
     this.trainrunsUpdated();
-    this.operation.emit(new TrainrunOperation(OperationType.update, trainrun));
+    this.operation.emit(new TrainrunUpdateOperation(trainrun));
   }
 
   getTrainruns(): Trainrun[] {
@@ -385,7 +391,7 @@ export class TrainrunService {
     newTrainrun.select();
     this.nodeService.transitionsUpdated();
     this.trainrunsUpdated();
-    this.operation.emit(new TrainrunOperation(OperationType.create, newTrainrun));
+    this.operation.emit(new TrainrunCreateOperation(newTrainrun));
   }
 
   combineTwoTrainruns(node: Node, port1: Port, port2: Port) {
@@ -532,7 +538,7 @@ export class TrainrunService {
       this.nodeService.nodesUpdated();
       this.trainrunsUpdated();
     }
-    this.operation.emit(new TrainrunOperation(OperationType.create, copiedtrainrun));
+    this.operation.emit(new TrainrunCreateOperation(copiedtrainrun));
     return copiedtrainrun;
   }
 
@@ -552,7 +558,7 @@ export class TrainrunService {
     trainrun.setLabelIds(labelIds);
     this.trainrunsUpdated();
     if (uniqueLabels.length === labels.length) {
-      this.operation.emit(new TrainrunOperation(OperationType.update, trainrun));
+      this.operation.emit(new TrainrunUpdateOperation(trainrun));
     }
   }
 

--- a/src/app/services/data/trainrun.service.ts
+++ b/src/app/services/data/trainrun.service.ts
@@ -310,6 +310,7 @@ export class TrainrunService {
       if (this.filterService.filterTrainrun(t)) {
         this.filterService.clearDeletetFilterTrainrunLabel(labelObject.getId());
         t.setLabelIds(t.getLabelIds().filter((labelId: number) => labelId !== labelObject.getId()));
+        this.operation.emit(new TrainrunUpdateOperation(t, ["labelIds"]));
       }
     });
 
@@ -396,6 +397,9 @@ export class TrainrunService {
     this.nodeService.transitionsUpdated();
     this.trainrunsUpdated();
     this.operation.emit(new TrainrunCreateOperation(newTrainrun));
+    this.operation.emit(
+      new TrainrunUpdateOperation(trainrun2split, ["nodes", "times", "numberOfStops"]),
+    );
   }
 
   combineTwoTrainruns(node: Node, port1: Port, port2: Port) {
@@ -508,6 +512,9 @@ export class TrainrunService {
 
     // update
     this.trainrunsUpdated();
+    this.operation.emit(
+      new TrainrunUpdateOperation(trainrun1, ["nodes", "times", "numberOfStops"]),
+    );
     this.nodeService.nodesUpdated();
     this.nodeService.connectionsUpdated();
     this.nodeService.transitionsUpdated();

--- a/src/app/services/data/trainrun.service.ts
+++ b/src/app/services/data/trainrun.service.ts
@@ -538,7 +538,7 @@ export class TrainrunService {
       this.nodeService.nodesUpdated();
       this.trainrunsUpdated();
     }
-    this.operation.emit(new TrainrunCreateOperation(copiedtrainrun));
+    this.operation.emit(new TrainrunCreateOperation(copiedtrainrun, trainrunId));
     return copiedtrainrun;
   }
 

--- a/src/app/services/data/trainrun.service.ts
+++ b/src/app/services/data/trainrun.service.ts
@@ -316,6 +316,7 @@ export class TrainrunService {
       if (this.filterService.filterTrainrun(t)) {
         this.filterService.clearDeletetFilterTrainrunLabel(labelObject.getId());
         t.setLabelIds(t.getLabelIds().filter((labelId: number) => labelId !== labelObject.getId()));
+        this.operation.emit(new TrainrunUpdateOperation(t, ["labelIds"]));
       }
     });
 
@@ -399,6 +400,9 @@ export class TrainrunService {
     this.nodeService.transitionsUpdated();
     this.trainrunsUpdated();
     this.operation.emit(new TrainrunCreateOperation(newTrainrun));
+    this.operation.emit(
+      new TrainrunUpdateOperation(trainrun2split, ["nodes", "times", "numberOfStops"]),
+    );
   }
 
   combineTwoTrainruns(node: Node, port1: Port, port2: Port) {
@@ -511,6 +515,9 @@ export class TrainrunService {
 
     // update
     this.trainrunsUpdated();
+    this.operation.emit(
+      new TrainrunUpdateOperation(trainrun1, ["nodes", "times", "numberOfStops"]),
+    );
     this.nodeService.nodesUpdated();
     this.nodeService.connectionsUpdated();
     this.nodeService.transitionsUpdated();

--- a/src/app/services/data/trainrun.service.ts
+++ b/src/app/services/data/trainrun.service.ts
@@ -540,7 +540,7 @@ export class TrainrunService {
       this.nodeService.transitionsUpdated();
       this.trainrunsUpdated();
     }
-    this.operation.emit(new TrainrunCreateOperation(copiedtrainrun));
+    this.operation.emit(new TrainrunCreateOperation(copiedtrainrun, trainrunId));
     return copiedtrainrun;
   }
 

--- a/src/app/services/data/trainrun.service.ts
+++ b/src/app/services/data/trainrun.service.ts
@@ -29,7 +29,13 @@ import {FilterService} from "../ui/filter.service";
 import {Transition} from "../../models/transition.model";
 import {Port} from "../../models/port.model";
 import {Connection} from "../../models/connection.model";
-import {Operation, OperationType, TrainrunOperation} from "../../models/operation.model";
+import {
+  Operation,
+  OperationType,
+  TrainrunCreateOperation,
+  TrainrunDeleteOperation,
+  TrainrunUpdateOperation,
+} from "../../models/operation.model";
 import {TrainrunsectionHelper} from "../util/trainrunsection.helper";
 
 @Injectable({
@@ -158,7 +164,7 @@ export class TrainrunService {
     if (enforceUpdate) {
       this.trainrunsUpdated();
     }
-    this.operation.emit(new TrainrunOperation(OperationType.delete, trainrun));
+    this.operation.emit(new TrainrunDeleteOperation(trainrun));
   }
 
   getSelectedTrainrun(): Trainrun {
@@ -231,7 +237,7 @@ export class TrainrunService {
     this.propagateTrainrunInitialConsecutiveTimes(trainrun);
     this.nodeService.initPortOrdering();
     this.trainrunsUpdated();
-    this.operation.emit(new TrainrunOperation(OperationType.update, trainrun));
+    this.operation.emit(new TrainrunUpdateOperation(trainrun));
     return freqOffset;
   }
 
@@ -244,7 +250,7 @@ export class TrainrunService {
     this.nodeService.reorderPortsOnNodesForTrainrun(trainrun, false);
     this.nodeService.initPortOrdering();
     this.trainrunsUpdated();
-    this.operation.emit(new TrainrunOperation(OperationType.update, trainrun));
+    this.operation.emit(new TrainrunUpdateOperation(trainrun));
   }
 
   updateTrainrunTimeCategory(trainrun: Trainrun, timeCategory: TrainrunTimeCategory) {
@@ -257,7 +263,7 @@ export class TrainrunService {
     this.nodeService.reorderPortsOnNodesForTrainrun(trainrun, false);
     this.nodeService.initPortOrdering();
     this.trainrunsUpdated();
-    this.operation.emit(new TrainrunOperation(OperationType.update, trainrun));
+    this.operation.emit(new TrainrunUpdateOperation(trainrun));
   }
 
   updateTrainrunTitle(trainrun: Trainrun, title: string) {
@@ -265,14 +271,14 @@ export class TrainrunService {
     this.nodeService.reorderPortsOnNodesForTrainrun(trainrun, false);
     this.nodeService.initPortOrdering();
     this.trainrunsUpdated();
-    this.operation.emit(new TrainrunOperation(OperationType.update, trainrun));
+    this.operation.emit(new TrainrunUpdateOperation(trainrun));
   }
 
   updateDirection(trainrun: Trainrun, direction: Direction) {
     const trainrunSection = this.getTrainrunFromId(trainrun.getId());
     trainrunSection.setDirection(direction);
     this.trainrunsUpdated();
-    this.operation.emit(new TrainrunOperation(OperationType.update, trainrun));
+    this.operation.emit(new TrainrunUpdateOperation(trainrun));
   }
 
   getTrainruns(): Trainrun[] {
@@ -386,7 +392,7 @@ export class TrainrunService {
     newTrainrun.select();
     this.nodeService.transitionsUpdated();
     this.trainrunsUpdated();
-    this.operation.emit(new TrainrunOperation(OperationType.create, newTrainrun));
+    this.operation.emit(new TrainrunCreateOperation(newTrainrun));
   }
 
   combineTwoTrainruns(node: Node, port1: Port, port2: Port) {
@@ -534,7 +540,7 @@ export class TrainrunService {
       this.nodeService.transitionsUpdated();
       this.trainrunsUpdated();
     }
-    this.operation.emit(new TrainrunOperation(OperationType.create, copiedtrainrun));
+    this.operation.emit(new TrainrunCreateOperation(copiedtrainrun));
     return copiedtrainrun;
   }
 
@@ -554,7 +560,7 @@ export class TrainrunService {
     trainrun.setLabelIds(labelIds);
     this.trainrunsUpdated();
     if (uniqueLabels.length === labels.length) {
-      this.operation.emit(new TrainrunOperation(OperationType.update, trainrun));
+      this.operation.emit(new TrainrunUpdateOperation(trainrun));
     }
   }
 

--- a/src/app/services/data/trainrun.service.ts
+++ b/src/app/services/data/trainrun.service.ts
@@ -237,7 +237,7 @@ export class TrainrunService {
     this.propagateTrainrunInitialConsecutiveTimes(trainrun);
     this.nodeService.initPortOrdering();
     this.trainrunsUpdated();
-    this.operation.emit(new TrainrunUpdateOperation(trainrun));
+    this.operation.emit(new TrainrunUpdateOperation(trainrun, ["times", "frequencyId"]));
     return freqOffset;
   }
 
@@ -250,7 +250,7 @@ export class TrainrunService {
     this.nodeService.reorderPortsOnNodesForTrainrun(trainrun, false);
     this.nodeService.initPortOrdering();
     this.trainrunsUpdated();
-    this.operation.emit(new TrainrunUpdateOperation(trainrun));
+    this.operation.emit(new TrainrunUpdateOperation(trainrun, ["categoryId"]));
   }
 
   updateTrainrunTimeCategory(trainrun: Trainrun, timeCategory: TrainrunTimeCategory) {
@@ -263,7 +263,7 @@ export class TrainrunService {
     this.nodeService.reorderPortsOnNodesForTrainrun(trainrun, false);
     this.nodeService.initPortOrdering();
     this.trainrunsUpdated();
-    this.operation.emit(new TrainrunUpdateOperation(trainrun));
+    this.operation.emit(new TrainrunUpdateOperation(trainrun, ["timeCategoryId"]));
   }
 
   updateTrainrunTitle(trainrun: Trainrun, title: string) {
@@ -271,14 +271,16 @@ export class TrainrunService {
     this.nodeService.reorderPortsOnNodesForTrainrun(trainrun, false);
     this.nodeService.initPortOrdering();
     this.trainrunsUpdated();
-    this.operation.emit(new TrainrunUpdateOperation(trainrun));
+    this.operation.emit(new TrainrunUpdateOperation(trainrun, ["name"]));
   }
 
   updateDirection(trainrun: Trainrun, direction: Direction) {
     const trainrunSection = this.getTrainrunFromId(trainrun.getId());
     trainrunSection.setDirection(direction);
     this.trainrunsUpdated();
-    this.operation.emit(new TrainrunUpdateOperation(trainrun));
+    this.operation.emit(
+      new TrainrunUpdateOperation(trainrun, ["direction", "nodes", "times"]),
+    );
   }
 
   getTrainruns(): Trainrun[] {
@@ -560,7 +562,7 @@ export class TrainrunService {
     trainrun.setLabelIds(labelIds);
     this.trainrunsUpdated();
     if (uniqueLabels.length === labels.length) {
-      this.operation.emit(new TrainrunUpdateOperation(trainrun));
+      this.operation.emit(new TrainrunUpdateOperation(trainrun, ["labelIds"]));
     }
   }
 

--- a/src/app/services/data/trainrun.service.ts
+++ b/src/app/services/data/trainrun.service.ts
@@ -274,12 +274,16 @@ export class TrainrunService {
     this.operation.emit(new TrainrunUpdateOperation(trainrun, ["name"]));
   }
 
-  updateDirection(trainrun: Trainrun, direction: Direction) {
+  updateDirection(
+    trainrun: Trainrun,
+    direction: Direction,
+    oneWayDirection?: "forward" | "backward",
+  ) {
     const trainrunSection = this.getTrainrunFromId(trainrun.getId());
     trainrunSection.setDirection(direction);
     this.trainrunsUpdated();
     this.operation.emit(
-      new TrainrunUpdateOperation(trainrun, ["direction", "nodes", "times"]),
+      new TrainrunUpdateOperation(trainrun, ["direction", "nodes", "times"], oneWayDirection),
     );
   }
 

--- a/src/app/services/data/trainrunsection.service.ts
+++ b/src/app/services/data/trainrunsection.service.ts
@@ -20,7 +20,12 @@ import {Transition} from "../../models/transition.model";
 import {takeUntil} from "rxjs/operators";
 import {FilterService} from "../ui/filter.service";
 import {DirectedTrainrunSectionProxy} from "../util/trainrun.iterator";
-import {Operation, OperationType, TrainrunOperation} from "../../models/operation.model";
+import {
+  Operation,
+  OperationType,
+  TrainrunCreateOperation,
+  TrainrunUpdateOperation,
+} from "../../models/operation.model";
 
 interface DepartureAndArrivalTimes {
   nodeFromDepartureTime: number;
@@ -309,7 +314,7 @@ export class TrainrunSectionService implements OnDestroy {
     const trainrunSection = this.getTrainrunSectionFromId(trs.getId());
     trainrunSection.setNumberOfStops(numberOfStops);
     this.trainrunSectionsUpdated();
-    this.operation.emit(new TrainrunOperation(OperationType.update, trainrunSection.getTrainrun()));
+    this.operation.emit(new TrainrunUpdateOperation(trainrunSection.getTrainrun()));
   }
 
   updateTrainrunSectionTime(
@@ -583,13 +588,9 @@ export class TrainrunSectionService implements OnDestroy {
     this.trainrunService.trainrunsUpdated();
 
     if (initialTrainrunsLength !== this.trainrunService.trainrunsStore.trainruns.length) {
-      this.operation.emit(
-        new TrainrunOperation(OperationType.create, trainrunSection.getTrainrun()),
-      );
+      this.operation.emit(new TrainrunCreateOperation(trainrunSection.getTrainrun()));
     } else {
-      this.operation.emit(
-        new TrainrunOperation(OperationType.update, trainrunSection.getTrainrun()),
-      );
+      this.operation.emit(new TrainrunUpdateOperation(trainrunSection.getTrainrun()));
     }
 
     return trainrunSection;
@@ -667,7 +668,7 @@ export class TrainrunSectionService implements OnDestroy {
       this.nodeService.transitionsUpdated();
       this.trainrunSectionsUpdated();
     }
-    this.operation.emit(new TrainrunOperation(OperationType.update, trainrunSection.getTrainrun()));
+    this.operation.emit(new TrainrunUpdateOperation(trainrunSection.getTrainrun()));
   }
 
   deleteListOfTrainrunSections(trainrunSections: TrainrunSection[], enforceUpdate = true) {
@@ -739,9 +740,7 @@ export class TrainrunSectionService implements OnDestroy {
       this.trainrunSectionsUpdated();
     }
     if (this.getTrainrunSections().length) {
-      this.operation.emit(
-        new TrainrunOperation(OperationType.update, trainrunSection.getTrainrun()),
-      );
+      this.operation.emit(new TrainrunUpdateOperation(trainrunSection.getTrainrun()));
     }
   }
 
@@ -784,9 +783,7 @@ export class TrainrunSectionService implements OnDestroy {
     timeStructure: LeftAndRightTimeStructure,
   ) {
     this.updateTrainrunSectionLeftAndRightTimes(section, timeStructure);
-    this.operation.emit(
-      new TrainrunOperation(OperationType.update, section.trainrunSection.getTrainrun()),
-    );
+    this.operation.emit(new TrainrunUpdateOperation(section.trainrunSection.getTrainrun()));
   }
 
   setTimeStructureToTrainrunSections(
@@ -849,7 +846,7 @@ export class TrainrunSectionService implements OnDestroy {
 
     this.trainrunSectionsUpdated();
     this.nodeService.connectionsUpdated();
-    this.operation.emit(new TrainrunOperation(OperationType.update, trainrunSection.getTrainrun()));
+    this.operation.emit(new TrainrunUpdateOperation(trainrunSection.getTrainrun()));
   }
 
   trainrunSectionsUpdated() {

--- a/src/app/services/data/trainrunsection.service.ts
+++ b/src/app/services/data/trainrunsection.service.ts
@@ -995,6 +995,13 @@ export class TrainrunSectionService implements OnDestroy {
     this.nodeService.connectionsUpdated();
     this.nodeService.nodesUpdated();
     this.trainrunSectionsUpdated();
+    this.operation.emit(
+      new TrainrunUpdateOperation(trainrunSection1.getTrainrun(), [
+        "nodes",
+        "times",
+        "numberOfStops",
+      ]),
+    );
   }
 
   setWarningOnNode(

--- a/src/app/services/data/trainrunsection.service.ts
+++ b/src/app/services/data/trainrunsection.service.ts
@@ -314,7 +314,9 @@ export class TrainrunSectionService implements OnDestroy {
     const trainrunSection = this.getTrainrunSectionFromId(trs.getId());
     trainrunSection.setNumberOfStops(numberOfStops);
     this.trainrunSectionsUpdated();
-    this.operation.emit(new TrainrunUpdateOperation(trainrunSection.getTrainrun()));
+    this.operation.emit(
+      new TrainrunUpdateOperation(trainrunSection.getTrainrun(), ["numberOfStops"]),
+    );
   }
 
   updateTrainrunSectionTime(
@@ -590,7 +592,13 @@ export class TrainrunSectionService implements OnDestroy {
     if (initialTrainrunsLength !== this.trainrunService.trainrunsStore.trainruns.length) {
       this.operation.emit(new TrainrunCreateOperation(trainrunSection.getTrainrun()));
     } else {
-      this.operation.emit(new TrainrunUpdateOperation(trainrunSection.getTrainrun()));
+      this.operation.emit(
+        new TrainrunUpdateOperation(trainrunSection.getTrainrun(), [
+          "nodes",
+          "times",
+          "numberOfStops",
+        ]),
+      );
     }
 
     return trainrunSection;
@@ -668,7 +676,13 @@ export class TrainrunSectionService implements OnDestroy {
       this.nodeService.transitionsUpdated();
       this.trainrunSectionsUpdated();
     }
-    this.operation.emit(new TrainrunUpdateOperation(trainrunSection.getTrainrun()));
+    this.operation.emit(
+      new TrainrunUpdateOperation(trainrunSection.getTrainrun(), [
+        "nodes",
+        "numberOfStops",
+        "times",
+      ]),
+    );
   }
 
   deleteListOfTrainrunSections(trainrunSections: TrainrunSection[], enforceUpdate = true) {
@@ -740,7 +754,13 @@ export class TrainrunSectionService implements OnDestroy {
       this.trainrunSectionsUpdated();
     }
     if (this.getTrainrunSections().length) {
-      this.operation.emit(new TrainrunUpdateOperation(trainrunSection.getTrainrun()));
+      this.operation.emit(
+        new TrainrunUpdateOperation(trainrunSection.getTrainrun(), [
+          "nodes",
+          "numberOfStops",
+          "times",
+        ]),
+      );
     }
   }
 
@@ -783,7 +803,9 @@ export class TrainrunSectionService implements OnDestroy {
     timeStructure: LeftAndRightTimeStructure,
   ) {
     this.updateTrainrunSectionLeftAndRightTimes(section, timeStructure);
-    this.operation.emit(new TrainrunUpdateOperation(section.trainrunSection.getTrainrun()));
+    this.operation.emit(
+      new TrainrunUpdateOperation(section.trainrunSection.getTrainrun(), ["times"]),
+    );
   }
 
   setTimeStructureToTrainrunSections(
@@ -846,7 +868,7 @@ export class TrainrunSectionService implements OnDestroy {
 
     this.trainrunSectionsUpdated();
     this.nodeService.connectionsUpdated();
-    this.operation.emit(new TrainrunUpdateOperation(trainrunSection.getTrainrun()));
+    this.operation.emit(new TrainrunUpdateOperation(trainrunSection.getTrainrun(), ["times"]));
   }
 
   trainrunSectionsUpdated() {

--- a/src/app/services/data/trainrunsection.service.ts
+++ b/src/app/services/data/trainrunsection.service.ts
@@ -321,7 +321,9 @@ export class TrainrunSectionService implements OnDestroy {
     const trainrunSection = this.getTrainrunSectionFromId(trs.getId());
     trainrunSection.setNumberOfStops(numberOfStops);
     this.trainrunSectionsUpdated();
-    this.operation.emit(new TrainrunUpdateOperation(trainrunSection.getTrainrun()));
+    this.operation.emit(
+      new TrainrunUpdateOperation(trainrunSection.getTrainrun(), ["numberOfStops"]),
+    );
   }
 
   updateTrainrunSectionTime(
@@ -407,7 +409,7 @@ export class TrainrunSectionService implements OnDestroy {
 
     this.iterateAlongTrainrunUntilEndAndPropagateTime(fromNode, fromTrainrunSectionId);
     this.trainrunSectionsUpdated();
-    this.operation.emit(new TrainrunUpdateOperation(trainrunSection.getTrainrun()));
+    this.operation.emit(new TrainrunUpdateOperation(trainrunSection.getTrainrun(), ["times"]));
   }
 
   propagateTrainrunSectionTime(
@@ -641,7 +643,13 @@ export class TrainrunSectionService implements OnDestroy {
     if (initialTrainrunsLength !== this.trainrunService.trainrunsStore.trainruns.length) {
       this.operation.emit(new TrainrunCreateOperation(trainrunSection.getTrainrun()));
     } else {
-      this.operation.emit(new TrainrunUpdateOperation(trainrunSection.getTrainrun()));
+      this.operation.emit(
+        new TrainrunUpdateOperation(trainrunSection.getTrainrun(), [
+          "nodes",
+          "times",
+          "numberOfStops",
+        ]),
+      );
     }
 
     return trainrunSection;
@@ -720,7 +728,13 @@ export class TrainrunSectionService implements OnDestroy {
       this.nodeService.transitionsUpdated();
       this.trainrunSectionsUpdated();
     }
-    this.operation.emit(new TrainrunUpdateOperation(trainrunSection.getTrainrun()));
+    this.operation.emit(
+      new TrainrunUpdateOperation(trainrunSection.getTrainrun(), [
+        "nodes",
+        "numberOfStops",
+        "times",
+      ]),
+    );
   }
 
   deleteListOfTrainrunSections(trainrunSections: TrainrunSection[], enforceUpdate = true) {
@@ -793,7 +807,13 @@ export class TrainrunSectionService implements OnDestroy {
       this.trainrunSectionsUpdated();
     }
     if (this.getTrainrunSections().length) {
-      this.operation.emit(new TrainrunUpdateOperation(trainrunSection.getTrainrun()));
+      this.operation.emit(
+        new TrainrunUpdateOperation(trainrunSection.getTrainrun(), [
+          "nodes",
+          "numberOfStops",
+          "times",
+        ]),
+      );
     }
   }
 
@@ -837,7 +857,9 @@ export class TrainrunSectionService implements OnDestroy {
     timeStructure: LeftAndRightTimeStructure,
   ) {
     this.updateTrainrunSectionLeftAndRightTimes(section, timeStructure);
-    this.operation.emit(new TrainrunUpdateOperation(section.trainrunSection.getTrainrun()));
+    this.operation.emit(
+      new TrainrunUpdateOperation(section.trainrunSection.getTrainrun(), ["times"]),
+    );
   }
 
   setTimeStructureToTrainrunSections(
@@ -903,7 +925,7 @@ export class TrainrunSectionService implements OnDestroy {
 
     this.trainrunSectionsUpdated();
     this.nodeService.connectionsUpdated();
-    this.operation.emit(new TrainrunUpdateOperation(trainrunSection.getTrainrun()));
+    this.operation.emit(new TrainrunUpdateOperation(trainrunSection.getTrainrun(), ["times"]));
   }
 
   private setTimeStructureInDirection({

--- a/src/app/services/data/trainrunsection.service.ts
+++ b/src/app/services/data/trainrunsection.service.ts
@@ -1103,6 +1103,13 @@ export class TrainrunSectionService implements OnDestroy {
     this.nodeService.connectionsUpdated();
     this.nodeService.nodesUpdated();
     this.trainrunSectionsUpdated();
+    this.operation.emit(
+      new TrainrunUpdateOperation(trainrunSection1.getTrainrun(), [
+        "nodes",
+        "times",
+        "numberOfStops",
+      ]),
+    );
   }
 
   setWarningOnNode(

--- a/src/app/services/data/trainrunsection.service.ts
+++ b/src/app/services/data/trainrunsection.service.ts
@@ -19,8 +19,13 @@ import {Transition} from "../../models/transition.model";
 import {takeUntil} from "rxjs/operators";
 import {FilterService} from "../ui/filter.service";
 import {DirectedTrainrunSectionProxy, TrainrunIterator} from "../util/trainrun.iterator";
-import {Operation, OperationType, TrainrunOperation} from "../../models/operation.model";
-
+import {
+  Operation,
+  OperationType,
+  TrainrunCreateOperation,
+  TrainrunDeleteOperation,
+  TrainrunUpdateOperation,
+} from "../../models/operation.model";
 interface DepartureAndArrivalTimes {
   nodeFromDepartureTime: number;
   nodeFromArrivalTime: number;
@@ -316,7 +321,7 @@ export class TrainrunSectionService implements OnDestroy {
     const trainrunSection = this.getTrainrunSectionFromId(trs.getId());
     trainrunSection.setNumberOfStops(numberOfStops);
     this.trainrunSectionsUpdated();
-    this.operation.emit(new TrainrunOperation(OperationType.update, trainrunSection.getTrainrun()));
+    this.operation.emit(new TrainrunUpdateOperation(trainrunSection.getTrainrun()));
   }
 
   updateTrainrunSectionTime(
@@ -402,7 +407,7 @@ export class TrainrunSectionService implements OnDestroy {
 
     this.iterateAlongTrainrunUntilEndAndPropagateTime(fromNode, fromTrainrunSectionId);
     this.trainrunSectionsUpdated();
-    this.operation.emit(new TrainrunOperation(OperationType.update, trainrunSection.getTrainrun()));
+    this.operation.emit(new TrainrunUpdateOperation(trainrunSection.getTrainrun()));
   }
 
   propagateTrainrunSectionTime(
@@ -634,13 +639,9 @@ export class TrainrunSectionService implements OnDestroy {
     this.trainrunService.trainrunsUpdated();
 
     if (initialTrainrunsLength !== this.trainrunService.trainrunsStore.trainruns.length) {
-      this.operation.emit(
-        new TrainrunOperation(OperationType.create, trainrunSection.getTrainrun()),
-      );
+      this.operation.emit(new TrainrunCreateOperation(trainrunSection.getTrainrun()));
     } else {
-      this.operation.emit(
-        new TrainrunOperation(OperationType.update, trainrunSection.getTrainrun()),
-      );
+      this.operation.emit(new TrainrunUpdateOperation(trainrunSection.getTrainrun()));
     }
 
     return trainrunSection;
@@ -719,7 +720,7 @@ export class TrainrunSectionService implements OnDestroy {
       this.nodeService.transitionsUpdated();
       this.trainrunSectionsUpdated();
     }
-    this.operation.emit(new TrainrunOperation(OperationType.update, trainrunSection.getTrainrun()));
+    this.operation.emit(new TrainrunUpdateOperation(trainrunSection.getTrainrun()));
   }
 
   deleteListOfTrainrunSections(trainrunSections: TrainrunSection[], enforceUpdate = true) {
@@ -792,9 +793,7 @@ export class TrainrunSectionService implements OnDestroy {
       this.trainrunSectionsUpdated();
     }
     if (this.getTrainrunSections().length) {
-      this.operation.emit(
-        new TrainrunOperation(OperationType.update, trainrunSection.getTrainrun()),
-      );
+      this.operation.emit(new TrainrunUpdateOperation(trainrunSection.getTrainrun()));
     }
   }
 
@@ -838,9 +837,7 @@ export class TrainrunSectionService implements OnDestroy {
     timeStructure: LeftAndRightTimeStructure,
   ) {
     this.updateTrainrunSectionLeftAndRightTimes(section, timeStructure);
-    this.operation.emit(
-      new TrainrunOperation(OperationType.update, section.trainrunSection.getTrainrun()),
-    );
+    this.operation.emit(new TrainrunUpdateOperation(section.trainrunSection.getTrainrun()));
   }
 
   setTimeStructureToTrainrunSections(
@@ -906,7 +903,7 @@ export class TrainrunSectionService implements OnDestroy {
 
     this.trainrunSectionsUpdated();
     this.nodeService.connectionsUpdated();
-    this.operation.emit(new TrainrunOperation(OperationType.update, trainrunSection.getTrainrun()));
+    this.operation.emit(new TrainrunUpdateOperation(trainrunSection.getTrainrun()));
   }
 
   private setTimeStructureInDirection({

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrunsection-card/trainrun-section-card.component.ts
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrunsection-card/trainrun-section-card.component.ts
@@ -161,13 +161,15 @@ export class TrainrunSectionCardComponent implements OnInit, AfterViewInit, OnDe
     }
 
     const referenceNode = position === "top" ? this.leftNode : this.rightNode;
+    let isTrainInverted = false;
     if (referenceNode !== trainrunSection.getSourceNode()) {
+      isTrainInverted = true;
       this.trainrunSectionService.invertTrainrunSectionsSourceAndTarget(
         trainrunSection.getTrainrunId(),
       );
     }
     this.chosenCard = position;
-    this.trainrunService.updateDirection(selectedTrainrun, Direction.ONE_WAY);
+    this.trainrunService.updateDirection(selectedTrainrun, Direction.ONE_WAY, isTrainInverted);
   }
 
   getTrainrunTimeStructure(): Omit<LeftAndRightTimeStructure, "travelTime"> {

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrunsection-card/trainrun-section-card.component.ts
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrunsection-card/trainrun-section-card.component.ts
@@ -195,9 +195,11 @@ export class TrainrunSectionCardComponent implements OnInit, AfterViewInit, OnDe
       trainrunSection = this.trainrunService.getLeftOrTopExtremitySection();
     }
 
+    let oneWayDirection: "forward" | "backward" = "forward";
     if (this.leftNode === this.rightNode) {
       // Cyclic trainrun
       // This ensures the two cards represent different directions
+      oneWayDirection = "backward";
       this.trainrunSectionService.invertTrainrunSectionsSourceAndTarget(
         trainrunSection.getTrainrunId(),
       );
@@ -205,6 +207,7 @@ export class TrainrunSectionCardComponent implements OnInit, AfterViewInit, OnDe
       // Non-cyclic trainrun
       const referenceNode = position === "top" ? this.leftNode : this.rightNode;
       if (referenceNode !== trainrunSection.getSourceNode()) {
+        oneWayDirection = "backward";
         this.trainrunSectionService.invertTrainrunSectionsSourceAndTarget(
           trainrunSection.getTrainrunId(),
         );
@@ -212,7 +215,7 @@ export class TrainrunSectionCardComponent implements OnInit, AfterViewInit, OnDe
     }
 
     this.chosenCard = position;
-    this.trainrunService.updateDirection(selectedTrainrun, Direction.ONE_WAY);
+    this.trainrunService.updateDirection(selectedTrainrun, Direction.ONE_WAY, oneWayDirection);
   }
 
   getTrainrunTimeStructure(): Omit<LeftAndRightTimeStructure, "travelTime" | "bottomTravelTime"> {


### PR DESCRIPTION
Close https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/issues/792

I don't completely understand numberOfStops, so it's possible I have not used the tag properly.

I have not tested the pr in osrd yet. In particular I'm quite unsure about the way to detect forward/backward direction.

The last commit add a few events that seemed missing. There's a couple that are not useful for osrd (as we deactivated the features), but should probably be emitted for other potential users that may want to use the event system too. There are a few that correspond to niche features enabled in osrd, and for which the osrd behavior is currently bugged. Finally I have not added any to visibleTrainrunsSetLabel, as the behavior already seems propagated somehow?