### PR TITLE
fix(view): preserve tab spacing in notes

### DIFF
--- a/src/app/view/editor-main-view/data-views/notes.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/notes.view.spec.ts
@@ -186,4 +186,9 @@ describe("Notes-View", () => {
     const txt0 = NotesView.convertText("qwertz");
     expect(txt0).toBe("qwertz");
   });
+
+  it("NotesView.convertText preserves tab spacing", () => {
+    const txt0 = NotesView.convertText("left\tright");
+    expect(txt0).toBe("left&nbsp;&nbsp;&nbsp;&nbsp;right");
+  });
 });

--- a/src/app/view/editor-main-view/data-views/notes.view.ts
+++ b/src/app/view/editor-main-view/data-views/notes.view.ts
@@ -33,6 +33,7 @@ export class NotesView {
 
   static convertText(strToConvert: string): string {
     return strToConvert
+      .replace(/\t/g, "&nbsp;&nbsp;&nbsp;&nbsp;")
       .trim()
       .split("::marker")
       .join("")


### PR DESCRIPTION
## Summary
- Preserve pasted tab characters in note text by converting them to non-breaking spaces before SVG rendering.
- Add regression coverage for tab spacing in `NotesView.convertText`.

Fixes #693

## Test plan
- `npx prettier --write src/app/view/editor-main-view/data-views/notes.view.ts src/app/view/editor-main-view/data-views/notes.view.spec.ts`
- `npx eslint src/app/view/editor-main-view/data-views/notes.view.ts src/app/view/editor-main-view/data-views/notes.view.spec.ts`
- `git diff --check`
- `npm run build:standalone`

Note: `ng test --include src/app/view/editor-main-view/data-views/notes.view.spec.ts --watch=false --browsers=ChromeHeadless` did not complete in this local environment and was stopped; build and targeted lint pass.