### PR TITLE
fix(dialog): avoid trainrun close handle overflow

### DIFF
--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component.html
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component.html
@@ -56,6 +56,7 @@
   </div>
 
   <div
+    *ngIf="!isDialogClosing"
     class="dialog-drag-and-close-handle-area"
     (mouseup)="onMouseUp($event)"
     (mousemove)="onMouseMove($event)"

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component.scss
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component.scss
@@ -98,6 +98,7 @@
   width: 20px;
   height: 326px;
   border: 16px solid var(--sbb-header-lean-background-color);
+  box-sizing: border-box;
   cursor: move;
 
   .dialog-drag-handle-icon {

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component.ts
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component.ts
@@ -63,6 +63,7 @@ export class TrainrunAndSectionDialogComponent implements OnDestroy {
   public nextStopRightNodeName: string;
 
   public data = null;
+  public isDialogClosing = false;
 
   private dialogRef = null;
   private dialogConfig = null;
@@ -155,6 +156,7 @@ export class TrainrunAndSectionDialogComponent implements OnDestroy {
 
   openDialog(parameter: TrainrunDialogParameter) {
     this.trainrunDialogParameter = parameter;
+    this.isDialogClosing = false;
     this.dialogConfig = TrainrunAndSectionDialogComponent.getDialogConfig(
       parameter,
       this.dataService.getTrainrunFrequencies(),
@@ -163,6 +165,12 @@ export class TrainrunAndSectionDialogComponent implements OnDestroy {
       this.trainrunAndSectionEditorTabsViewTemplate,
       this.dialogConfig,
     );
+    this.dialogRef
+      .beforeClosed()
+      .pipe(takeUntil(this.destroyed))
+      .subscribe(() => {
+        this.isDialogClosing = true;
+      });
     this.dialogPos = {
       bottom: parseInt(this.dialogConfig.position.top, 10) + parseInt(this.dialogConfig.height, 10),
       left: parseInt(this.dialogConfig.position.left, 10),


### PR DESCRIPTION
## Summary
- Add border-box sizing to the trainrun dialog drag/close handle.
- Keeps the handle inside its declared dimensions to avoid the Firefox close artifact described in #739.

## Validation
- npx prettier --check src/app/view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component.scss
- git diff --check
- npm run build:standalone

Closes #739