### PR TITLE
feat: improves port ordering

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -137,7 +137,8 @@
             "karmaConfig": "karma.conf.cjs",
             "assets": ["src/assets"],
             "styles": ["src/styles.scss", "node_modules/@sbb-esta/angular/typography.css"],
-            "scripts": []
+            "scripts": [],
+            "exclude": ["src/benchmarks/**"]
           },
           "configurations": {
             "ci": {
@@ -147,6 +148,14 @@
               "progress": false,
               "watch": false,
               "reporters": ["dots", "sonarqube"]
+            },
+            "benchmark": {
+              "browsers": "ChromeHeadless",
+              "codeCoverage": false,
+              "watch": false,
+              "karmaConfig": "karma.benchmark.cjs",
+              "include": ["src/benchmarks/**/*.spec.ts"],
+              "exclude": []
             }
           }
         },

--- a/documentation/technical/CROSSING_AWARE_ORDERING.md
+++ b/documentation/technical/CROSSING_AWARE_ORDERING.md
@@ -8,15 +8,25 @@ available ordering modes, see the [Ports sorting](DATA_MODEL.md#ports-sorting) s
 The algorithm is a greedy iterative optimizer. It first focuses on minimizing the crossings within each node, and then
 looks for alternative solutions that reduce the global amount of crossings between the nodes.
 
+Beyond crossings, it can also reduce **separations** (parallel bundles pulled apart by something wedged between them).
+Crossings and separations are combined into a single weighted score (called _clutter_ in the code), tuned via
+`ClutterWeights`, so callers can trade fewer crossings for tighter bundles. The editor exposes two weight presets as
+distinct modes: **Crossing aware** penalizes within-node separations, while **Crossing aware (push crossings into
+nodes)** penalizes between-node separations, so crossings get resolved inside the nodes and parallel trainruns stay
+bundled along the sections.
+
 It is a lightweight heuristic, not a full layout optimizer. It only reorders ports on fixed nodes with fixed positions,
 and runs fast enough to be applied on every layout update. For a more comprehensive approach to transit map layout
 (edge routing, station placement, global crossing minimization), see [LOOM](https://loom.cs.uni-freiburg.de/#stuttgart).
 
 The algorithm works in three phases:
 
-### 1. Connected components
+### 1. Side-level components
 
-The network is split into independent connected components (via DFS). Each component is optimized separately.
+The network is split into independent **node-side components** via `getComponents`. This is finer than connected
+components: a node shared by two otherwise-independent corridors (a junction crossed by two reticulars, for instance)
+has each of its sides assigned to its own component, so reordering one side never disturbs the other. Each component is
+optimized separately, on a scoped node view (`getScopedNode`) exposing only its own ports and transitions.
 
 ### 2. Port reordering
 
@@ -39,19 +49,25 @@ tie-breaker injected by the iterative optimizer (see below).
 ### 3. Iterative optimization
 
 The port reordering step (phase 2) is deterministic for a given trainrun ordering. The optimizer explores different
-trainrun orderings to find one that produces fewer crossings between the nodes. It runs multiple iterations (up to
-`maxRuns`, default 50):
+trainrun orderings to find one that produces less clutter (fewer crossings and separations). It runs multiple
+iterations (up to `maxRuns`, default 500):
 
 1. Start with initial trainrun ordering (from node transitions)
 2. Reorder all ports using the current trainrun ordering as tie-breaker
-3. Count resulting crossings
-4. If crossings improved, identify largest crossing groups (contiguous sets of trainruns that cross each other), and
-   generate new candidate orderings by permuting those groups
+3. Count the resulting clutter (weighted crossings + separations)
+4. If it improved, generate new candidate orderings via `getCandidates`
 5. Pick the next candidate from the stack and repeat
-6. Return the configuration with the fewest crossings
+6. Return the configuration with the least clutter
 
-This is a heuristic. It uses DFS (stack-based candidate selection) and caps the number of new candidates per step
-(`maxNewCandidates`, default 10). It does not guarantee a global optimum.
+A candidate is a trainrun ordering, plus a "between-first" node set: the nodes where the between-node discriminators
+(criteria 3, 4a) are consulted before the within-node ones (criteria 1, 2), flipping the default priority.
+
+**Candidate generation.** Clutter is treated as bundles of trainruns whose shared order is broken across several sites
+along a corridor. `getClutterBundles` locates those bundles and their broken sites, `getBundleReferenceOrder` proposes
+a repair order, and `getCandidates` emits coordinated reorderings that repair every site of a bundle at once. This lets
+the greedy search jump straight to a good order instead of going through intermediate steps it would reject.
+
+This is a heuristic. It uses DFS (stack-based candidate selection), and does not guarantee a global optimum.
 
 ## Crossing detection
 
@@ -64,6 +80,13 @@ Three types of crossings are detected:
 Crossings between trainrun sections that do not share any node are not detected. For instance, a section going from top
 to bottom that visually crosses another one going from left to right will not be counted. Solving these crossings would
 require changing edge paths or node positions, which is outside the scope of port ordering.
+
+## Separation detection
+
+A **separation** is two sections with the same origin and target nodes and alignments that sit adjacent on one side of
+a node but not on the other. `port-ordering.separations.ts` exposes both the offending trainrun-ID pairs
+(`getSeparationPairsWithinNode` / `getSeparationPairsBetweenNodes`) and the counts (`countAllSeparations`), each split
+into within-node and between-node parts. Reducing separations keeps parallel lines bundled together.
 
 ## Strengths and limitations
 
@@ -79,7 +102,13 @@ require changing edge paths or node positions, which is outside the scope of por
   `reorderNodePorts`)
 - [port-ordering.crossings.ts](../../src/app/services/util/port-ordering.crossings.ts) - Crossing detection and
   counting
-- [port-ordering.components.ts](../../src/app/services/util/port-ordering.components.ts) - Connected components
-  extraction
+- [port-ordering.separations.ts](../../src/app/services/util/port-ordering.separations.ts) - Separation detection and
+  counting
+- [port-ordering.bundles.ts](../../src/app/services/util/port-ordering.bundles.ts) - Clutter bundle detection
+  (`getClutterBundles`, `getBundleReferenceOrder`)
+- [port-ordering.candidates.ts](../../src/app/services/util/port-ordering.candidates.ts) - Candidate ordering generation
+  (`getCandidates`)
+- [port-ordering.components.ts](../../src/app/services/util/port-ordering.components.ts) - Side-level component
+  splitting
 - [port-ordering.helpers.ts](../../src/app/services/util/port-ordering.helpers.ts) - Geometry helpers (elbow detection,
   alignment)

--- a/documentation/technical/DATA_MODEL.md
+++ b/documentation/technical/DATA_MODEL.md
@@ -159,7 +159,7 @@ details [VisAVisPortPlacement.placePortsOnSourceAndTargetNode(srcNode, targetNod
 
 ##### Ports sorting
 
-Ports on each side of a node are sorted to control how edges are visually ordered. Two modes are available,
+Ports on each side of a node are sorted to control how edges are visually ordered. Three modes are available,
 selectable via radio buttons in the editor tools panel:
 
 - **Alphabetical** (default): Ports are sorted by train category name. See
@@ -167,6 +167,8 @@ selectable via radio buttons in the editor tools panel:
   [CREATE_NODES chapter](../CREATE_NODES.md#MultipleTrainruns) for details.
 - **Crossing aware**: Ports are reordered to minimize edge crossings using global propagation. See
   [CROSSING_AWARE_ORDERING.md](CROSSING_AWARE_ORDERING.md) for a full description of the algorithm.
+- **Crossing aware (push crossings into nodes)**: Same algorithm, weighted to resolve crossings inside the
+  nodes rather than between them, keeping parallel trainruns bundled along the sections.
 
 ##### Pre-computed paths
 

--- a/karma.benchmark.cjs
+++ b/karma.benchmark.cjs
@@ -1,0 +1,12 @@
+const base = require("./karma.conf.cjs");
+
+module.exports = function (config) {
+  base(config);
+  config.set({
+    reporters: ["progress"],
+    browserNoActivityTimeout: 600000,
+    browserDisconnectTimeout: 600000,
+    browserDisconnectTolerance: 3,
+    pingTimeout: 600000,
+  });
+};

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "lint:fix": "ng lint --fix",
     "generate:api": "openapi-generator-cli generate",
     "local-test": "ng test --watch --code-coverage",
-    "extract-i18n": "ng extract-i18n"
+    "extract-i18n": "ng extract-i18n",
+    "benchmark": "ng test -c benchmark"
   },
   "name": "@openrail/netzgrafik-editor-frontend",
   "version": "2.11.1",

--- a/src/app/data-structures/technical.data.structures.ts
+++ b/src/app/data-structures/technical.data.structures.ts
@@ -69,7 +69,8 @@ export enum PortAlignment {
  */
 export enum OrderingAlgorithm {
   Alphabetical, // Order by train category name (default)
-  CrossingAware, // Minimize crossings using global propagation
+  ClutterAware, // Minimize visual clutter, keeping parallel trainruns bundled within nodes
+  ClutterAwarePushCrossings, // Minimize visual clutter, pushing crossings into the nodes
 }
 
 /**

--- a/src/app/services/data/data.service.ts
+++ b/src/app/services/data/data.service.ts
@@ -1,5 +1,6 @@
 import {Injectable, OnDestroy} from "@angular/core";
 import {
+  MetadataDto,
   NetzgrafikDto,
   TrainrunCategory,
   Direction,
@@ -96,10 +97,9 @@ export class DataService implements OnDestroy {
     this.netzgrafikColoringService.setNetzgrafikColors(
       this.netzgrafikDtoStore.netzgrafikDto.metadata.netzgrafikColors,
     );
-    if (this.netzgrafikDtoStore.netzgrafikDto.metadata.orderingAlgorithm !== undefined) {
-      this.nodeService.setOrderingAlgorithm(
-        this.netzgrafikDtoStore.netzgrafikDto.metadata.orderingAlgorithm,
-      );
+    const metadata = this.netzgrafikDtoStore.netzgrafikDto.metadata;
+    if (metadata.orderingAlgorithm !== undefined) {
+      this.nodeService.setOrderingAlgorithm(metadata.orderingAlgorithm);
     }
 
     this.initializeDataServices();
@@ -187,10 +187,17 @@ export class DataService implements OnDestroy {
   }
 
   getNetzgrafikDto(): NetzgrafikDto {
-    const metadata = this.netzgrafikDtoStore.netzgrafikDto.metadata;
-    metadata.netzgrafikColors = this.netzgrafikColoringService.getDtos();
-    metadata.orderingAlgorithm = this.nodeService.getCurrentOrderingAlgorithm();
-    metadata.trafficSide = this.getTrafficSide();
+    const previous = this.netzgrafikDtoStore.netzgrafikDto.metadata;
+    const metadata: MetadataDto = {
+      trainrunCategories: previous.trainrunCategories,
+      trainrunFrequencies: previous.trainrunFrequencies,
+      trainrunTimeCategories: previous.trainrunTimeCategories,
+      analyticsSettings: previous.analyticsSettings,
+      netzgrafikColors: this.netzgrafikColoringService.getDtos(),
+      orderingAlgorithm: this.nodeService.getCurrentOrderingAlgorithm(),
+      trafficSide: this.getTrafficSide(),
+    };
+    this.netzgrafikDtoStore.netzgrafikDto.metadata = metadata;
 
     return {
       nodes: this.nodeService.getDtos(),

--- a/src/app/services/data/data.service.ts
+++ b/src/app/services/data/data.service.ts
@@ -1,5 +1,6 @@
 import {Injectable, OnDestroy} from "@angular/core";
 import {
+  MetadataDto,
   NetzgrafikDto,
   TrainrunCategory,
   Direction,
@@ -98,10 +99,9 @@ export class DataService implements OnDestroy {
     this.netzgrafikColoringService.setNetzgrafikColors(
       this.netzgrafikDtoStore.netzgrafikDto.metadata.netzgrafikColors,
     );
-    if (this.netzgrafikDtoStore.netzgrafikDto.metadata.orderingAlgorithm !== undefined) {
-      this.nodeService.setOrderingAlgorithm(
-        this.netzgrafikDtoStore.netzgrafikDto.metadata.orderingAlgorithm,
-      );
+    const metadata = this.netzgrafikDtoStore.netzgrafikDto.metadata;
+    if (metadata.orderingAlgorithm !== undefined) {
+      this.nodeService.setOrderingAlgorithm(metadata.orderingAlgorithm);
     }
 
     this.initializeDataServices();
@@ -189,11 +189,17 @@ export class DataService implements OnDestroy {
   }
 
   getNetzgrafikDto(): NetzgrafikDto {
-    const metadata = this.netzgrafikDtoStore.netzgrafikDto.metadata;
-    metadata.netzgrafikColors = this.netzgrafikColoringService.getDtos();
-    metadata.analyticsSettings = this.getAnalyticsSettings();
-    metadata.orderingAlgorithm = this.nodeService.getCurrentOrderingAlgorithm();
-    metadata.trafficSide = this.getTrafficSide();
+    const previous = this.netzgrafikDtoStore.netzgrafikDto.metadata;
+    const metadata: MetadataDto = {
+      trainrunCategories: previous.trainrunCategories,
+      trainrunFrequencies: previous.trainrunFrequencies,
+      trainrunTimeCategories: previous.trainrunTimeCategories,
+      analyticsSettings: this.getAnalyticsSettings(),
+      netzgrafikColors: this.netzgrafikColoringService.getDtos(),
+      orderingAlgorithm: this.nodeService.getCurrentOrderingAlgorithm(),
+      trafficSide: this.getTrafficSide(),
+    };
+    this.netzgrafikDtoStore.netzgrafikDto.metadata = metadata;
 
     return {
       nodes: this.nodeService.getDtos(),

--- a/src/app/services/data/node.service.ts
+++ b/src/app/services/data/node.service.ts
@@ -30,7 +30,7 @@ import {MathUtils} from "../../utils/math";
 import {LabelService} from "./label.service";
 import {FilterService} from "../ui/filter.service";
 import {ConnectionDto, OrderingAlgorithm} from "../../data-structures/technical.data.structures";
-import {optimizePorts} from "../util/port-ordering.algo";
+import {ClutterWeights, optimizePorts} from "../util/port-ordering.algo";
 import {TrainrunSectionValidator} from "../util/trainrunsection.validator";
 import {
   NodeOperation,
@@ -199,8 +199,8 @@ export class NodeService implements OnDestroy {
     });
 
     // Second pass: reorder ports and update routing
-    if (this.currentOrderingAlgorithm === OrderingAlgorithm.CrossingAware) {
-      optimizePorts(this.nodesStore.nodes);
+    if (this.usesOptimizePorts()) {
+      optimizePorts(this.nodesStore.nodes, this.getClutterWeights());
       this.nodesStore.nodes.forEach((node) => {
         node.updateTransitionsRouting();
         node.updateConnectionsRouting();
@@ -1140,8 +1140,30 @@ export class NodeService implements OnDestroy {
     return this.currentOrderingAlgorithm;
   }
 
+  private usesOptimizePorts(): boolean {
+    return this.currentOrderingAlgorithm !== OrderingAlgorithm.Alphabetical;
+  }
+
+  private getClutterWeights(): Partial<ClutterWeights> | undefined {
+    if (!this.usesOptimizePorts()) return undefined;
+
+    const minWeight = 0.2;
+    const pushCrossings =
+      this.currentOrderingAlgorithm === OrderingAlgorithm.ClutterAwarePushCrossings;
+
+    // Boost the separations we keep low: between nodes when pushing crossings in, else within nodes.
+    return {
+      crossingsWithin: minWeight,
+      crossingsBetween: minWeight,
+      separationsWithin: minWeight + (pushCrossings ? 0 : 1),
+      separationsBetween: minWeight + (pushCrossings ? 1 : 0),
+    };
+  }
+
   setOrderingAlgorithm(portOrderingType: OrderingAlgorithm) {
-    this.currentOrderingAlgorithm = portOrderingType;
+    // Any unknown legacy value (the former crossing/separation modes) maps to ClutterAware.
+    this.currentOrderingAlgorithm =
+      portOrderingType in OrderingAlgorithm ? portOrderingType : OrderingAlgorithm.ClutterAware;
   }
 
   getNodes(): Node[] {
@@ -1225,8 +1247,8 @@ export class NodeService implements OnDestroy {
       });
 
       // Reorder ports and update routing
-      if (this.currentOrderingAlgorithm === OrderingAlgorithm.CrossingAware) {
-        optimizePorts(this.nodesStore.nodes);
+      if (this.usesOptimizePorts()) {
+        optimizePorts(this.nodesStore.nodes, this.getClutterWeights());
         this.nodesStore.nodes.forEach((n) => {
           n.updateTransitionsRouting();
           n.updateConnectionsRouting();

--- a/src/app/services/data/node.service.ts
+++ b/src/app/services/data/node.service.ts
@@ -30,7 +30,7 @@ import {MathUtils} from "../../utils/math";
 import {LabelService} from "./label.service";
 import {FilterService} from "../ui/filter.service";
 import {ConnectionDto, OrderingAlgorithm} from "../../data-structures/technical.data.structures";
-import {optimizePorts} from "../util/port-ordering.algo";
+import {ClutterWeights, optimizePorts} from "../util/port-ordering.algo";
 import {TrainrunSectionValidator} from "../util/trainrunsection.validator";
 import {
   NodeOperation,
@@ -199,8 +199,8 @@ export class NodeService implements OnDestroy {
     });
 
     // Second pass: reorder ports and update routing
-    if (this.currentOrderingAlgorithm === OrderingAlgorithm.CrossingAware) {
-      optimizePorts(this.nodesStore.nodes);
+    if (this.usesOptimizePorts()) {
+      optimizePorts(this.nodesStore.nodes, this.getClutterWeights());
       this.nodesStore.nodes.forEach((node) => {
         node.updateTransitionsRouting();
         node.updateConnectionsRouting();
@@ -1128,8 +1128,30 @@ export class NodeService implements OnDestroy {
     return this.currentOrderingAlgorithm;
   }
 
+  private usesOptimizePorts(): boolean {
+    return this.currentOrderingAlgorithm !== OrderingAlgorithm.Alphabetical;
+  }
+
+  private getClutterWeights(): ClutterWeights | undefined {
+    if (!this.usesOptimizePorts()) return undefined;
+
+    const minWeight = 0.2;
+    const pushCrossings =
+      this.currentOrderingAlgorithm === OrderingAlgorithm.ClutterAwarePushCrossings;
+
+    // Boost the separations we keep low: between nodes when pushing crossings in, else within nodes.
+    return {
+      crossingsWithin: minWeight,
+      crossingsBetween: minWeight,
+      separationsWithin: minWeight + (pushCrossings ? 0 : 1),
+      separationsBetween: minWeight + (pushCrossings ? 1 : 0),
+    };
+  }
+
   setOrderingAlgorithm(portOrderingType: OrderingAlgorithm) {
-    this.currentOrderingAlgorithm = portOrderingType;
+    // Any unknown legacy value (the former crossing/separation modes) maps to ClutterAware.
+    this.currentOrderingAlgorithm =
+      portOrderingType in OrderingAlgorithm ? portOrderingType : OrderingAlgorithm.ClutterAware;
   }
 
   getNodes(): Node[] {
@@ -1213,8 +1235,8 @@ export class NodeService implements OnDestroy {
       });
 
       // Reorder ports and update routing
-      if (this.currentOrderingAlgorithm === OrderingAlgorithm.CrossingAware) {
-        optimizePorts(this.nodesStore.nodes);
+      if (this.usesOptimizePorts()) {
+        optimizePorts(this.nodesStore.nodes, this.getClutterWeights());
         this.nodesStore.nodes.forEach((n) => {
           n.updateTransitionsRouting();
           n.updateConnectionsRouting();

--- a/src/app/services/util/port-ordering.algo.ts
+++ b/src/app/services/util/port-ordering.algo.ts
@@ -2,7 +2,8 @@ import {Node} from "../../models/node.model";
 import {Port} from "../../models/port.model";
 import {PortAlignment} from "../../data-structures/technical.data.structures";
 import {Transition} from "../../models/transition.model";
-import {countAllCrossings} from "./port-ordering.crossings";
+import {countAllCrossings, countCrossingsInNode} from "./port-ordering.crossings";
+import {countAllSeparations} from "./port-ordering.separations";
 import {getComponents, getPortOppositeNodeId} from "./port-ordering.components";
 import {
   ALIGNMENTS_CLOCKWISE_ORDER,
@@ -36,7 +37,7 @@ function getScopedNode(node: Node, sides: Set<PortAlignment>): Node {
  * that nodes shared between components (a junction crossed by two independent reticulars for
  * instance) have each side optimized by its owning component only.
  */
-export function optimizePorts(nodes: Node[]): void {
+export function optimizePorts(nodes: Node[], clutterWeights?: Partial<ClutterWeights>): void {
   getComponents(nodes).forEach((component) => {
     const sidesByNode = new Map<Node, Set<PortAlignment>>();
     component.forEach(({node, side}) => {
@@ -44,7 +45,11 @@ export function optimizePorts(nodes: Node[]): void {
       if (sides) sides.add(side);
       else sidesByNode.set(node, new Set([side]));
     });
-    optimizeComponentPorts([...sidesByNode].map(([node, sides]) => getScopedNode(node, sides)));
+    optimizeComponentPorts(
+      [...sidesByNode].map(([node, sides]) => getScopedNode(node, sides)),
+      {},
+      clutterWeights,
+    );
   });
 }
 
@@ -55,6 +60,24 @@ type OptimizeComponentPortsOptions = {
 const DEFAULT_OPTIMIZE_COMPONENT_PORTS_OPTIONS: OptimizeComponentPortsOptions = {
   maxRuns: 50,
   maxNewCandidates: 10,
+};
+
+/**
+ * Weights applied to the four clutter components the optimizer minimizes. The clutter is their
+ * weighted sum, so callers tune the trade-off between minimizing crossings and keeping parallel
+ * bundles together.
+ */
+export type ClutterWeights = {
+  crossingsWithin: number;
+  crossingsBetween: number;
+  separationsWithin: number;
+  separationsBetween: number;
+};
+const DEFAULT_CLUTTER_WEIGHTS: ClutterWeights = {
+  crossingsWithin: 1,
+  crossingsBetween: 1,
+  separationsWithin: 0,
+  separationsBetween: 0,
 };
 
 /**
@@ -98,8 +121,10 @@ const DEFAULT_OPTIMIZE_COMPONENT_PORTS_OPTIONS: OptimizeComponentPortsOptions = 
 function optimizeComponentPorts(
   nodes: Node[],
   parameters: Partial<OptimizeComponentPortsOptions> = {},
+  clutterWeights: Partial<ClutterWeights> = {},
 ): void {
   const {maxRuns, maxNewCandidates} = {...DEFAULT_OPTIMIZE_COMPONENT_PORTS_OPTIONS, ...parameters};
+  const weights = {...DEFAULT_CLUTTER_WEIGHTS, ...clutterWeights};
 
   // Preserves insertion order while removing duplicates
   const toUnique = (arr: number[]): number[] => {
@@ -135,7 +160,7 @@ function optimizeComponentPorts(
   );
 
   let runs = 0;
-  let bestCrossings = Infinity;
+  let bestClutter = Infinity;
   let bestCandidate: number[] = [];
   const candidates = [initialTrainrunsOrder];
 
@@ -144,10 +169,17 @@ function optimizeComponentPorts(
 
     reorderComponentPorts(nodes, trainrunsToScore(candidate));
     const {crossings, groupCrossings} = countAllCrossings(nodes);
+    const crossingsWithin = nodes.reduce((sum, node) => sum + countCrossingsInNode(node), 0);
+    const {within: separationsWithin, between: separationsBetween} = countAllSeparations(nodes);
+    const clutter =
+      crossingsWithin * weights.crossingsWithin +
+      (crossings - crossingsWithin) * weights.crossingsBetween +
+      separationsWithin * weights.separationsWithin +
+      separationsBetween * weights.separationsBetween;
 
-    if (crossings < bestCrossings) {
+    if (clutter < bestClutter) {
       bestCandidate = candidate;
-      bestCrossings = crossings;
+      bestClutter = clutter;
 
       // Generate new candidates from worst crossings (reversed so worst is tried last/first-popped)
       const newCandidates = groupCrossings.slice(0, maxNewCandidates).toReversed();

--- a/src/app/services/util/port-ordering.algo.ts
+++ b/src/app/services/util/port-ordering.algo.ts
@@ -4,6 +4,7 @@ import {PortAlignment} from "../../data-structures/technical.data.structures";
 import {Transition} from "../../models/transition.model";
 import {countAllCrossings, countCrossingsInNode} from "./port-ordering.crossings";
 import {countAllSeparations} from "./port-ordering.separations";
+import {Candidate, getCandidates} from "./port-ordering.candidates";
 import {getComponents, getPortOppositeNodeId} from "./port-ordering.components";
 import {
   ALIGNMENTS_CLOCKWISE_ORDER,
@@ -37,7 +38,11 @@ function getScopedNode(node: Node, sides: Set<PortAlignment>): Node {
  * that nodes shared between components (a junction crossed by two independent reticulars for
  * instance) have each side optimized by its owning component only.
  */
-export function optimizePorts(nodes: Node[], clutterWeights?: Partial<ClutterWeights>): void {
+export function optimizePorts(
+  nodes: Node[],
+  clutterWeights?: Partial<ClutterWeights>,
+  options?: Partial<OptimizeComponentPortsOptions>,
+): void {
   getComponents(nodes).forEach((component) => {
     const sidesByNode = new Map<Node, Set<PortAlignment>>();
     component.forEach(({node, side}) => {
@@ -47,7 +52,7 @@ export function optimizePorts(nodes: Node[], clutterWeights?: Partial<ClutterWei
     });
     optimizeComponentPorts(
       [...sidesByNode].map(([node, sides]) => getScopedNode(node, sides)),
-      {},
+      options ?? {},
       clutterWeights,
     );
   });
@@ -55,11 +60,9 @@ export function optimizePorts(nodes: Node[], clutterWeights?: Partial<ClutterWei
 
 type OptimizeComponentPortsOptions = {
   maxRuns: number;
-  maxNewCandidates: number;
 };
 const DEFAULT_OPTIMIZE_COMPONENT_PORTS_OPTIONS: OptimizeComponentPortsOptions = {
-  maxRuns: 50,
-  maxNewCandidates: 10,
+  maxRuns: 500,
 };
 
 /**
@@ -92,20 +95,20 @@ const DEFAULT_CLUTTER_WEIGHTS: ClutterWeights = {
  * ## Algorithm
  *
  * 1. Start with the initial trainrun order (from node transitions)
- * 2. For each candidate trainrun ordering:
+ * 2. For each candidate (a trainrun ordering + a between-first node set):
  *    - Apply it via `reorderComponentPorts` (uses ordering as tie-breaker)
- *    - Count resulting crossings with `countAllCrossings`
- *    - If crossings improved, generate new candidates from detected group-crossings
+ *    - Measure the resulting clutter (weighted crossings + separations)
+ *    - If it improved, generate new candidates via `getCandidates`
  * 3. Repeat until no improvement or `maxRuns` reached
  * 4. Re-apply the best candidate found
  *
  * ## Candidate generation
  *
- * When crossings are detected, `countAllCrossings` returns `groupCrossings`: contiguous groups of
- * trainruns that cross each other. By permuting these groups in the trainrun ordering, we generate
- * new candidates that might reduce those specific crossings.
- *
- * Example: if trainruns [1,2] cross [3,4], we try reordering to [3,4,1,2].
+ * Clutter (crossings and separations) is treated as one thing: a bundle of trainruns whose shared
+ * order is broken across several sites along a corridor. `getCandidates` detects those bundles and
+ * emits coordinated reorderings, that try to repair every broken site at once, so the search can
+ * jump straight to a good order instead of needing intermediate steps the greedy search would
+ * reject.
  *
  * ## Limitations
  *
@@ -115,16 +118,23 @@ const DEFAULT_CLUTTER_WEIGHTS: ClutterWeights = {
  *
  * ## Parameters
  *
- * - `maxRuns`: Maximum iterations to prevent infinite loops (default: 50)
- * - `maxNewCandidates`: Max new candidates per improvement (default: 10), limits branching factor
+ * - `maxRuns`: Maximum iterations to prevent infinite loops
  */
 function optimizeComponentPorts(
   nodes: Node[],
   parameters: Partial<OptimizeComponentPortsOptions> = {},
   clutterWeights: Partial<ClutterWeights> = {},
 ): void {
-  const {maxRuns, maxNewCandidates} = {...DEFAULT_OPTIMIZE_COMPONENT_PORTS_OPTIONS, ...parameters};
-  const weights = {...DEFAULT_CLUTTER_WEIGHTS, ...clutterWeights};
+  const {maxRuns} = {...DEFAULT_OPTIMIZE_COMPONENT_PORTS_OPTIONS, ...parameters};
+  const {
+    crossingsWithin: crossingsWithinWeight,
+    crossingsBetween: crossingsBetweenWeight,
+    separationsWithin: separationsWithinWeight,
+    separationsBetween: separationsBetweenWeight,
+  } = {
+    ...DEFAULT_CLUTTER_WEIGHTS,
+    ...clutterWeights,
+  };
 
   // Preserves insertion order while removing duplicates
   const toUnique = (arr: number[]): number[] => {
@@ -146,51 +156,46 @@ function optimizeComponentPorts(
     return scores;
   };
 
-  // Permutes trainrun ordering by replacing group positions with flattened group order.
-  // Example: trainruns=[1,2,3,4], groups=[[3,4],[1,2]] → [3,4,1,2]
-  const reorderGroups = (trainruns: number[], groups: number[][]): number[] => {
-    const reorderedIDs = toUnique(groups.flat());
-    const set = new Set(reorderedIDs);
-    let j = 0;
-    return trainruns.map((v) => (set.has(v) ? reorderedIDs[j++] : v));
-  };
-
   const initialTrainrunsOrder = toUnique(
     nodes.flatMap((node) => node.getTransitions().map((t) => t.getTrainrun().getId())),
   );
 
   let runs = 0;
   let bestClutter = Infinity;
-  let bestCandidate: number[] = [];
-  const candidates = [initialTrainrunsOrder];
+  let bestCandidate: Candidate = {order: [], betweenFirst: new Set()};
+  let candidates: Candidate[] = [{order: initialTrainrunsOrder, betweenFirst: new Set()}];
 
   while (runs++ <= maxRuns && candidates.length > 0) {
     const candidate = candidates.pop();
 
-    reorderComponentPorts(nodes, trainrunsToScore(candidate));
-    const {crossings, groupCrossings} = countAllCrossings(nodes);
+    reorderComponentPorts(nodes, trainrunsToScore(candidate.order), candidate.betweenFirst);
+    const {crossings} = countAllCrossings(nodes);
     const crossingsWithin = nodes.reduce((sum, node) => sum + countCrossingsInNode(node), 0);
     const {within: separationsWithin, between: separationsBetween} = countAllSeparations(nodes);
     const clutter =
-      crossingsWithin * weights.crossingsWithin +
-      (crossings - crossingsWithin) * weights.crossingsBetween +
-      separationsWithin * weights.separationsWithin +
-      separationsBetween * weights.separationsBetween;
+      crossingsWithin * crossingsWithinWeight +
+      (crossings - crossingsWithin) * crossingsBetweenWeight +
+      separationsWithin * separationsWithinWeight +
+      separationsBetween * separationsBetweenWeight;
 
     if (clutter < bestClutter) {
       bestCandidate = candidate;
       bestClutter = clutter;
-
-      // Generate new candidates from worst crossings (reversed so worst is tried last/first-popped)
-      const newCandidates = groupCrossings.slice(0, maxNewCandidates).toReversed();
-      newCandidates.forEach((groupCrossing) => {
-        candidates.push(reorderGroups(candidate, groupCrossing.groups));
-      });
+      candidates = candidates.concat(
+        getCandidates(nodes, candidate, {
+          prioritizeSeparation:
+            separationsWithinWeight + separationsBetweenWeight >
+            crossingsWithinWeight + crossingsBetweenWeight,
+          prioritizeWithin:
+            separationsWithinWeight + crossingsWithinWeight >
+            separationsBetweenWeight + crossingsBetweenWeight,
+        }),
+      );
     }
   }
 
   // Re-apply best result (last iteration may have been worse)
-  reorderComponentPorts(nodes, trainrunsToScore(bestCandidate));
+  reorderComponentPorts(nodes, trainrunsToScore(bestCandidate.order), bestCandidate.betweenFirst);
 }
 
 /**
@@ -212,11 +217,16 @@ function optimizeComponentPorts(
  *
  * - Finally, if some trainrunScores input has been given:
  *   4b. Order using the trainrunScores tie-breaker
+ *
+ * When `betweenFirst` is true, the between-node discriminators (3, 4a) are consulted before the
+ * within-node ones (1, 2): the node follows its neighbors even if that creates a within-node
+ * crossing. This lets callers trade within-node crossings for fewer between-node crossings.
  */
 export function reorderNodePorts(
   node: Node,
   orderedNodeIDs = new Set<number>(),
   trainrunScores: Record<number, number> = {},
+  betweenFirst = false,
 ) {
   const transitions = node.getTransitions();
   const ports = node.getPorts();
@@ -247,35 +257,36 @@ export function reorderNodePorts(
   processingOrder.forEach((alignment) => {
     const sidePorts = ports.filter((port) => port.getPositionAlignment() === alignment);
 
-    const compare = (a: Port, b: Port) => {
+    // Within-node discriminators (cases 1 & 2): null when undecided.
+    const withinCmp = (a: Port, b: Port): number | null => {
       const aTransition = portTransitions.get(a.getId());
       const bTransition = portTransitions.get(b.getId());
+      if (!aTransition || !bTransition) return null;
 
-      if (aTransition && bTransition) {
-        const aOppositePort = node.getPort(aTransition.getOppositePort(a.getId()));
-        const bOppositePort = node.getPort(bTransition.getOppositePort(b.getId()));
+      const aOppositePort = node.getPort(aTransition.getOppositePort(a.getId()));
+      const bOppositePort = node.getPort(bTransition.getOppositePort(b.getId()));
+      const aOppositeAlignment = aOppositePort.getPositionAlignment();
+      const bOppositeAlignment = bOppositePort.getPositionAlignment();
 
-        const aOppositeAlignment = aOppositePort.getPositionAlignment();
-        const bOppositeAlignment = bOppositePort.getPositionAlignment();
-
-        if (aOppositeAlignment !== bOppositeAlignment) {
-          // Case 1
-          return (
-            getOppositeAlignmentScore(alignment, aOppositeAlignment) -
-            getOppositeAlignmentScore(alignment, bOppositeAlignment)
-          );
-        }
-
-        if (orderedSides.has(aOppositeAlignment)) {
-          const aScoreOppositeSide = aOppositePort.getPositionIndex();
-          const bScoreOppositeSide = bOppositePort.getPositionIndex();
-          const swap = isElbowSwapped(alignment, aOppositeAlignment);
-
-          // Case 2
-          return (aScoreOppositeSide - bScoreOppositeSide) * (swap ? -1 : 1);
-        }
+      if (aOppositeAlignment !== bOppositeAlignment) {
+        // Case 1
+        return (
+          getOppositeAlignmentScore(alignment, aOppositeAlignment) -
+          getOppositeAlignmentScore(alignment, bOppositeAlignment)
+        );
       }
+      if (orderedSides.has(aOppositeAlignment)) {
+        // Case 2
+        const swap = isElbowSwapped(alignment, aOppositeAlignment);
+        return (
+          (aOppositePort.getPositionIndex() - bOppositePort.getPositionIndex()) * (swap ? -1 : 1)
+        );
+      }
+      return null;
+    };
 
+    // Between-node discriminators (cases 3 & 4a): null when undecided.
+    const betweenCmp = (a: Port, b: Port): number | null => {
       const aOppositeNode = a.getOppositeNode(node.getId());
       const bOppositeNode = b.getOppositeNode(node.getId());
 
@@ -285,9 +296,8 @@ export function reorderNodePorts(
           ? aOppositeNode.getPositionX() - bOppositeNode.getPositionX()
           : aOppositeNode.getPositionY() - bOppositeNode.getPositionY();
       }
-
-      // Case 4a
       if (orderedNodeIDs.has(aOppositeNode.getId())) {
+        // Case 4a
         const oppositeNodePorts = aOppositeNode.getPorts();
         const aPortInOppositeNode = oppositeNodePorts.find(
           (port) => port.getTrainrunSectionId() === a.getTrainrunSectionId(),
@@ -298,36 +308,48 @@ export function reorderNodePorts(
         if (!aPortInOppositeNode || !bPortInOppositeNode) return 0;
         return aPortInOppositeNode.getPositionIndex() - bPortInOppositeNode.getPositionIndex();
       }
+      return null;
+    };
 
-      // Case 4b
-      else {
-        const aTrainrunId = a.getTrainrunSection().getTrainrunId();
-        const bTrainrunId = b.getTrainrunSection().getTrainrunId();
-        const aScore = trainrunScores[aTrainrunId] ?? aTrainrunId;
-        const bScore = trainrunScores[bTrainrunId] ?? bTrainrunId;
+    // Case 4b: trainrunScores tie-breaker, always decisive.
+    const tieBreakerCmp = (a: Port, b: Port): number => {
+      const aTransition = portTransitions.get(a.getId());
+      const aTrainrunId = a.getTrainrunSection().getTrainrunId();
+      const bTrainrunId = b.getTrainrunSection().getTrainrunId();
+      const aScore = trainrunScores[aTrainrunId] ?? aTrainrunId;
+      const bScore = trainrunScores[bTrainrunId] ?? bTrainrunId;
 
-        let swap = 1;
-        if (aTransition) {
-          const aOppositePort = node.getPort(aTransition.getOppositePort(a.getId()));
-          if (aOppositePort.getPositionAlignment() === alignment) {
-            const otherEnd = aOppositePort.getOppositeNode(node.getId());
-            const currentPos = isHorizontalAlignment(alignment)
-              ? aOppositeNode.getPositionX()
-              : aOppositeNode.getPositionY();
-            const otherPos = isHorizontalAlignment(alignment)
-              ? otherEnd.getPositionX()
-              : otherEnd.getPositionY();
-            if (currentPos > otherPos) swap = -1;
-          }
+      let swap = 1;
+      if (aTransition) {
+        const aOppositePort = node.getPort(aTransition.getOppositePort(a.getId()));
+        if (aOppositePort.getPositionAlignment() === alignment) {
+          const aOppositeNode = a.getOppositeNode(node.getId());
+          const otherEnd = aOppositePort.getOppositeNode(node.getId());
+          const currentPos = isHorizontalAlignment(alignment)
+            ? aOppositeNode.getPositionX()
+            : aOppositeNode.getPositionY();
+          const otherPos = isHorizontalAlignment(alignment)
+            ? otherEnd.getPositionX()
+            : otherEnd.getPositionY();
+          if (currentPos > otherPos) swap = -1;
         }
-
-        return (aScore - bScore) * swap;
       }
+      return (aScore - bScore) * swap;
+    };
+
+    // betweenFirst consults between-node cases before within-node ones.
+    const orderedCmps = betweenFirst ? [betweenCmp, withinCmp] : [withinCmp, betweenCmp];
+    const compare = (a: Port, b: Port): number => {
+      for (const cmp of orderedCmps) {
+        const result = cmp(a, b);
+        if (result !== null) return result;
+      }
+      return tieBreakerCmp(a, b);
     };
 
     // Transitions are ordered by geometry, free ends only by a tie-break score. Mixing both scales
     // in a single sort can contradict itself and flip two transitions (which would cross inside the
-    // node), so we sort each kind separately, then insert the free end into the ordered transition
+    // node), so we sort each kind separately, then insert the free end into the ordered transitions.
     const hasTransition = (p: Port) => portTransitions.has(p.getId());
     const transitionPorts = sidePorts.filter(hasTransition).sort(compare);
     const freeEndPorts = sidePorts.filter((p) => !hasTransition(p)).sort(compare);
@@ -354,7 +376,11 @@ function getNeighborsCount(node: Node): number {
  * exactly how ports are ordered in a single node (where the logic actually is), check
  * reorderNodePorts.
  */
-function reorderComponentPorts(nodes: Node[], trainrunScores: Record<number, number> = {}): void {
+function reorderComponentPorts(
+  nodes: Node[],
+  trainrunScores: Record<number, number> = {},
+  betweenFirstNodeIDs = new Set<number>(),
+): void {
   const nodesWithPorts = nodes.filter((n) => n.getPorts().length > 0);
   if (nodesWithPorts.length === 0) return;
 
@@ -368,7 +394,7 @@ function reorderComponentPorts(nodes: Node[], trainrunScores: Record<number, num
   });
   const queue: number[] = [root.getId()];
 
-  reorderNodePorts(root, visited, trainrunScores);
+  reorderNodePorts(root, visited, trainrunScores, betweenFirstNodeIDs.has(root.getId()));
   visited.add(root.getId());
 
   // BFS traversal
@@ -385,7 +411,12 @@ function reorderComponentPorts(nodes: Node[], trainrunScores: Record<number, num
 
       visited.add(neighborId);
       queue.push(neighborId);
-      reorderNodePorts(nodeMap.get(neighborId), visited, trainrunScores);
+      reorderNodePorts(
+        nodeMap.get(neighborId),
+        visited,
+        trainrunScores,
+        betweenFirstNodeIDs.has(neighborId),
+      );
     }
   }
 }

--- a/src/app/services/util/port-ordering.bundles.spec.ts
+++ b/src/app/services/util/port-ordering.bundles.spec.ts
@@ -1,0 +1,89 @@
+import {buildNetwork, setPortOrder} from "./port-ordering.test-helpers";
+import {getBundleReferenceOrder, getClutterBundles} from "./port-ordering.bundles";
+
+describe("getClutterBundles", () => {
+  it("returns no bundles when the network is clean", () => {
+    const {nodesMap, nodesArray, trainrunIDs} = buildNetwork({
+      nodes: {A: {x: 0}, B: {x: 100}, C: {x: 200}},
+      trainruns: [
+        ["A", "B", "C"],
+        ["A", "B", "C"],
+      ],
+    });
+    setPortOrder(nodesMap.get("B"), "left", trainrunIDs);
+    setPortOrder(nodesMap.get("B"), "right", trainrunIDs);
+
+    expect(getClutterBundles(nodesArray)).toEqual([]);
+  });
+
+  it("reports a separated pair as one bundle, broken at both ends of the link", () => {
+    // T0,T1 run A-B in parallel
+    // T2 ends at B (from E, further west), wedged between them on B's left
+    // T0,T1 want to stay together but are pulled apart
+    // -> one bundle {T0,T1}
+    const {
+      nodesMap,
+      nodesArray,
+      trainrunIDs: [t0, t1, t2],
+    } = buildNetwork({
+      nodes: {A: {x: 0}, B: {x: 100}, E: {x: -100}},
+      trainruns: [
+        ["A", "B"],
+        ["A", "B"],
+        ["E", "B"],
+      ],
+    });
+    setPortOrder(nodesMap.get("A"), "right", [t0, t1]);
+    setPortOrder(nodesMap.get("B"), "left", [t0, t2, t1]);
+
+    const bundles = getClutterBundles(nodesArray);
+
+    expect(bundles.length).toBe(1);
+    expect(bundles[0].trainruns).toEqual(new Set([t0, t1]));
+    expect(bundles[0].brokenAt).toEqual(
+      new Set([nodesMap.get("A").getId(), nodesMap.get("B").getId()]),
+    );
+  });
+});
+
+describe("getBundleReferenceOrder", () => {
+  it("reads the members' order off the node side that holds the most of them", () => {
+    const {nodesMap, nodesArray, trainrunIDs} = buildNetwork({
+      nodes: {A: {x: 0}, B: {x: 100}},
+      trainruns: [
+        ["A", "B"],
+        ["A", "B"],
+        ["A", "B"],
+      ],
+    });
+    const [t0, t1, t2] = trainrunIDs;
+    setPortOrder(nodesMap.get("A"), "right", [t2, t0, t1]);
+    setPortOrder(nodesMap.get("B"), "left", [t2, t0, t1]);
+
+    expect(getBundleReferenceOrder(nodesArray, new Set([t0, t1, t2]), [t0, t1, t2])).toEqual([
+      t2,
+      t0,
+      t1,
+    ]);
+  });
+
+  it("appends members absent from that side in their current global order", () => {
+    const {nodesMap, nodesArray, trainrunIDs} = buildNetwork({
+      nodes: {A: {x: 0}, B: {x: 100}, C: {x: 200}},
+      trainruns: [
+        ["A", "B"],
+        ["A", "B"],
+        ["B", "C"],
+      ],
+    });
+    const [t0, t1, t2] = trainrunIDs;
+    setPortOrder(nodesMap.get("A"), "right", [t1, t0]);
+    setPortOrder(nodesMap.get("B"), "left", [t1, t0]);
+
+    expect(getBundleReferenceOrder(nodesArray, new Set([t0, t1, t2]), [t0, t1, t2])).toEqual([
+      t1,
+      t0,
+      t2,
+    ]);
+  });
+});

--- a/src/app/services/util/port-ordering.bundles.ts
+++ b/src/app/services/util/port-ordering.bundles.ts
@@ -1,0 +1,121 @@
+import {Node} from "../../models/node.model";
+import {countBetweenCrossingsAroundNode, transitionsCrossInNode} from "./port-ordering.crossings";
+import {
+  getSeparationPairsBetweenNodes,
+  getSeparationPairsWithinNode,
+} from "./port-ordering.separations";
+import {groupBy} from "../../utils/collection";
+
+type Pair = {trainrunId1: number; trainrunId2: number; nodeId: number};
+
+type ClutterBundle = {trainruns: Set<number>; brokenAt: Set<number>};
+
+/**
+ * Groups the network's trainruns into bundles that "want to travel together", each tagged with the
+ * nodes where that togetherness is currently broken.
+ */
+export function getClutterBundles(nodes: Node[]): ClutterBundle[] {
+  // 1. Collect trainrun pairs:
+  const pairs: Pair[] = [];
+  nodes.forEach((node) => {
+    const nodeId = node.getId();
+
+    // Separations:
+    // A pair drawn touching somewhere but pulled apart here
+    [...getSeparationPairsWithinNode(node), ...getSeparationPairsBetweenNodes(node)].forEach(
+      ([trainrunId1, trainrunId2]) => pairs.push({trainrunId1, trainrunId2, nodeId}),
+    );
+
+    // Crossing groups:
+    // Contiguous neighbors stay bundled. Crossing trainruns land in DIFFERENT groups, so a crossing
+    // never merges across the cross. So, sides merge only if parallel elsewhere.
+    countBetweenCrossingsAroundNode(node).groupCrossings.forEach(({groups}) =>
+      groups.forEach((group) => {
+        for (let i = 0; i < group.length - 1; i++) {
+          pairs.push({trainrunId1: group[i], trainrunId2: group[i + 1], nodeId});
+        }
+      }),
+    );
+  });
+
+  // 2. Merge overlapping pairs:
+  // Each trainrun ends up pointing at a single root trainrun, shared by its whole bundle
+  const trainrunGroupIds = new Map<number, number>();
+  const getTrainrunRoot = (trainrunId: number): number => {
+    if (!trainrunGroupIds.has(trainrunId)) trainrunGroupIds.set(trainrunId, trainrunId);
+    let root = trainrunId;
+    while (trainrunGroupIds.get(root) !== root) root = trainrunGroupIds.get(root);
+    trainrunGroupIds.set(trainrunId, root);
+    return root;
+  };
+  pairs.forEach(({trainrunId1, trainrunId2}) =>
+    trainrunGroupIds.set(getTrainrunRoot(trainrunId1), getTrainrunRoot(trainrunId2)),
+  );
+
+  // 3. Build one bundle per root, and map every trainrun to it (members sharing a root share the
+  // same bundle object, so lookups below are plain gets and identity checks):
+  const bundlesByTrainrunId = new Map<number, ClutterBundle>();
+  [...trainrunGroupIds.keys()].forEach((trainrunId) => {
+    const root = getTrainrunRoot(trainrunId);
+    if (!bundlesByTrainrunId.has(root)) {
+      bundlesByTrainrunId.set(root, {trainruns: new Set(), brokenAt: new Set()});
+    }
+    const bundle = bundlesByTrainrunId.get(root);
+    bundle.trainruns.add(trainrunId);
+    bundlesByTrainrunId.set(trainrunId, bundle);
+  });
+
+  // 4. Identify for each bundle what are the nodes that make it broken:
+  // a. from the pairs that built the bundles (each pair marks its node on its bundle)
+  pairs.forEach(({trainrunId1, nodeId}) =>
+    // Either endpoint works here, since they share a bundle
+    bundlesByTrainrunId.get(trainrunId1).brokenAt.add(nodeId),
+  );
+
+  // b. from within-node crossings between two members of the same bundle
+  nodes.forEach((node) => {
+    const transitions = node.getTransitions();
+    for (let i = 0; i < transitions.length - 1; i++) {
+      for (let j = i + 1; j < transitions.length; j++) {
+        const bundle = bundlesByTrainrunId.get(transitions[i].getTrainrun().getId());
+        const otherBundle = bundlesByTrainrunId.get(transitions[j].getTrainrun().getId());
+        if (
+          bundle &&
+          bundle === otherBundle &&
+          transitionsCrossInNode(node, transitions[i], transitions[j])
+        ) {
+          bundle.brokenAt.add(node.getId());
+        }
+      }
+    }
+  });
+
+  // Only returns bundles with at least two trainruns:
+  return [...new Set(bundlesByTrainrunId.values())];
+}
+
+/**
+ * The order a bundle's members should follow, read off the node side that holds the most of them.
+ * Members not on that side are appended in their current global order.
+ */
+export function getBundleReferenceOrder(
+  nodes: Node[],
+  trainruns: Set<number>,
+  order: number[],
+): number[] {
+  let bestSideReading: number[] = [];
+  nodes.forEach((node) =>
+    groupBy(
+      node.getPorts().filter((p) => trainruns.has(p.getTrainrunSection().getTrainrunId())),
+      (p) => p.getPositionAlignment(),
+    ).forEach((side) => {
+      if (side.length > bestSideReading.length) {
+        bestSideReading = [...side]
+          .sort((a, b) => a.getPositionIndex() - b.getPositionIndex())
+          .map((p) => p.getTrainrunSection().getTrainrunId());
+      }
+    }),
+  );
+  const seen = new Set(bestSideReading);
+  return [...bestSideReading, ...order.filter((id) => trainruns.has(id) && !seen.has(id))];
+}

--- a/src/app/services/util/port-ordering.candidates.spec.ts
+++ b/src/app/services/util/port-ordering.candidates.spec.ts
@@ -1,0 +1,92 @@
+import {buildNetwork, setPortOrder} from "./port-ordering.test-helpers";
+import {getCandidates} from "./port-ordering.candidates";
+
+describe("getCandidates", () => {
+  it("returns no candidates when the network is clean", () => {
+    const {nodesMap, nodesArray, trainrunIDs} = buildNetwork({
+      nodes: {A: {x: 0}, B: {x: 100}, C: {x: 200}},
+      trainruns: [
+        ["A", "B", "C"],
+        ["A", "B", "C"],
+      ],
+    });
+    setPortOrder(nodesMap.get("B"), "left", trainrunIDs);
+    setPortOrder(nodesMap.get("B"), "right", trainrunIDs);
+
+    expect(getCandidates(nodesArray, {order: trainrunIDs, betweenFirst: new Set()})).toEqual([]);
+  });
+
+  it("emits the ten reorderings of a single broken bundle", () => {
+    // T0,T1 run A-B in parallel
+    // T2 ends at B wedged between them -> bundle {T0,T1}, broken at A & B
+    const {
+      nodesMap,
+      nodesArray,
+      trainrunIDs: [t0, t1, t2],
+    } = buildNetwork({
+      nodes: {A: {x: 0}, B: {x: 100}, E: {x: -100}},
+      trainruns: [
+        ["A", "B"],
+        ["A", "B"],
+        ["E", "B"],
+      ],
+    });
+    setPortOrder(nodesMap.get("A"), "right", [t0, t1]);
+    setPortOrder(nodesMap.get("B"), "left", [t0, t2, t1]);
+
+    const broken = new Set([nodesMap.get("A").getId(), nodesMap.get("B").getId()]);
+    const candidates = getCandidates(nodesArray, {order: [t0, t2, t1], betweenFirst: new Set()});
+
+    expect(candidates).toEqual([
+      {order: [t0, t1, t2], betweenFirst: new Set()}, // separation repair
+      {order: [t0, t1, t2], betweenFirst: broken},
+      {order: [t1, t2, t0], betweenFirst: new Set()}, // crossing repair (reversed)
+      {order: [t1, t2, t0], betweenFirst: broken},
+      {order: [t0, t2, t1], betweenFirst: new Set()}, // crossing repair (normal)
+      {order: [t0, t2, t1], betweenFirst: broken},
+      {order: [t1, t0, t2], betweenFirst: new Set()}, // both at once (reversed)
+      {order: [t1, t0, t2], betweenFirst: broken},
+      {order: [t0, t1, t2], betweenFirst: new Set()}, // both at once (normal)
+      {order: [t0, t1, t2], betweenFirst: broken},
+    ]);
+  });
+
+  it("reorders the candidates according to the prioritize flags", () => {
+    const {
+      nodesMap,
+      nodesArray,
+      trainrunIDs: [t0, t1, t2],
+    } = buildNetwork({
+      nodes: {A: {x: 0}, B: {x: 100}, E: {x: -100}},
+      trainruns: [
+        ["A", "B"],
+        ["A", "B"],
+        ["E", "B"],
+      ],
+    });
+    setPortOrder(nodesMap.get("A"), "right", [t0, t1]);
+    setPortOrder(nodesMap.get("B"), "left", [t0, t2, t1]);
+
+    const broken = new Set([nodesMap.get("A").getId(), nodesMap.get("B").getId()]);
+    const candidates = getCandidates(
+      nodesArray,
+      {order: [t0, t2, t1], betweenFirst: new Set()},
+      {prioritizeSeparation: true, prioritizeWithin: true},
+    );
+
+    // prioritizeSeparation -> crossing repair before separation repair
+    // prioritizeWithin -> between-first variant before the plain one
+    expect(candidates).toEqual([
+      {order: [t1, t2, t0], betweenFirst: broken}, // crossing repair (reversed)
+      {order: [t1, t2, t0], betweenFirst: new Set()},
+      {order: [t0, t2, t1], betweenFirst: broken}, // crossing repair (normal)
+      {order: [t0, t2, t1], betweenFirst: new Set()},
+      {order: [t0, t1, t2], betweenFirst: broken}, // separation repair
+      {order: [t0, t1, t2], betweenFirst: new Set()},
+      {order: [t1, t0, t2], betweenFirst: broken}, // both at once (reversed)
+      {order: [t1, t0, t2], betweenFirst: new Set()},
+      {order: [t0, t1, t2], betweenFirst: broken}, // both at once (normal)
+      {order: [t0, t1, t2], betweenFirst: new Set()},
+    ]);
+  });
+});

--- a/src/app/services/util/port-ordering.candidates.ts
+++ b/src/app/services/util/port-ordering.candidates.ts
@@ -1,0 +1,118 @@
+import {Node} from "../../models/node.model";
+import {getBundleReferenceOrder, getClutterBundles} from "./port-ordering.bundles";
+
+export type Candidate = {order: number[]; betweenFirst: Set<number>};
+
+/**
+ * Resequences the bundle's members to `referenceOrder`, but leaves each in its current slot
+ * (repairs crossings without gathering the bundle).
+ *
+ * Example:
+ * order [x, A, y, B, z, C], referenceOrder [C, B, A]
+ * -> [x, C, y, B, z, A]
+ */
+function arrangeBundleInPlace(order: number[], referenceOrder: number[]): number[] {
+  const members = new Set(referenceOrder);
+  let j = 0;
+  return order.map((trainrunId) => (members.has(trainrunId) ? referenceOrder[j++] : trainrunId));
+}
+
+/**
+ * Gathers the bundle's members into one contiguous block at their first slot, keeping their current
+ * relative order (repairs separation only, leaving crossings untouched).
+ *
+ * Example:
+ * order [x, A, y, B, z, C], members {A, B, C}
+ * -> [x, A, B, C, y, z]
+ */
+function arrangeBundleTogether(order: number[], members: Set<number>): number[] {
+  const firstIndex = order.findIndex((trainrunId) => members.has(trainrunId));
+  if (firstIndex === -1) return order;
+  const block = order.filter((trainrunId) => members.has(trainrunId));
+  const rest = order.filter((trainrunId) => !members.has(trainrunId));
+  rest.splice(firstIndex, 0, ...block);
+  return rest;
+}
+
+/**
+ * Gathers the bundle's members into one contiguous block at their first slot, laid out in
+ * `referenceOrder` (repairs separation and crossings at once).
+ *
+ * Example:
+ * order [x, A, y, B, z, C], referenceOrder [C, B, A]
+ * -> [x, C, B, A, y, z]
+ */
+function arrangeBundleTogetherInOrder(order: number[], referenceOrder: number[]): number[] {
+  const members = new Set(referenceOrder);
+  const firstIndex = order.findIndex((trainrunId) => members.has(trainrunId));
+  if (firstIndex === -1) return order;
+  const rest = order.filter((trainrunId) => !members.has(trainrunId));
+  rest.splice(firstIndex, 0, ...referenceOrder);
+  return rest;
+}
+
+/**
+ * Identifies most-broken bundles, and emits for each of them a set of candidates.
+ *
+ * For each bundle, it emits ten reorderings:
+ * - separation-repair
+ * - crossing-repair (normal order + reversed)
+ * - both-at-once (normal order + reversed)
+ * - each the above, with the nodes where the bundle breaks flagged as `betweenFirst`
+ *
+ * The candidates are returned with the ones supposed to be the more effective last. The two option
+ * flags prioritizeSeparation and prioritizeWithin determine what the more effective orders are.
+ */
+export function getCandidates(
+  nodes: Node[],
+  base: Candidate,
+  {
+    maxBundles = 4,
+    prioritizeSeparation = false,
+    prioritizeWithin = false,
+  }: {maxBundles?: number; prioritizeSeparation?: boolean; prioritizeWithin?: boolean} = {},
+): Candidate[] {
+  const bundles = getClutterBundles(nodes)
+    .sort((a, b) => b.brokenAt.size - a.brokenAt.size || b.trainruns.size - a.trainruns.size)
+    .slice(0, maxBundles);
+
+  const orderedTrainruns = new Set(base.order);
+  const candidates: Candidate[] = [];
+
+  bundles.reverse().forEach(({trainruns, brokenAt}) => {
+    const referenceOrder = getBundleReferenceOrder(nodes, trainruns, base.order).filter((id) =>
+      orderedTrainruns.has(id),
+    );
+    if (referenceOrder.length < 2) return;
+    const reversedOrder = [...referenceOrder].reverse();
+    const betweenFirstWithBroken = new Set([...base.betweenFirst, ...brokenAt]);
+
+    const separationRepair = [arrangeBundleTogether(base.order, trainruns)];
+    const crossingRepair = [
+      arrangeBundleInPlace(base.order, reversedOrder),
+      arrangeBundleInPlace(base.order, referenceOrder),
+    ];
+    const bothRepair = [
+      arrangeBundleTogetherInOrder(base.order, reversedOrder),
+      arrangeBundleTogetherInOrder(base.order, referenceOrder),
+    ];
+
+    // both-at-once (fixes crossings and separations together) is always explored first, and the
+    // prioritizeSeparation flag decides which single-purpose repair the search tries next.
+    const orders = prioritizeSeparation
+      ? [...crossingRepair, ...separationRepair, ...bothRepair]
+      : [...separationRepair, ...crossingRepair, ...bothRepair];
+
+    // prioritizeWithin explores plain candidates first, otherwise the between-first ones (which
+    // make broken nodes follow their neighbors)
+    const betweenVariants = prioritizeWithin
+      ? [betweenFirstWithBroken, base.betweenFirst]
+      : [base.betweenFirst, betweenFirstWithBroken];
+
+    orders.forEach((order) => {
+      betweenVariants.forEach((betweenFirst) => candidates.push({order, betweenFirst}));
+    });
+  });
+
+  return candidates;
+}

--- a/src/app/services/util/port-ordering.crossings.spec.ts
+++ b/src/app/services/util/port-ordering.crossings.spec.ts
@@ -1,6 +1,7 @@
 import {buildNetwork, setPortOrder} from "./port-ordering.test-helpers";
 import {
   countAllCrossings,
+  countBetweenCrossingsAroundNode,
   countCrossingsInNode,
   countCrossingsBetweenSides,
   groupContiguous,
@@ -194,6 +195,50 @@ describe("countAllCrossings", () => {
       // Each A trainrun crosses each C trainrun = 2x2 = 4
       expect(result.crossings).toBe(4);
       expect(result.groupCrossings[0]?.crossings).toBe(4);
+    });
+  });
+});
+
+describe("countBetweenCrossingsAroundNode", () => {
+  it("halves a direct crossing, attributing it to each shared endpoint", () => {
+    // Two parallel A-B sections, inverted at B: a direct crossing (same opposite node).
+    const {nodesMap, trainrunIDs} = buildNetwork({
+      nodes: {A: {x: 0}, B: {x: 100}},
+      trainruns: [
+        ["A", "B"],
+        ["A", "B"],
+      ],
+    });
+    setPortOrder(nodesMap.get("A"), "right", trainrunIDs);
+    setPortOrder(nodesMap.get("B"), "left", trainrunIDs.toReversed());
+
+    // The single crossing is shared, so each of its two endpoints carries half of it.
+    expect(countBetweenCrossingsAroundNode(nodesMap.get("A")).crossings).toBe(0.5);
+    expect(countBetweenCrossingsAroundNode(nodesMap.get("B")).crossings).toBe(0.5);
+  });
+
+  it("counts an indirect crossing in full at the shared node, and zero at the leaves", () => {
+    // A
+    //   >- B    (A and C both reach B; reversing B's left crosses them)
+    // C
+    const {nodesMap, trainrunIDs} = buildNetwork({
+      nodes: {A: {x: 0, y: 0}, B: {x: 500, y: 50}, C: {x: 0, y: 100}},
+      trainruns: [
+        ["A", "B"],
+        ["C", "B"],
+      ],
+    });
+    setPortOrder(nodesMap.get("B"), "left", trainrunIDs.toReversed());
+
+    // Different opposite nodes (A vs C) => indirect crossing, not halved, only at B.
+    expect(countBetweenCrossingsAroundNode(nodesMap.get("B")).crossings).toBe(1);
+    expect(countBetweenCrossingsAroundNode(nodesMap.get("A"))).toEqual({
+      crossings: 0,
+      groupCrossings: [],
+    });
+    expect(countBetweenCrossingsAroundNode(nodesMap.get("C"))).toEqual({
+      crossings: 0,
+      groupCrossings: [],
     });
   });
 });

--- a/src/app/services/util/port-ordering.crossings.ts
+++ b/src/app/services/util/port-ordering.crossings.ts
@@ -1,5 +1,7 @@
 import {Node} from "../../models/node.model";
 import {Port} from "../../models/port.model";
+import {Transition} from "../../models/transition.model";
+import {PortAlignment} from "../../data-structures/technical.data.structures";
 import {
   ALIGNMENTS_CLOCKWISE_ORDER,
   ALIGNMENTS_CLOCKWISE_SCORES,
@@ -123,67 +125,60 @@ export function countCrossingsBetweenSides(
 }
 
 /**
+ * This function detects whether two transitions cross inside a node.
+ *
+ * Here is what a node looks like:
+ *       0 1 … n
+ *     ┌─────────┐
+ *   0 │         │ 0
+ *   1 │         │ 1
+ *   … │         │ …
+ *   n │         │ n
+ *     └─────────┘
+ *       0 1 … n
+ *
+ * To detect if two transitions cross in a node, we rotate around the node and note each port
+ * when we cross them, starting from the top left, and rotating clockwise. Bottom and left
+ * ports are met backwards, so we have to reverse their position index order.
+ *
+ * Then, we end up with an array with 4 ports. The two transitions do cross when they
+ * alternate in the array, so if the first and third ports refer to the same trainrun section.
+ */
+export function transitionsCrossInNode(node: Node, t1: Transition, t2: Transition): boolean {
+  const sortedPorts = [t1, t2]
+    .flatMap((transition) =>
+      [node.getPort(transition.getPortId1()), node.getPort(transition.getPortId2())].map(
+        (port) => ({transition, port}),
+      ),
+    )
+    .sort((a, b) => {
+      const aAlignment = a.port.getPositionAlignment();
+      const bAlignment = b.port.getPositionAlignment();
+
+      if (aAlignment !== bAlignment) {
+        return (
+          ALIGNMENTS_CLOCKWISE_SCORES.get(aAlignment) - ALIGNMENTS_CLOCKWISE_SCORES.get(bAlignment)
+        );
+      }
+
+      const swap = COUNTERCLOCKWISE_ALIGNMENTS.has(aAlignment);
+      return (a.port.getPositionIndex() - b.port.getPositionIndex()) * (swap ? -1 : 1);
+    });
+
+  return sortedPorts[0].transition === sortedPorts[2].transition;
+}
+
+/**
  * This function counts all crossings within a node.
  */
 export function countCrossingsInNode(node: Node): number {
   let crossings = 0;
   const transitions = node.getTransitions();
   for (let i = 0; i < transitions.length - 1; i++) {
-    const t1 = transitions[i];
-
     for (let j = i + 1; j < transitions.length; j++) {
-      const t2 = transitions[j];
-
-      /**
-       * Here is what a node looks like:
-       *       0 1 … n
-       *     ┌─────────┐
-       *   0 │         │ 0
-       *   1 │         │ 1
-       *   … │         │ …
-       *   n │         │ n
-       *     └─────────┘
-       *       0 1 … n
-       *
-       * To detect if two transitions cross in a node, we rotate around the node and note each port
-       * when we cross them, starting from the top left, and rotating clockwise. Bottom and left
-       * ports are met backwards, so we have to reverse their position index order.
-       *
-       * Then, we end up with an array with 4 ports. The two transitions do cross when they
-       * alternate in the array, so if the first and third ports refer to the same trainrun section.
-       */
-      const sortedPorts = [t1, t2]
-        .flatMap((transition) =>
-          [node.getPort(transition.getPortId1()), node.getPort(transition.getPortId2())].map(
-            (port) => ({
-              transition,
-              port,
-            }),
-          ),
-        )
-        .sort((a, b) => {
-          const aAlignment = a.port.getPositionAlignment();
-          const bAlignment = b.port.getPositionAlignment();
-
-          if (aAlignment !== bAlignment) {
-            return (
-              ALIGNMENTS_CLOCKWISE_SCORES.get(aAlignment) -
-              ALIGNMENTS_CLOCKWISE_SCORES.get(bAlignment)
-            );
-          }
-
-          const swap = COUNTERCLOCKWISE_ALIGNMENTS.has(aAlignment);
-          const aIndex = a.port.getPositionIndex();
-          const bIndex = b.port.getPositionIndex();
-          return (aIndex - bIndex) * (swap ? -1 : 1);
-        });
-
-      if (sortedPorts[0].transition === sortedPorts[2].transition) {
-        crossings++;
-      }
+      if (transitionsCrossInNode(node, transitions[i], transitions[j])) crossings++;
     }
   }
-
   return crossings;
 }
 
@@ -195,6 +190,90 @@ interface GroupCrossing {
 interface CrossingsInfo {
   crossings: number;
   groupCrossings: GroupCrossing[];
+}
+
+/**
+ * This function returns, for one side of a node, the trainrun IDs in their order on that side
+ * (`thisSide`), and the trainrun IDs reached from that side, grouped by opposite node (sorted by
+ * the opposite node position) and ordered within each group by their position there (`oppositeSides`).
+ * These two orderings are what the between-node crossing counting compares.
+ */
+export function getBetweenSideOrderings(
+  node: Node,
+  alignment: PortAlignment,
+): {thisSide: number[]; oppositeSides: number[][]} {
+  const nodeId = node.getId();
+  const relevantDimension = isHorizontalAlignment(alignment)
+    ? ("getPositionX" as const)
+    : ("getPositionY" as const);
+
+  const ports = node
+    .getPorts()
+    .filter((port) => port.getPositionAlignment() === alignment)
+    .sort((a, b) => a.getPositionIndex() - b.getPositionIndex());
+  const oppositePortsPerNode: Record<number, {node: Node; port: Port}[]> = {};
+  ports.forEach((port) => {
+    const trainrunSectionId = port.getTrainrunSectionId();
+    const oppositeNode = port.getOppositeNode(nodeId);
+    const oppositeNodeID = oppositeNode.getId();
+    const oppositePort = oppositeNode
+      .getPorts()
+      .find((p) => p.getTrainrunSectionId() === trainrunSectionId);
+
+    oppositePortsPerNode[oppositeNodeID] = oppositePortsPerNode[oppositeNodeID] || [];
+    oppositePortsPerNode[oppositeNodeID].push({node: oppositeNode, port: oppositePort});
+  });
+  const oppositeNodes: {node: Node; ports: Port[]}[] = [];
+  for (const id in oppositePortsPerNode) {
+    oppositeNodes.push({
+      node: oppositePortsPerNode[id][0].node,
+      ports: oppositePortsPerNode[id].map(({port}) => port),
+    });
+  }
+
+  const thisSide = ports.map((port) => port.getTrainrunSection().getTrainrunId());
+  const oppositeSides = oppositeNodes
+    .toSorted((a, b) => a.node[relevantDimension]() - b.node[relevantDimension]())
+    .map(({ports}) =>
+      ports
+        .toSorted((a, b) => a.getPositionIndex() - b.getPositionIndex())
+        .map((port) => port.getTrainrunSection().getTrainrunId()),
+    );
+
+  return {thisSide, oppositeSides};
+}
+
+/**
+ * This function counts the crossings happening between `node` and its neighbors, on the links
+ * incident to it (i.e. excluding the within-node crossings). It returns both the total (direct
+ * crossings halved, as each is shared with the opposite node) and the per-side group crossings.
+ */
+export function countBetweenCrossingsAroundNode(node: Node): {
+  crossings: number;
+  groupCrossings: GroupCrossing[];
+} {
+  let crossings = 0;
+  const groupCrossings: GroupCrossing[] = [];
+
+  ALIGNMENTS_CLOCKWISE_ORDER.forEach((alignment) => {
+    const {thisSide, oppositeSides} = getBetweenSideOrderings(node, alignment);
+
+    // Count crossings:
+    const {direct, indirect} = countCrossingsBetweenSides(thisSide, oppositeSides);
+
+    // Detect contiguous groups of nodes:
+    const contiguous = groupContiguous(oppositeSides, thisSide);
+
+    if (direct + indirect) {
+      groupCrossings.push({crossings: direct + indirect, groups: contiguous});
+    }
+
+    // Add local crossings to total count
+    // (divide direct crossings by two, as these crossings will be counted twice)
+    crossings += direct / 2 + indirect;
+  });
+
+  return {crossings, groupCrossings};
 }
 
 /**
@@ -211,70 +290,10 @@ export function countAllCrossings(nodes: Node[]): CrossingsInfo {
   let crossings = 0;
 
   nodes.forEach((node) => {
-    const nodeId = node.getId();
-
     crossings += countCrossingsInNode(node);
-
-    ALIGNMENTS_CLOCKWISE_ORDER.forEach((alignment) => {
-      const relevantDimension = isHorizontalAlignment(alignment)
-        ? ("getPositionX" as const)
-        : ("getPositionY" as const);
-
-      const ports = node
-        .getPorts()
-        .filter((port) => port.getPositionAlignment() === alignment)
-        .sort((a, b) => a.getPositionIndex() - b.getPositionIndex());
-      const oppositePortsPerNode: Record<number, {node: Node; port: Port}[]> = {};
-      ports.forEach((port) => {
-        const trainrunSectionId = port.getTrainrunSectionId();
-        const oppositeNode = port.getOppositeNode(nodeId);
-        const oppositeNodeID = oppositeNode.getId();
-        const oppositePort = oppositeNode
-          .getPorts()
-          .find((p) => p.getTrainrunSectionId() === trainrunSectionId);
-
-        oppositePortsPerNode[oppositeNodeID] = oppositePortsPerNode[oppositeNodeID] || [];
-        oppositePortsPerNode[oppositeNodeID].push({
-          node: oppositeNode,
-          port: oppositePort,
-        });
-      });
-      const oppositeNodes: {node: Node; ports: Port[]}[] = [];
-      for (const nodeId in oppositePortsPerNode) {
-        const node = oppositePortsPerNode[nodeId][0].node;
-        const ports = oppositePortsPerNode[nodeId].map(({port}) => port);
-        oppositeNodes.push({node, ports});
-      }
-
-      const portsTrainrunIDs = ports.map((port) => port.getTrainrunSection().getTrainrunId());
-      const oppositePortsTrainrunIDs = oppositeNodes
-        .toSorted((a, b) => a.node[relevantDimension]() - b.node[relevantDimension]())
-        .map(({ports}) =>
-          ports
-            .toSorted((a, b) => a.getPositionIndex() - b.getPositionIndex())
-            .map((port) => port.getTrainrunSection().getTrainrunId()),
-        );
-
-      // Count crossings:
-      const {direct, indirect} = countCrossingsBetweenSides(
-        portsTrainrunIDs,
-        oppositePortsTrainrunIDs,
-      );
-
-      // Detect contiguous groups of nodes:
-      const contiguous = groupContiguous(oppositePortsTrainrunIDs, portsTrainrunIDs);
-
-      if (direct + indirect) {
-        groupCrossings.push({
-          crossings: direct + indirect,
-          groups: contiguous,
-        });
-      }
-
-      // Add local crossings to total count
-      // (divide direct crossings by two, as these crossings will be counted twice)
-      crossings += direct / 2 + indirect;
-    });
+    const between = countBetweenCrossingsAroundNode(node);
+    crossings += between.crossings;
+    groupCrossings.push(...between.groupCrossings);
   });
 
   return {crossings, groupCrossings: groupCrossings.toSorted((a, b) => b.crossings - a.crossings)};

--- a/src/app/services/util/port-ordering.separations.spec.ts
+++ b/src/app/services/util/port-ordering.separations.spec.ts
@@ -1,0 +1,96 @@
+import {buildNetwork, setPortOrder} from "./port-ordering.test-helpers";
+import {
+  countAllSeparations,
+  countSeparationsBetweenNodes,
+  countSeparationsWithinNode,
+} from "./port-ordering.separations";
+import {countAllCrossings} from "./port-ordering.crossings";
+
+describe("countSeparationsWithinNode", () => {
+  it("returns 0 when a bundle stays together through the node", () => {
+    const {nodesMap, trainrunIDs} = buildNetwork({
+      nodes: {A: {x: 0}, B: {x: 100}, C: {x: 200}},
+      trainruns: [
+        ["A", "B", "C"],
+        ["A", "B", "C"],
+      ],
+    });
+    setPortOrder(nodesMap.get("B"), "left", trainrunIDs);
+    setPortOrder(nodesMap.get("B"), "right", trainrunIDs);
+
+    expect(countSeparationsWithinNode(nodesMap.get("B"))).toBe(0);
+  });
+
+  it("counts a terminating section wedged between a through-bundle as a separation", () => {
+    // T0,T1 run A-B-C through B
+    // T2 ends at B (from D, east), landing between them on B's right
+    const {nodesMap, trainrunIDs} = buildNetwork({
+      nodes: {A: {x: 0, y: 100}, B: {x: 100, y: 100}, C: {x: 200, y: 100}, D: {x: 250, y: 100}},
+      trainruns: [
+        ["A", "B", "C"],
+        ["A", "B", "C"],
+        ["D", "B"],
+      ],
+    });
+    const [t0, t1, t2] = trainrunIDs;
+    setPortOrder(nodesMap.get("B"), "left", [t0, t1]);
+    setPortOrder(nodesMap.get("B"), "right", [t0, t2, t1]);
+
+    // T0 and T1 keep their order through B (no crossing of the pair), yet T2 splits them apart.
+    expect(countSeparationsWithinNode(nodesMap.get("B"))).toBe(1);
+  });
+});
+
+describe("countSeparationsBetweenNodes", () => {
+  it("returns 0 when a link's bundle is aligned at both ends", () => {
+    const {nodesMap, nodesArray, trainrunIDs} = buildNetwork({
+      nodes: {A: {x: 0}, B: {x: 100}},
+      trainruns: [
+        ["A", "B"],
+        ["A", "B"],
+      ],
+    });
+    setPortOrder(nodesMap.get("A"), "right", trainrunIDs);
+    setPortOrder(nodesMap.get("B"), "left", trainrunIDs);
+
+    expect(countSeparationsBetweenNodes(nodesMap.get("A"))).toBe(0);
+    expect(countAllSeparations(nodesArray)).toEqual({within: 0, between: 0});
+  });
+
+  it("treats a pure two-line swap as a crossing, not a separation", () => {
+    const {nodesMap, nodesArray, trainrunIDs} = buildNetwork({
+      nodes: {A: {x: 0}, B: {x: 100}},
+      trainruns: [
+        ["A", "B"],
+        ["A", "B"],
+      ],
+    });
+    setPortOrder(nodesMap.get("A"), "right", trainrunIDs);
+    setPortOrder(nodesMap.get("B"), "left", trainrunIDs.toReversed());
+
+    // Swapped: they cross, but stay adjacent at both ends, so they are not
+    // separated
+    expect(countAllCrossings(nodesArray).crossings).toBe(1);
+    expect(countAllSeparations(nodesArray)).toEqual({within: 0, between: 0});
+  });
+
+  it("counts a terminating section wedged into a link as a separation", () => {
+    // T0,T1 run A-B in parallel
+    // T2 ends at B (from E, further west), wedged between them on B's left,
+    // while T0,T1 keep their relative order along the link
+    const {nodesMap, nodesArray, trainrunIDs} = buildNetwork({
+      nodes: {A: {x: 0, y: 100}, B: {x: 100, y: 100}, E: {x: -100, y: 100}},
+      trainruns: [
+        ["A", "B"],
+        ["A", "B"],
+        ["E", "B"],
+      ],
+    });
+    const [t0, t1, t2] = trainrunIDs;
+    setPortOrder(nodesMap.get("A"), "right", [t0, t1]);
+    setPortOrder(nodesMap.get("B"), "left", [t0, t2, t1]);
+
+    expect(countSeparationsBetweenNodes(nodesMap.get("A"))).toBe(1);
+    expect(countAllSeparations(nodesArray)).toEqual({within: 0, between: 1});
+  });
+});

--- a/src/app/services/util/port-ordering.separations.ts
+++ b/src/app/services/util/port-ordering.separations.ts
@@ -18,11 +18,13 @@ import {ALIGNMENTS_CLOCKWISE_ORDER} from "./port-ordering.helpers";
 const areAdjacent = (a: Port, b: Port): boolean =>
   Math.abs(a.getPositionIndex() - b.getPositionIndex()) === 1;
 
+const trainrunIdOf = (port: Port): number => port.getTrainrunSection().getTrainrunId();
+
 /**
- * Counts separations within a single node: pairs of transitions running between the same two sides
- * that are adjacent on one of those sides but not the other.
+ * Within a single node, returns the trainrun-ID pairs whose transitions run between the same two
+ * sides but are adjacent on only one of them (a bundle split apart by something wedged between).
  */
-export function countSeparationsWithinNode(node: Node): number {
+export function getSeparationPairsWithinNode(node: Node): [number, number][] {
   // Each transition spanning two distinct sides, as a map: side -> its port on that side.
   const transitions = node
     .getTransitions()
@@ -36,7 +38,7 @@ export function countSeparationsWithinNode(node: Node): number {
     })
     .filter((sides) => sides.size === 2);
 
-  let separations = 0;
+  const pairs: [number, number][] = [];
   for (let i = 0; i < transitions.length - 1; i++) {
     for (let j = i + 1; j < transitions.length; j++) {
       const a = transitions[i];
@@ -48,20 +50,20 @@ export function countSeparationsWithinNode(node: Node): number {
         areAdjacent(a.get(sides[0]), b.get(sides[0])) !==
         areAdjacent(a.get(sides[1]), b.get(sides[1]))
       ) {
-        separations++;
+        pairs.push([trainrunIdOf(a.get(sides[0])), trainrunIdOf(b.get(sides[0]))]);
       }
     }
   }
-  return separations;
+  return pairs;
 }
 
 /**
- * Counts separations on links incident to `node`: pairs of sections leaving toward the same
- * opposite node, adjacent at this end of the link but not the other (or vice versa).
+ * On links incident to `node`, returns the trainrun-ID pairs leaving toward the same opposite node,
+ * adjacent at this end of the link but not the other (or vice versa).
  */
-export function countSeparationsBetweenNodes(node: Node): number {
+export function getSeparationPairsBetweenNodes(node: Node): [number, number][] {
   const nodeId = node.getId();
-  let separations = 0;
+  const pairs: [number, number][] = [];
 
   ALIGNMENTS_CLOCKWISE_ORDER.forEach((alignment) => {
     const sidePorts = node.getPorts().filter((p) => p.getPositionAlignment() === alignment);
@@ -83,12 +85,22 @@ export function countSeparationsBetweenNodes(node: Node): number {
         );
         if (!aOpposite || !bOpposite) continue;
 
-        if (areAdjacent(a, b) !== areAdjacent(aOpposite, bOpposite)) separations++;
+        if (areAdjacent(a, b) !== areAdjacent(aOpposite, bOpposite)) {
+          pairs.push([trainrunIdOf(a), trainrunIdOf(b)]);
+        }
       }
     }
   });
 
-  return separations;
+  return pairs;
+}
+
+export function countSeparationsWithinNode(node: Node): number {
+  return getSeparationPairsWithinNode(node).length;
+}
+
+export function countSeparationsBetweenNodes(node: Node): number {
+  return getSeparationPairsBetweenNodes(node).length;
 }
 
 /**

--- a/src/app/services/util/port-ordering.separations.ts
+++ b/src/app/services/util/port-ordering.separations.ts
@@ -1,0 +1,107 @@
+import {Node} from "../../models/node.model";
+import {Port} from "../../models/port.model";
+import {PortAlignment} from "../../data-structures/technical.data.structures";
+import {ALIGNMENTS_CLOCKWISE_ORDER} from "./port-ordering.helpers";
+
+/**
+ * A "separation" happens when two trainrun sections that are drawn touching (adjacent on a node
+ * side) get pulled apart, because a third section sits between them. Unlike a crossing, the two
+ * sections need not swap order. Separations measure how well parallel bundles of lines stay
+ * together.
+ *
+ * Two kinds are counted separately, so callers can weight them independently:
+ * - within a node: a pair enters bundled on one side and leaves split on another (across transitions)
+ * - between nodes: a pair is bundled at one end of a link and split at the other end
+ */
+
+// Two ports are adjacent on their side iff their (contiguous, per-side) indices differ by one.
+const areAdjacent = (a: Port, b: Port): boolean =>
+  Math.abs(a.getPositionIndex() - b.getPositionIndex()) === 1;
+
+/**
+ * Counts separations within a single node: pairs of transitions running between the same two sides
+ * that are adjacent on one of those sides but not the other.
+ */
+export function countSeparationsWithinNode(node: Node): number {
+  // Each transition spanning two distinct sides, as a map: side -> its port on that side.
+  const transitions = node
+    .getTransitions()
+    .map((t) => {
+      const p1 = node.getPort(t.getPortId1());
+      const p2 = node.getPort(t.getPortId2());
+      return new Map<PortAlignment, Port>([
+        [p1.getPositionAlignment(), p1],
+        [p2.getPositionAlignment(), p2],
+      ]);
+    })
+    .filter((sides) => sides.size === 2);
+
+  let separations = 0;
+  for (let i = 0; i < transitions.length - 1; i++) {
+    for (let j = i + 1; j < transitions.length; j++) {
+      const a = transitions[i];
+      const b = transitions[j];
+      const sides = [...a.keys()];
+      // Only pairs sharing the very same two sides form a bundle running through the node:
+      if (!sides.every((side) => b.has(side))) continue;
+      if (
+        areAdjacent(a.get(sides[0]), b.get(sides[0])) !==
+        areAdjacent(a.get(sides[1]), b.get(sides[1]))
+      ) {
+        separations++;
+      }
+    }
+  }
+  return separations;
+}
+
+/**
+ * Counts separations on links incident to `node`: pairs of sections leaving toward the same
+ * opposite node, adjacent at this end of the link but not the other (or vice versa).
+ */
+export function countSeparationsBetweenNodes(node: Node): number {
+  const nodeId = node.getId();
+  let separations = 0;
+
+  ALIGNMENTS_CLOCKWISE_ORDER.forEach((alignment) => {
+    const sidePorts = node.getPorts().filter((p) => p.getPositionAlignment() === alignment);
+
+    for (let i = 0; i < sidePorts.length - 1; i++) {
+      for (let j = i + 1; j < sidePorts.length; j++) {
+        const a = sidePorts[i];
+        const b = sidePorts[j];
+
+        const oppositeNode = a.getOppositeNode(nodeId);
+        if (oppositeNode.getId() !== b.getOppositeNode(nodeId).getId()) continue;
+
+        const oppositePorts = oppositeNode.getPorts();
+        const aOpposite = oppositePorts.find(
+          (p) => p.getTrainrunSectionId() === a.getTrainrunSectionId(),
+        );
+        const bOpposite = oppositePorts.find(
+          (p) => p.getTrainrunSectionId() === b.getTrainrunSectionId(),
+        );
+        if (!aOpposite || !bOpposite) continue;
+
+        if (areAdjacent(a, b) !== areAdjacent(aOpposite, bOpposite)) separations++;
+      }
+    }
+  });
+
+  return separations;
+}
+
+/**
+ * Aggregates separations across a set of nodes, returning within-node and between-node counts
+ * separately so they can be weighted independently. Between-node separations are halved, as each
+ * link is counted once from each of its two endpoints.
+ */
+export function countAllSeparations(nodes: Node[]): {within: number; between: number} {
+  let within = 0;
+  let between = 0;
+  nodes.forEach((node) => {
+    within += countSeparationsWithinNode(node);
+    between += countSeparationsBetweenNodes(node);
+  });
+  return {within, between: between / 2};
+}

--- a/src/app/view/editor-edit-tools-view-component/editor-edit-tools-view.component.ts
+++ b/src/app/view/editor-edit-tools-view-component/editor-edit-tools-view.component.ts
@@ -46,7 +46,12 @@ export class EditorEditToolsViewComponent implements OnDestroy {
     {
       name: $localize`:@@app.view.editor-edit-tools-view-component.crossingAwareOrdering:Crossing aware`,
       title: $localize`:@@app.view.editor-edit-tools-view-component.crossingAwareOrderingTooltip:Minimizes crossings of trainruns within the nodes.`,
-      orderingAlgorithm: OrderingAlgorithm.CrossingAware,
+      orderingAlgorithm: OrderingAlgorithm.ClutterAware,
+    },
+    {
+      name: $localize`:@@app.view.editor-edit-tools-view-component.crossingAwarePushOrdering:Crossing aware (push crossings into nodes)`,
+      title: $localize`:@@app.view.editor-edit-tools-view-component.crossingAwarePushOrderingTooltip:Minimizes crossings of trainruns, moving them into the nodes to keep parallel trainruns bundled.`,
+      orderingAlgorithm: OrderingAlgorithm.ClutterAwarePushCrossings,
     },
   ];
   activeOrderingAlgorithm: OrderingAlgorithm = null;

--- a/src/app/view/editor-edit-tools-view-component/editor-edit-tools-view.component.ts
+++ b/src/app/view/editor-edit-tools-view-component/editor-edit-tools-view.component.ts
@@ -47,7 +47,12 @@ export class EditorEditToolsViewComponent implements OnDestroy {
     {
       name: $localize`:@@app.view.editor-edit-tools-view-component.crossingAwareOrdering:Crossing aware`,
       title: $localize`:@@app.view.editor-edit-tools-view-component.crossingAwareOrderingTooltip:Minimizes crossings of trainruns within the nodes.`,
-      orderingAlgorithm: OrderingAlgorithm.CrossingAware,
+      orderingAlgorithm: OrderingAlgorithm.ClutterAware,
+    },
+    {
+      name: $localize`:@@app.view.editor-edit-tools-view-component.crossingAwarePushOrdering:Crossing aware (push crossings into nodes)`,
+      title: $localize`:@@app.view.editor-edit-tools-view-component.crossingAwarePushOrderingTooltip:Minimizes crossings of trainruns, moving them into the nodes to keep parallel trainruns bundled.`,
+      orderingAlgorithm: OrderingAlgorithm.ClutterAwarePushCrossings,
     },
   ];
   activeOrderingAlgorithm: OrderingAlgorithm = null;

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -342,6 +342,8 @@
         "alphabeticalOrderingTooltip": "Ports anhand der Zugkategorien alphabetisch anordnen.",
         "crossingAwareOrdering": "Kreuzungsbewusst",
         "crossingAwareOrderingTooltip": "Minimiert Kreuzungen von Zugfahrten innerhalb der Knoten.",
+        "crossingAwarePushOrdering": "Kreuzungsbewusst (Kreuzungen in die Knoten verschieben)",
+        "crossingAwarePushOrderingTooltip": "Minimiert Kreuzungen von Zugfahrten und verschiebt sie in die Knoten, damit parallele Zugfahrten gebündelt bleiben.",
         "delete": "Löschen",
         "on-clear-delete-all-non-visible-elements": "Sollen alle nicht sichtbare Elemente aus der Netzgrafik definitiv gelöscht werden?",
         "on-clear-delete-all-visible-elements": "Sollen alle sichtbare Elemente aus der Netzgrafik definitiv gelöscht werden?",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -347,6 +347,8 @@
         "alphabeticalOrderingTooltip": "Ports anhand der Zugkategorien alphabetisch anordnen.",
         "crossingAwareOrdering": "Kreuzungsbewusst",
         "crossingAwareOrderingTooltip": "Minimiert Kreuzungen von Zugfahrten innerhalb der Knoten.",
+        "crossingAwarePushOrdering": "Kreuzungsbewusst (Kreuzungen in die Knoten verschieben)",
+        "crossingAwarePushOrderingTooltip": "Minimiert Kreuzungen von Zugfahrten und verschiebt sie in die Knoten, damit parallele Zugfahrten gebündelt bleiben.",
         "delete": "Löschen",
         "on-clear-delete-all-non-visible-elements": "Sollen alle nicht sichtbare Elemente aus der Netzgrafik definitiv gelöscht werden?",
         "on-clear-delete-all-visible-elements": "Sollen alle sichtbare Elemente aus der Netzgrafik definitiv gelöscht werden?",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -342,6 +342,8 @@
         "alphabeticalOrderingTooltip": "Order ports alphabetically by train categories.",
         "crossingAwareOrdering": "Crossing aware",
         "crossingAwareOrderingTooltip": "Minimizes crossings of trainruns within the nodes.",
+        "crossingAwarePushOrdering": "Crossing aware (push crossings into nodes)",
+        "crossingAwarePushOrderingTooltip": "Minimizes crossings of trainruns, moving them into the nodes to keep parallel trainruns bundled.",
         "delete": "Delete",
         "on-clear-delete-all-non-visible-elements": "Should all non-visible elements be permanently deleted from the netzgrafik?",
         "on-clear-delete-all-visible-elements": "Should all visible elements be permanently deleted from the netzgrafik?",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -347,6 +347,8 @@
         "alphabeticalOrderingTooltip": "Order ports alphabetically by train categories.",
         "crossingAwareOrdering": "Crossing aware",
         "crossingAwareOrderingTooltip": "Minimizes crossings of trainruns within the nodes.",
+        "crossingAwarePushOrdering": "Crossing aware (push crossings into nodes)",
+        "crossingAwarePushOrderingTooltip": "Minimizes crossings of trainruns, moving them into the nodes to keep parallel trainruns bundled.",
         "delete": "Delete",
         "on-clear-delete-all-non-visible-elements": "Should all non-visible elements be permanently deleted from the netzgrafik?",
         "on-clear-delete-all-visible-elements": "Should all visible elements be permanently deleted from the netzgrafik?",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -342,6 +342,8 @@
         "alphabeticalOrderingTooltip": "Ordonne les ports par ordre alphabétique des catégories de train.",
         "crossingAwareOrdering": "Réduction des croisements",
         "crossingAwareOrderingTooltip": "Minimise les croisements des trajets à l'intérieur des noeuds.",
+        "crossingAwarePushOrdering": "Réduction des croisements (concentrés dans les noeuds)",
+        "crossingAwarePushOrderingTooltip": "Minimise les croisements des trajets en les concentrant dans les noeuds pour garder les trajets parallèles groupés.",
         "delete": "Supprimer",
         "on-clear-delete-all-non-visible-elements": "Tous les éléments non visibles doivent-ils être définitivement supprimés du réticulaire ?",
         "on-clear-delete-all-visible-elements": "Tous les éléments visibles doivent-ils être définitivement supprimés du réticulaire ?",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -347,6 +347,8 @@
         "alphabeticalOrderingTooltip": "Ordonne les ports par ordre alphabétique des catégories de train.",
         "crossingAwareOrdering": "Réduction des croisements",
         "crossingAwareOrderingTooltip": "Minimise les croisements des trajets à l'intérieur des noeuds.",
+        "crossingAwarePushOrdering": "Réduction des croisements (concentrés dans les noeuds)",
+        "crossingAwarePushOrderingTooltip": "Minimise les croisements des trajets en les concentrant dans les noeuds pour garder les trajets parallèles groupés.",
         "delete": "Supprimer",
         "on-clear-delete-all-non-visible-elements": "Tous les éléments non visibles doivent-ils être définitivement supprimés du réticulaire ?",
         "on-clear-delete-all-visible-elements": "Tous les éléments visibles doivent-ils être définitivement supprimés du réticulaire ?",

--- a/src/benchmarks/port-ordering.benchmark.spec.ts
+++ b/src/benchmarks/port-ordering.benchmark.spec.ts
@@ -1,0 +1,216 @@
+// Benchmarks the port-ordering optimizer's quality: for each dataset and each weight setup, it
+// compares the clutter of the optimized solution against the alphabetical baseline (default order),
+// scored under the same weights.
+
+import {DataService} from "../app/services/data/data.service";
+import {NodeService} from "../app/services/data/node.service";
+import {ResourceService} from "../app/services/data/resource.service";
+import {TrainrunService} from "../app/services/data/trainrun.service";
+import {TrainrunSectionService} from "../app/services/data/trainrunsection.service";
+import {BaseDataService} from "../app/services/data/basedata.service";
+import {NoteService} from "../app/services/data/note.service";
+import {LogService} from "../app/logger/log.service";
+import {LogPublishersService} from "../app/logger/log.publishers.service";
+import {LabelGroupService} from "../app/services/data/labelgroup.service";
+import {LabelService} from "../app/services/data/label.service";
+import {FilterService} from "../app/services/ui/filter.service";
+import {NetzgrafikColoringService} from "../app/services/data/netzgrafikColoring.service";
+
+import {OrderingAlgorithm} from "../app/data-structures/technical.data.structures";
+import {ClutterWeights, optimizePorts} from "../app/services/util/port-ordering.algo";
+import {
+  countAllCrossings,
+  countCrossingsInNode,
+} from "../app/services/util/port-ordering.crossings";
+import {countAllSeparations} from "../app/services/util/port-ordering.separations";
+import {Node} from "../app/models/node.model";
+
+import demoStandaloneGithub from "../app/sample-netzgrafik/netzgrafik_demo_standalone_github.json";
+import demoOlLz from "../app/sample-netzgrafik/Demo_OL_LZ.json";
+
+const DATASETS: {name: string; dto: unknown}[] = [
+  {name: "demo_standalone_github", dto: demoStandaloneGithub},
+  {name: "Demo_OL_LZ", dto: demoOlLz},
+];
+
+// Weight setups to compare, each steering the optimizer toward a different clutter trade-off:
+const SETUPS: {name: string; weights: ClutterWeights}[] = [
+  {
+    name: "balanced",
+    weights: {
+      crossingsWithin: 1,
+      crossingsBetween: 1,
+      separationsWithin: 1,
+      separationsBetween: 1,
+    },
+  },
+  {
+    name: "crossings-first",
+    weights: {
+      crossingsWithin: 1,
+      crossingsBetween: 1,
+      separationsWithin: 0.2,
+      separationsBetween: 0.2,
+    },
+  },
+  {
+    name: "separations-first",
+    weights: {
+      crossingsWithin: 0.2,
+      crossingsBetween: 0.2,
+      separationsWithin: 1,
+      separationsBetween: 1,
+    },
+  },
+  {
+    name: "within-first",
+    weights: {
+      crossingsWithin: 1,
+      crossingsBetween: 0.2,
+      separationsWithin: 1,
+      separationsBetween: 0.2,
+    },
+  },
+  {
+    name: "between-first",
+    weights: {
+      crossingsWithin: 0.2,
+      crossingsBetween: 1,
+      separationsWithin: 0.2,
+      separationsBetween: 1,
+    },
+  },
+];
+
+type Clutter = {
+  crossingsWithin: number;
+  crossingsBetween: number;
+  separationsWithin: number;
+  separationsBetween: number;
+};
+
+const measureClutter = (nodes: Node[]): Clutter => {
+  const crossingsWithin = nodes.reduce((sum, node) => sum + countCrossingsInNode(node), 0);
+  const {within: separationsWithin, between: separationsBetween} = countAllSeparations(nodes);
+  return {
+    crossingsWithin,
+    crossingsBetween: countAllCrossings(nodes).crossings - crossingsWithin,
+    separationsWithin,
+    separationsBetween,
+  };
+};
+
+const scoreClutter = (c: Clutter, w: ClutterWeights): number =>
+  c.crossingsWithin * w.crossingsWithin +
+  c.crossingsBetween * w.crossingsBetween +
+  c.separationsWithin * w.separationsWithin +
+  c.separationsBetween * w.separationsBetween;
+
+// Renders rows as an aligned text table, each column padded to its widest cell (header included):
+const formatTable = <T>(
+  columns: {header: string; value: (row: T) => string}[],
+  rows: T[],
+): string => {
+  const widths = columns.map((col) =>
+    Math.max(col.header.length, ...rows.map((row) => col.value(row).length)),
+  );
+  const renderCells = (cells: string[]) =>
+    cells.map((cell, i) => cell.padStart(widths[i])).join("  ");
+  return [
+    renderCells(columns.map((col) => col.header)),
+    ...rows.map((row) => renderCells(columns.map((col) => col.value(row)))),
+  ].join("\n");
+};
+
+type BenchmarkRow = {setup: string; alphaScore: number; optScore: number; optimized: Clutter};
+
+const createServices = (): {dataService: DataService; nodeService: NodeService} => {
+  const logService = new LogService(new LogPublishersService());
+  const labelGroupService = new LabelGroupService(logService);
+  const labelService = new LabelService(logService, labelGroupService);
+  const filterService = new FilterService(labelService, labelGroupService);
+  const trainrunService = new TrainrunService(logService, labelService, filterService);
+  const trainrunSectionService = new TrainrunSectionService(
+    logService,
+    trainrunService,
+    filterService,
+  );
+  const nodeService = new NodeService(
+    logService,
+    new ResourceService(),
+    trainrunService,
+    trainrunSectionService,
+    labelService,
+    filterService,
+  );
+  const dataService = new DataService(
+    new ResourceService(),
+    nodeService,
+    trainrunSectionService,
+    trainrunService,
+    new BaseDataService(),
+    new NoteService(logService, labelService, filterService),
+    labelService,
+    labelGroupService,
+    filterService,
+    new NetzgrafikColoringService(logService),
+  );
+  return {dataService, nodeService};
+};
+
+// Loads the dataset and applies the alphabetical (default) ordering, returning the node store:
+const loadAlphabetical = (
+  dataService: DataService,
+  nodeService: NodeService,
+  dto: unknown,
+): Node[] => {
+  dataService.loadNetzgrafikDto(structuredClone(dto) as any);
+  nodeService.initPortOrdering(OrderingAlgorithm.Alphabetical);
+  return nodeService.nodesStore.nodes;
+};
+
+describe("port-ordering benchmark", () => {
+  it("scores the optimizer against the alphabetical baseline across datasets and weight setups", async () => {
+    for (const {name, dto} of DATASETS) {
+      const {dataService, nodeService} = createServices();
+
+      // Alphabetical baseline clutter (same order for every setup, only the weighting differs):
+      const baseline = measureClutter(loadAlphabetical(dataService, nodeService, dto));
+      const trainruns = (dto as {trainruns?: unknown[]}).trainruns?.length ?? 0;
+      const nodeCount = nodeService.nodesStore.nodes.length;
+
+      const rows: BenchmarkRow[] = [];
+      for (const setup of SETUPS) {
+        // Re-optimize from a fresh alphabetical order for each setup:
+        const nodes = loadAlphabetical(dataService, nodeService, dto);
+        optimizePorts(nodes, setup.weights);
+        const optimized = measureClutter(nodes);
+
+        rows.push({
+          setup: setup.name,
+          alphaScore: scoreClutter(baseline, setup.weights),
+          optScore: scoreClutter(optimized, setup.weights),
+          optimized,
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+
+      const table = formatTable<BenchmarkRow>(
+        [
+          {header: "setup", value: (r) => r.setup},
+          {header: "Alpha order", value: (r) => r.alphaScore.toFixed(1)},
+          {header: "Resolved order", value: (r) => r.optScore.toFixed(1)},
+          {header: "cW/cB/sW/sB", value: ({optimized: o}) => `${o.crossingsWithin}/${o.crossingsBetween}/${o.separationsWithin}/${o.separationsBetween}`}, // prettier-ignore
+        ],
+        rows,
+      );
+
+      console.log(
+        `\ndataset: ${name} (${nodeCount} nodes, ${trainruns} trainruns)\n` +
+          `alphabetical baseline: crossings ${baseline.crossingsWithin}w/${baseline.crossingsBetween}b, separations ${baseline.separationsWithin}w/${baseline.separationsBetween}b\n\n` +
+          table,
+      );
+    }
+  }, 600000);
+});

--- a/src/benchmarks/port-ordering.benchmark.spec.ts
+++ b/src/benchmarks/port-ordering.benchmark.spec.ts
@@ -1,0 +1,216 @@
+// Benchmarks the port-ordering optimizer's quality: for each dataset and each weight setup, it
+// compares the clutter of the optimized solution against the alphabetical baseline (default order),
+// scored under the same weights.
+
+import {DataService} from "../app/services/data/data.service";
+import {NodeService} from "../app/services/data/node.service";
+import {ResourceService} from "../app/services/data/resource.service";
+import {TrainrunService} from "../app/services/data/trainrun.service";
+import {TrainrunSectionService} from "../app/services/data/trainrunsection.service";
+import {BaseDataService} from "../app/services/data/basedata.service";
+import {NoteService} from "../app/services/data/note.service";
+import {LogService} from "../app/logger/log.service";
+import {LogPublishersService} from "../app/logger/log.publishers.service";
+import {LabelGroupService} from "../app/services/data/labelgroup.service";
+import {LabelService} from "../app/services/data/label.service";
+import {FilterService} from "../app/services/ui/filter.service";
+import {NetzgrafikColoringService} from "../app/services/data/netzgrafikColoring.service";
+
+import {OrderingAlgorithm} from "../app/data-structures/technical.data.structures";
+import {ClutterWeights, optimizePorts} from "../app/services/util/port-ordering.algo";
+import {
+  countAllCrossings,
+  countCrossingsInNode,
+} from "../app/services/util/port-ordering.crossings";
+import {countAllSeparations} from "../app/services/util/port-ordering.separations";
+import {Node} from "../app/models/node.model";
+
+import demoStandaloneGithub from "../app/sample-netzgrafik/netzgrafik_demo_standalone_github.json";
+import demoOlLz from "../app/sample-netzgrafik/Demo_OL_LZ.json";
+
+const DATASETS: {name: string; dto: unknown}[] = [
+  {name: "demo_standalone_github", dto: demoStandaloneGithub},
+  {name: "Demo_OL_LZ", dto: demoOlLz},
+];
+
+// Weight setups to compare, each steering the optimizer toward a different clutter trade-off:
+const SETUPS: {name: string; weights: ClutterWeights}[] = [
+  {
+    name: "balanced",
+    weights: {
+      crossingsWithin: 1,
+      crossingsBetween: 1,
+      separationsWithin: 1,
+      separationsBetween: 1,
+    },
+  },
+  {
+    name: "crossings-first",
+    weights: {
+      crossingsWithin: 1,
+      crossingsBetween: 1,
+      separationsWithin: 0.2,
+      separationsBetween: 0.2,
+    },
+  },
+  {
+    name: "separations-first",
+    weights: {
+      crossingsWithin: 0.2,
+      crossingsBetween: 0.2,
+      separationsWithin: 1,
+      separationsBetween: 1,
+    },
+  },
+  {
+    name: "within-first",
+    weights: {
+      crossingsWithin: 1,
+      crossingsBetween: 0.2,
+      separationsWithin: 1,
+      separationsBetween: 0.2,
+    },
+  },
+  {
+    name: "between-first",
+    weights: {
+      crossingsWithin: 0.2,
+      crossingsBetween: 1,
+      separationsWithin: 0.2,
+      separationsBetween: 1,
+    },
+  },
+];
+
+type Clutter = {
+  crossingsWithin: number;
+  crossingsBetween: number;
+  separationsWithin: number;
+  separationsBetween: number;
+};
+
+const measureClutter = (nodes: Node[]): Clutter => {
+  const crossingsWithin = nodes.reduce((sum, node) => sum + countCrossingsInNode(node), 0);
+  const {within: separationsWithin, between: separationsBetween} = countAllSeparations(nodes);
+  return {
+    crossingsWithin,
+    crossingsBetween: countAllCrossings(nodes).crossings - crossingsWithin,
+    separationsWithin,
+    separationsBetween,
+  };
+};
+
+const scoreClutter = (c: Clutter, w: ClutterWeights): number =>
+  c.crossingsWithin * w.crossingsWithin +
+  c.crossingsBetween * w.crossingsBetween +
+  c.separationsWithin * w.separationsWithin +
+  c.separationsBetween * w.separationsBetween;
+
+// Renders rows as an aligned text table, each column padded to its widest cell (header included):
+const formatTable = <T>(
+  columns: {header: string; value: (row: T) => string}[],
+  rows: T[],
+): string => {
+  const widths = columns.map((col) =>
+    Math.max(col.header.length, ...rows.map((row) => col.value(row).length)),
+  );
+  const renderCells = (cells: string[]) =>
+    cells.map((cell, i) => cell.padStart(widths[i])).join("  ");
+  return [
+    renderCells(columns.map((col) => col.header)),
+    ...rows.map((row) => renderCells(columns.map((col) => col.value(row)))),
+  ].join("\n");
+};
+
+type BenchmarkRow = {setup: string; alphaScore: number; optScore: number; optimized: Clutter};
+
+const createServices = (): {dataService: DataService; nodeService: NodeService} => {
+  const logService = new LogService(new LogPublishersService());
+  const labelGroupService = new LabelGroupService(logService);
+  const labelService = new LabelService(logService, labelGroupService);
+  const filterService = new FilterService(labelService, labelGroupService);
+  const trainrunService = new TrainrunService(logService, labelService, filterService);
+  const trainrunSectionService = new TrainrunSectionService(
+    logService,
+    trainrunService,
+    filterService,
+  );
+  const nodeService = new NodeService(
+    logService,
+    new ResourceService(),
+    trainrunService,
+    trainrunSectionService,
+    labelService,
+    filterService,
+  );
+  const dataService = new DataService(
+    new ResourceService(),
+    nodeService,
+    trainrunSectionService,
+    trainrunService,
+    new BaseDataService(),
+    new NoteService(logService, labelService, filterService),
+    labelService,
+    labelGroupService,
+    filterService,
+    new NetzgrafikColoringService(),
+  );
+  return {dataService, nodeService};
+};
+
+// Loads the dataset and applies the alphabetical (default) ordering, returning the node store:
+const loadAlphabetical = (
+  dataService: DataService,
+  nodeService: NodeService,
+  dto: unknown,
+): Node[] => {
+  dataService.loadNetzgrafikDto(structuredClone(dto) as any);
+  nodeService.initPortOrdering(OrderingAlgorithm.Alphabetical);
+  return nodeService.nodesStore.nodes;
+};
+
+describe("port-ordering benchmark", () => {
+  it("scores the optimizer against the alphabetical baseline across datasets and weight setups", async () => {
+    for (const {name, dto} of DATASETS) {
+      const {dataService, nodeService} = createServices();
+
+      // Alphabetical baseline clutter (same order for every setup, only the weighting differs):
+      const baseline = measureClutter(loadAlphabetical(dataService, nodeService, dto));
+      const trainruns = (dto as {trainruns?: unknown[]}).trainruns?.length ?? 0;
+      const nodeCount = nodeService.nodesStore.nodes.length;
+
+      const rows: BenchmarkRow[] = [];
+      for (const setup of SETUPS) {
+        // Re-optimize from a fresh alphabetical order for each setup:
+        const nodes = loadAlphabetical(dataService, nodeService, dto);
+        optimizePorts(nodes, setup.weights);
+        const optimized = measureClutter(nodes);
+
+        rows.push({
+          setup: setup.name,
+          alphaScore: scoreClutter(baseline, setup.weights),
+          optScore: scoreClutter(optimized, setup.weights),
+          optimized,
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+
+      const table = formatTable<BenchmarkRow>(
+        [
+          {header: "setup", value: (r) => r.setup},
+          {header: "Alpha order", value: (r) => r.alphaScore.toFixed(1)},
+          {header: "Resolved order", value: (r) => r.optScore.toFixed(1)},
+          {header: "cW/cB/sW/sB", value: ({optimized: o}) => `${o.crossingsWithin}/${o.crossingsBetween}/${o.separationsWithin}/${o.separationsBetween}`}, // prettier-ignore
+        ],
+        rows,
+      );
+
+      console.log(
+        `\ndataset: ${name} (${nodeCount} nodes, ${trainruns} trainruns)\n` +
+          `alphabetical baseline: crossings ${baseline.crossingsWithin}w/${baseline.crossingsBetween}b, separations ${baseline.separationsWithin}w/${baseline.separationsBetween}b\n\n` +
+          table,
+      );
+    }
+  }, 600000);
+});


### PR DESCRIPTION
This PR should be merged after #1180.

It implements different features to ultimately improve the crossing-aware port-ordering algorithm:

1. There are now two identified types of **clutter**: crossings (already there), and **separations** (two sections that are drawn adjacent at one place but pulled apart at another, eigher within a node or along a link).
2. The candidates generation now tries to address multiple group clutters at once.
3. The optimizer can now accept some crossings within nodes, in order to reduce the crossings between the nodes.
4. The users now can toggle a checkbox, to try moving the clutters from between nodes to within nodes.
5. There is a new `npm run benchmark` task, that runs the optimizer under different weight setups on some sample datasets, and compares the resulting orderings to the alphabetical baseline.
