### PR TITLE
chore(ci): enable release-please-action on release branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - v[0-9]+.[0-9]+
 
 permissions:
   contents: write
@@ -25,6 +26,8 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v5
         id: release
+        with:
+          target-branch: ${{ github.ref_name }}
 
   release:
     needs: release-please

--- a/CI.md
+++ b/CI.md
@@ -16,3 +16,24 @@ See [release-please CLI documentation](https://github.com/googleapis/release-ple
 ### FAQ
 
 - [How do I change the version number?](https://github.com/googleapis/release-please?tab=readme-ov-file#how-do-i-change-the-version-number)
+
+### Release branches
+
+After a release is published and some `feat` commits have been merged to `main`, release-please will update its pull request to a new major or minor version. However, to ship bug fixes to users in a timely manner, it may be desirable to cut a new patch release with a subset of the merged commits (e.g. only `fix` commits). For instance, after v2.11.0 has been published, release-please may open a pull request for v2.12.0 with all unreleased commits sitting in `main`, while maintainers may wish to release v2.11.1 with a handful of bug fixes.
+
+In this situation, a release branch needs to be created. The release branch needs to be based on the last release's Git tag and be named `vX.Y` (a `v` prefix, followed by major and minor numbers separated by a dot). Then bug fix commits can be cherry-picked from `main` and submitted via a pull request targeting the release branch. Once that's done, release-please will create a new pull request to publish a new patch release.
+
+Here is an example for an hypothetical v2.11.1 patch release:
+
+```sh
+# Create the v2.11 branch based off of the v2.11.0 tag
+git switch -c v2.11 netzgrafik-editor-frontend-v2.11.0
+git push
+
+# Backport some commits to the release branch: create a new branch based off of
+# v2.11, copy over two bug fixes (-x records the original commit hash), then
+# push and open a pull request (select "v2.11" in the "base" field)
+git switch -c adrian/v2.11-backports v2.11
+git cherry-pick -x 0b61263dcb8e 161e03596824
+git push
+```


### PR DESCRIPTION
This lets maintainers create branches named e.g. "v2.11" and backport bugfixes to these branches via `git cherry-pick -x`. The GitHub action will then open a pull request to release a new bugfix version.

See this README section about release branches:
https://github.com/googleapis/release-please-action#supporting-multiple-release-branches

See this GitHub docs section about glob patterns:
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#filter-pattern-cheat-sheet