### PR TITLE
951 infinity loop on iterator

### DIFF
--- a/src/app/models/node.model.ts
+++ b/src/app/models/node.model.ts
@@ -620,12 +620,13 @@ export class Node {
     return this.getTransitionFromId(transitionId).getIsNonStopTransit();
   }
 
-  removePort(trainrunSection: TrainrunSection) {
-    let portId = trainrunSection.getSourcePortId();
-    if (this.getId() === trainrunSection.getTargetNodeId()) {
-      portId = trainrunSection.getTargetPortId();
+  removePort(trainrunSection: TrainrunSection) { 
+    if (this.getId() === trainrunSection.getSourceNodeId()) {
+      this.ports = this.ports.filter((port) => port.getId() !== trainrunSection.getSourcePortId());
     }
-    this.ports = this.ports.filter((port) => port.getId() !== portId);
+    if (this.getId() === trainrunSection.getTargetNodeId()) { 
+      this.ports = this.ports.filter((port) => port.getId() !== trainrunSection.getTargetPortId());
+    }
   }
 
   removeTransition(trainrunSection: TrainrunSection) {

--- a/src/app/models/node.model.ts
+++ b/src/app/models/node.model.ts
@@ -620,11 +620,11 @@ export class Node {
     return this.getTransitionFromId(transitionId).getIsNonStopTransit();
   }
 
-  removePort(trainrunSection: TrainrunSection) { 
+  removePort(trainrunSection: TrainrunSection) {
     if (this.getId() === trainrunSection.getSourceNodeId()) {
       this.ports = this.ports.filter((port) => port.getId() !== trainrunSection.getSourcePortId());
     }
-    if (this.getId() === trainrunSection.getTargetNodeId()) { 
+    if (this.getId() === trainrunSection.getTargetNodeId()) {
       this.ports = this.ports.filter((port) => port.getId() !== trainrunSection.getTargetPortId());
     }
   }

--- a/src/app/services/data/data.service.spec.ts
+++ b/src/app/services/data/data.service.spec.ts
@@ -57,10 +57,7 @@ describe("DataService", () => {
       trainrunId: orphanTrainrunId,
     });
 
-    DataMigration.ensureAllTrainrunSectionsHaveDiffertSourceAndTargetNodes(
-      dto,
-      logger as any,
-    );
+    DataMigration.ensureAllTrainrunSectionsHaveDiffertSourceAndTargetNodes(dto, logger as any);
 
     expect(dto.trainrunSections.some((section) => section.id === invalidSectionId)).toBeFalse();
     expect(node.ports.some((port) => port.id === invalidPortId1)).toBeFalse();

--- a/src/app/services/data/data.service.spec.ts
+++ b/src/app/services/data/data.service.spec.ts
@@ -1,0 +1,74 @@
+import {DataService} from "./data.service";
+import {NetzgrafikUnitTesting} from "../../../integration-testing/netzgrafik.unit.testing";
+import {DataMigration} from "../../utils/data-migration";
+
+describe("DataService", () => {
+  it("ensureAllTrainrunSectionsHaveDiffertSourceAndTargetNodes removes invalid sections and related node links", () => {
+    const dataService = Object.create(DataService.prototype) as DataService;
+    const logger = {error: jasmine.createSpy("error")};
+    (dataService as any).logger = logger;
+
+    const localizeFn =
+      (globalThis as any).$localize ||
+      ((strings: TemplateStringsArray, ...expressions: unknown[]) =>
+        strings.reduce(
+          (acc, part, index) => acc + (index > 0 ? String(expressions[index - 1]) : "") + part,
+          "",
+        ));
+    (globalThis as any).$localize = localizeFn;
+
+    const dto = NetzgrafikUnitTesting.getUnitTestNetzgrafik();
+    const node = dto.nodes[0];
+
+    const maxSectionId = Math.max(...dto.trainrunSections.map((section) => section.id));
+    const maxPortId = Math.max(...dto.nodes.flatMap((n) => n.ports.map((port) => port.id)));
+    const maxTransitionId = Math.max(
+      ...dto.nodes.flatMap((n) => n.transitions.map((transition) => transition.id)),
+    );
+    const maxTrainrunId = Math.max(...dto.trainruns.map((trainrun) => trainrun.id));
+
+    const invalidSectionId = maxSectionId + 1;
+    const orphanTrainrunId = maxTrainrunId + 1;
+    const invalidPortId1 = maxPortId + 1;
+    const invalidPortId2 = maxPortId + 2;
+    const invalidTransitionId = maxTransitionId + 1;
+
+    const portTemplate = node.ports[0];
+    node.ports.push({...portTemplate, id: invalidPortId1, trainrunSectionId: invalidSectionId});
+    node.ports.push({...portTemplate, id: invalidPortId2, trainrunSectionId: invalidSectionId});
+    node.transitions.push({
+      id: invalidTransitionId,
+      port1Id: invalidPortId1,
+      port2Id: invalidPortId2,
+      isNonStopTransit: false,
+    });
+
+    const trainrunTemplate = dto.trainruns[0];
+    dto.trainruns.push({...trainrunTemplate, id: orphanTrainrunId, name: "orphan-trainrun"});
+
+    const sectionTemplate = dto.trainrunSections[0];
+    dto.trainrunSections.push({
+      ...sectionTemplate,
+      id: invalidSectionId,
+      sourceNodeId: node.id,
+      targetNodeId: node.id,
+      sourcePortId: invalidPortId1,
+      targetPortId: invalidPortId2,
+      trainrunId: orphanTrainrunId,
+    });
+
+    DataMigration.ensureAllTrainrunSectionsHaveDiffertSourceAndTargetNodes(
+      dto,
+      logger as any,
+    );
+
+    expect(dto.trainrunSections.some((section) => section.id === invalidSectionId)).toBeFalse();
+    expect(node.ports.some((port) => port.id === invalidPortId1)).toBeFalse();
+    expect(node.ports.some((port) => port.id === invalidPortId2)).toBeFalse();
+    expect(
+      node.transitions.some((transition) => transition.id === invalidTransitionId),
+    ).toBeFalse();
+    expect(dto.trainruns.some((trainrun) => trainrun.id === orphanTrainrunId)).toBeFalse();
+    expect(logger.error).toHaveBeenCalled();
+  });
+});

--- a/src/app/services/data/data.service.spec.ts
+++ b/src/app/services/data/data.service.spec.ts
@@ -57,7 +57,7 @@ describe("DataService", () => {
       trainrunId: orphanTrainrunId,
     });
 
-    DataMigration.ensureAllTrainrunSectionsHaveDiffertSourceAndTargetNodes(dto, logger as any);
+    DataMigration.sanitizeTrainrunSectionsWithSameSourceAndTargetNodes(dto, logger as any);
 
     expect(dto.trainrunSections.some((section) => section.id === invalidSectionId)).toBeFalse();
     expect(node.ports.some((port) => port.id === invalidPortId1)).toBeFalse();

--- a/src/app/services/data/data.service.ts
+++ b/src/app/services/data/data.service.ts
@@ -6,6 +6,7 @@ import {
   TrainrunFrequency,
   TrainrunTimeCategory,
   TrafficSide,
+  TrainrunSectionDto,
 } from "../../data-structures/business.data.structures";
 import {NetzgrafikDefault} from "../../sample-netzgrafik/netzgrafik.default";
 import {NodeService} from "./node.service";
@@ -23,7 +24,9 @@ import {DataMigration} from "../../utils/data-migration";
 import {FilterService} from "../ui/filter.service";
 import {NetzgrafikColoringService} from "./netzgrafikColoring.service";
 import {Trainrun} from "src/app/models/trainrun.model";
+import {TrainrunSection} from "src/app/models/trainrunsection.model";
 import {SimpleTrainrunSectionRouter} from "../util/trainrunsection.routing";
+import {LogService} from "../../logger/log.service";
 
 export class NetzgrafikLoadedInfo {
   constructor(
@@ -58,6 +61,7 @@ export class DataService implements OnDestroy {
     private labelGroupService: LabelGroupService,
     private filterService: FilterService,
     private netzgrafikColoringService: NetzgrafikColoringService,
+    private logger: LogService,
   ) {
     this.trainrunService.setDataService(this);
     this.nodeService.setDataService(this);
@@ -78,6 +82,12 @@ export class DataService implements OnDestroy {
     this.netzgrafikLoadedInfoSubject.next(new NetzgrafikLoadedInfo(true, preview));
 
     DataMigration.migrateNetzgrafikDto(netzgrafikDto);
+
+    // Loading an elder Version Netzgrafik can have errournous data due of a bug which was in the 
+    // past. It's now fixed see https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/issues/851  
+    // but the data can be still in the stored Netzgrafik. So we need to check and fix this issue here.
+    this.ensureAllTrainrunSectionsHaveDiffertSourceAndTargetNodes(netzgrafikDto);
+
 
     this.netzgrafikDtoStore.netzgrafikDto = netzgrafikDto;
     SimpleTrainrunSectionRouter.setTrafficSideType(
@@ -102,6 +112,10 @@ export class DataService implements OnDestroy {
       );
     }
 
+
+
+    // Initialize the data services to ensure that all references between nodes, 
+    // trainrun sections, and trainruns are correctly set up.
     this.initializeDataServices();
 
     // Ensure that all trainrun sections have a consistent chain direction
@@ -320,4 +334,39 @@ export class DataService implements OnDestroy {
     // clean / fix resource objects which have no attechment.
     this.resourceService.clearUnlinkedResources(resIds);
   }
+
+  ensureAllTrainrunSectionsHaveDiffertSourceAndTargetNodes(netzgrafikDto: NetzgrafikDto) {
+    // Ensures that all trainrun sections have different source and target nodes. This function is important
+    // to maintain the relationship between the trainrun section and the nodes correctly and to
+    // avoid errors.
+    const errornousTrainrunSections:TrainrunSectionDto[] = [];
+    netzgrafikDto.trainrunSections.forEach((trs) => {
+      if (trs.sourceNodeId === trs.targetNodeId) {
+        errornousTrainrunSections.push(trs);
+      }
+    });
+
+    // delete all errornous trainrun sections with identical source and target nodes
+    errornousTrainrunSections.forEach((trs) => { 
+        const node = netzgrafikDto.nodes.find((n)=>n.id === trs.sourceNodeId && n.id === trs.targetNodeId);
+        if (node){
+          const sectionPorts = node.ports.filter((p)=>p.trainrunSectionId !== trs.id).map((p)=>p.id);
+          node.ports = node.ports.filter((p)=> !sectionPorts.includes(p.id));
+          node.transitions = node.transitions.filter((t)=>!sectionPorts.includes(t.port1Id) && !sectionPorts.includes(t.port2Id)); 
+        }
+        netzgrafikDto.trainrunSections = netzgrafikDto.trainrunSections.filter((t)=>t.id !== trs.id);
+    });
+    netzgrafikDto.trainruns = netzgrafikDto.trainruns.filter((trainrun) =>  
+      (netzgrafikDto.trainrunSections.find((trs) => trs.trainrunId === trainrun.id) !== undefined)
+    );
+
+    console.log(netzgrafikDto);
+    if (errornousTrainrunSections.length > 0) {
+      const message =
+        $localize`:@@app.services.data.data-service.deleted-trainrun-sections:Deleted ${errornousTrainrunSections.length} trainrun sections with identical source and target nodes. This was caused by a bug in an older version of the editor. Please check your Netzgrafik for correctness.`;
+      this.logger.error(message);
+    }
+
+  } 
+
 }

--- a/src/app/services/data/data.service.ts
+++ b/src/app/services/data/data.service.ts
@@ -83,11 +83,10 @@ export class DataService implements OnDestroy {
 
     DataMigration.migrateNetzgrafikDto(netzgrafikDto);
 
-    // Loading an elder Version Netzgrafik can have errournous data due of a bug which was in the 
-    // past. It's now fixed see https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/issues/851  
+    // Loading an elder Version Netzgrafik can have errournous data due of a bug which was in the
+    // past. It's now fixed see https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/issues/851
     // but the data can be still in the stored Netzgrafik. So we need to check and fix this issue here.
     this.ensureAllTrainrunSectionsHaveDiffertSourceAndTargetNodes(netzgrafikDto);
-
 
     this.netzgrafikDtoStore.netzgrafikDto = netzgrafikDto;
     SimpleTrainrunSectionRouter.setTrafficSideType(
@@ -112,9 +111,7 @@ export class DataService implements OnDestroy {
       );
     }
 
-
-
-    // Initialize the data services to ensure that all references between nodes, 
+    // Initialize the data services to ensure that all references between nodes,
     // trainrun sections, and trainruns are correctly set up.
     this.initializeDataServices();
 
@@ -339,7 +336,7 @@ export class DataService implements OnDestroy {
     // Ensures that all trainrun sections have different source and target nodes. This function is important
     // to maintain the relationship between the trainrun section and the nodes correctly and to
     // avoid errors.
-    const errornousTrainrunSections:TrainrunSectionDto[] = [];
+    const errornousTrainrunSections: TrainrunSectionDto[] = [];
     netzgrafikDto.trainrunSections.forEach((trs) => {
       if (trs.sourceNodeId === trs.targetNodeId) {
         errornousTrainrunSections.push(trs);
@@ -347,26 +344,32 @@ export class DataService implements OnDestroy {
     });
 
     // delete all errornous trainrun sections with identical source and target nodes
-    errornousTrainrunSections.forEach((trs) => { 
-        const node = netzgrafikDto.nodes.find((n)=>n.id === trs.sourceNodeId && n.id === trs.targetNodeId);
-        if (node){
-          const sectionPorts = node.ports.filter((p)=>p.trainrunSectionId !== trs.id).map((p)=>p.id);
-          node.ports = node.ports.filter((p)=> !sectionPorts.includes(p.id));
-          node.transitions = node.transitions.filter((t)=>!sectionPorts.includes(t.port1Id) && !sectionPorts.includes(t.port2Id)); 
-        }
-        netzgrafikDto.trainrunSections = netzgrafikDto.trainrunSections.filter((t)=>t.id !== trs.id);
+    errornousTrainrunSections.forEach((trs) => {
+      const node = netzgrafikDto.nodes.find(
+        (n) => n.id === trs.sourceNodeId && n.id === trs.targetNodeId,
+      );
+      if (node) {
+        const sectionPorts = node.ports
+          .filter((p) => p.trainrunSectionId !== trs.id)
+          .map((p) => p.id);
+        node.ports = node.ports.filter((p) => !sectionPorts.includes(p.id));
+        node.transitions = node.transitions.filter(
+          (t) => !sectionPorts.includes(t.port1Id) && !sectionPorts.includes(t.port2Id),
+        );
+      }
+      netzgrafikDto.trainrunSections = netzgrafikDto.trainrunSections.filter(
+        (t) => t.id !== trs.id,
+      );
     });
-    netzgrafikDto.trainruns = netzgrafikDto.trainruns.filter((trainrun) =>  
-      (netzgrafikDto.trainrunSections.find((trs) => trs.trainrunId === trainrun.id) !== undefined)
+    netzgrafikDto.trainruns = netzgrafikDto.trainruns.filter(
+      (trainrun) =>
+        netzgrafikDto.trainrunSections.find((trs) => trs.trainrunId === trainrun.id) !== undefined,
     );
 
     console.log(netzgrafikDto);
     if (errornousTrainrunSections.length > 0) {
-      const message =
-        $localize`:@@app.services.data.data-service.deleted-trainrun-sections:Deleted ${errornousTrainrunSections.length} trainrun sections with identical source and target nodes. This was caused by a bug in an older version of the editor. Please check your Netzgrafik for correctness.`;
+      const message = $localize`:@@app.services.data.data-service.deleted-trainrun-sections:Deleted ${errornousTrainrunSections.length} trainrun sections with identical source and target nodes. This was caused by a bug in an older version of the editor. Please check your Netzgrafik for correctness.`;
       this.logger.error(message);
     }
-
-  } 
-
+  }
 }

--- a/src/app/services/data/data.service.ts
+++ b/src/app/services/data/data.service.ts
@@ -82,10 +82,7 @@ export class DataService implements OnDestroy {
     // Loading an elder Version Netzgrafik can have errournous data due of a bug which was in the
     // past. It's now fixed see https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/issues/851
     // but the data can be still in the stored Netzgrafik. So we need to check and fix this issue here.
-    DataMigration.ensureAllTrainrunSectionsHaveDiffertSourceAndTargetNodes(
-      netzgrafikDto,
-      this.logger,
-    );
+    DataMigration.sanitizeTrainrunSectionsWithSameSourceAndTargetNodes(netzgrafikDto, this.logger);
     DataMigration.migrateNetzgrafikDto(netzgrafikDto);
 
     this.netzgrafikDtoStore.netzgrafikDto = netzgrafikDto;

--- a/src/app/services/data/data.service.ts
+++ b/src/app/services/data/data.service.ts
@@ -365,8 +365,7 @@ export class DataService implements OnDestroy {
       (trainrun) =>
         netzgrafikDto.trainrunSections.find((trs) => trs.trainrunId === trainrun.id) !== undefined,
     );
-
-    console.log(netzgrafikDto);
+ 
     if (errornousTrainrunSections.length > 0) {
       const message = $localize`:@@app.services.data.data-service.deleted-trainrun-sections:Deleted ${errornousTrainrunSections.length} trainrun sections with identical source and target nodes. This was caused by a bug in an older version of the editor. Please check your Netzgrafik for correctness.`;
       this.logger.error(message);

--- a/src/app/services/data/data.service.ts
+++ b/src/app/services/data/data.service.ts
@@ -5,7 +5,7 @@ import {
   Direction,
   TrainrunFrequency,
   TrainrunTimeCategory,
-  TrafficSide, 
+  TrafficSide,
 } from "../../data-structures/business.data.structures";
 import {NetzgrafikDefault} from "../../sample-netzgrafik/netzgrafik.default";
 import {NodeService} from "./node.service";

--- a/src/app/services/data/data.service.ts
+++ b/src/app/services/data/data.service.ts
@@ -5,8 +5,7 @@ import {
   Direction,
   TrainrunFrequency,
   TrainrunTimeCategory,
-  TrafficSide,
-  TrainrunSectionDto,
+  TrafficSide, 
 } from "../../data-structures/business.data.structures";
 import {NetzgrafikDefault} from "../../sample-netzgrafik/netzgrafik.default";
 import {NodeService} from "./node.service";
@@ -24,7 +23,6 @@ import {DataMigration} from "../../utils/data-migration";
 import {FilterService} from "../ui/filter.service";
 import {NetzgrafikColoringService} from "./netzgrafikColoring.service";
 import {Trainrun} from "src/app/models/trainrun.model";
-import {TrainrunSection} from "src/app/models/trainrunsection.model";
 import {SimpleTrainrunSectionRouter} from "../util/trainrunsection.routing";
 import {LogService} from "../../logger/log.service";
 
@@ -61,7 +59,7 @@ export class DataService implements OnDestroy {
     private labelGroupService: LabelGroupService,
     private filterService: FilterService,
     private netzgrafikColoringService: NetzgrafikColoringService,
-    private logger: LogService,
+    private logger?: LogService,
   ) {
     this.trainrunService.setDataService(this);
     this.nodeService.setDataService(this);
@@ -81,12 +79,14 @@ export class DataService implements OnDestroy {
   loadNetzgrafikDto(netzgrafikDto: NetzgrafikDto, preview = false) {
     this.netzgrafikLoadedInfoSubject.next(new NetzgrafikLoadedInfo(true, preview));
 
-    DataMigration.migrateNetzgrafikDto(netzgrafikDto);
-
     // Loading an elder Version Netzgrafik can have errournous data due of a bug which was in the
     // past. It's now fixed see https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/issues/851
     // but the data can be still in the stored Netzgrafik. So we need to check and fix this issue here.
-    this.ensureAllTrainrunSectionsHaveDiffertSourceAndTargetNodes(netzgrafikDto);
+    DataMigration.ensureAllTrainrunSectionsHaveDiffertSourceAndTargetNodes(
+      netzgrafikDto,
+      this.logger,
+    );
+    DataMigration.migrateNetzgrafikDto(netzgrafikDto);
 
     this.netzgrafikDtoStore.netzgrafikDto = netzgrafikDto;
     SimpleTrainrunSectionRouter.setTrafficSideType(
@@ -330,45 +330,5 @@ export class DataService implements OnDestroy {
     });
     // clean / fix resource objects which have no attechment.
     this.resourceService.clearUnlinkedResources(resIds);
-  }
-
-  ensureAllTrainrunSectionsHaveDiffertSourceAndTargetNodes(netzgrafikDto: NetzgrafikDto) {
-    // Ensures that all trainrun sections have different source and target nodes. This function is important
-    // to maintain the relationship between the trainrun section and the nodes correctly and to
-    // avoid errors.
-    const errornousTrainrunSections: TrainrunSectionDto[] = [];
-    netzgrafikDto.trainrunSections.forEach((trs) => {
-      if (trs.sourceNodeId === trs.targetNodeId) {
-        errornousTrainrunSections.push(trs);
-      }
-    });
-
-    // delete all errornous trainrun sections with identical source and target nodes
-    errornousTrainrunSections.forEach((trs) => {
-      const node = netzgrafikDto.nodes.find(
-        (n) => n.id === trs.sourceNodeId && n.id === trs.targetNodeId,
-      );
-      if (node) {
-        const sectionPorts = node.ports
-          .filter((p) => p.trainrunSectionId !== trs.id)
-          .map((p) => p.id);
-        node.ports = node.ports.filter((p) => !sectionPorts.includes(p.id));
-        node.transitions = node.transitions.filter(
-          (t) => !sectionPorts.includes(t.port1Id) && !sectionPorts.includes(t.port2Id),
-        );
-      }
-      netzgrafikDto.trainrunSections = netzgrafikDto.trainrunSections.filter(
-        (t) => t.id !== trs.id,
-      );
-    });
-    netzgrafikDto.trainruns = netzgrafikDto.trainruns.filter(
-      (trainrun) =>
-        netzgrafikDto.trainrunSections.find((trs) => trs.trainrunId === trainrun.id) !== undefined,
-    );
- 
-    if (errornousTrainrunSections.length > 0) {
-      const message = $localize`:@@app.services.data.data-service.deleted-trainrun-sections:Deleted ${errornousTrainrunSections.length} trainrun sections with identical source and target nodes. This was caused by a bug in an older version of the editor. Please check your Netzgrafik for correctness.`;
-      this.logger.error(message);
-    }
   }
 }

--- a/src/app/utils/data-migration.ts
+++ b/src/app/utils/data-migration.ts
@@ -1,8 +1,13 @@
 import {Trainrun} from "../models/trainrun.model";
 import {Node} from "../models/node.model";
 import {NetzgrafikDefault} from "../sample-netzgrafik/netzgrafik.default";
-import {NetzgrafikDto, TrainrunCategory} from "../data-structures/business.data.structures";
+import {
+  NetzgrafikDto,
+  TrainrunCategory,
+  TrainrunSectionDto,
+} from "../data-structures/business.data.structures";
 import {Note} from "../models/note.model";
+import {LogService} from "../logger/log.service";
 
 export class DataMigration {
   static getMinimalTurnaroundTime(): number {
@@ -104,5 +109,48 @@ export class DataMigration {
         cat.sectionHeadway = DataMigration.getSectionHeadway(cat);
       }
     });
+  }
+
+  static ensureAllTrainrunSectionsHaveDiffertSourceAndTargetNodes(
+    netzgrafikDto: NetzgrafikDto,
+    logger?: LogService,
+  ) {
+    // Ensures that all trainrun sections have different source and target nodes. This function is important
+    // to maintain the relationship between the trainrun section and the nodes correctly and to
+    // avoid errors.
+    const errornousTrainrunSections: TrainrunSectionDto[] = [];
+    netzgrafikDto.trainrunSections.forEach((trs) => {
+      if (trs.sourceNodeId === trs.targetNodeId) {
+        errornousTrainrunSections.push(trs);
+      }
+    });
+
+    // delete all errornous trainrun sections with identical source and target nodes
+    errornousTrainrunSections.forEach((trs) => {
+      const node = netzgrafikDto.nodes.find(
+        (n) => n.id === trs.sourceNodeId && n.id === trs.targetNodeId,
+      );
+      if (node) {
+        const sectionPorts = node.ports
+          .filter((p) => p.trainrunSectionId === trs.id)
+          .map((p) => p.id);
+        node.ports = node.ports.filter((p) => !sectionPorts.includes(p.id));
+        node.transitions = node.transitions.filter(
+          (t) => !sectionPorts.includes(t.port1Id) && !sectionPorts.includes(t.port2Id),
+        );
+      }
+      netzgrafikDto.trainrunSections = netzgrafikDto.trainrunSections.filter(
+        (t) => t.id !== trs.id,
+      );
+    });
+    netzgrafikDto.trainruns = netzgrafikDto.trainruns.filter(
+      (trainrun) =>
+        netzgrafikDto.trainrunSections.find((trs) => trs.trainrunId === trainrun.id) !== undefined,
+    );
+
+    if (errornousTrainrunSections.length > 0) {
+      const message = $localize`:@@app.services.data.data-service.deleted-trainrun-sections:Deleted ${errornousTrainrunSections.length} trainrun sections with identical source and target nodes. This was caused by a bug in an older version of the editor. Please check your Netzgrafik for correctness.`;
+      logger?.error(message);
+    }
   }
 }

--- a/src/app/utils/data-migration.ts
+++ b/src/app/utils/data-migration.ts
@@ -111,7 +111,7 @@ export class DataMigration {
     });
   }
 
-  static ensureAllTrainrunSectionsHaveDiffertSourceAndTargetNodes(
+  static sanitizeTrainrunSectionsWithSameSourceAndTargetNodes(
     netzgrafikDto: NetzgrafikDto,
     logger?: LogService,
   ) {

--- a/src/app/utils/data-migration.ts
+++ b/src/app/utils/data-migration.ts
@@ -115,18 +115,20 @@ export class DataMigration {
     netzgrafikDto: NetzgrafikDto,
     logger?: LogService,
   ) {
-    // Ensures that all trainrun sections have different source and target nodes - when not 
+    // Ensures that all trainrun sections have different source and target nodes - when not
     // remove the trainrun section and all related node links (ports and transitions).
     // This is important to maintain correct relationships between trainrun sections and nodes
     // and to avoid errors. Corrupted data can be generated when using an older version of the Netzgrafik Editor
     // where this fix had not yet been deployed:
     // https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/issues/851
-    const errornousTrainrunSections: TrainrunSectionDto[] = [];
-    netzgrafikDto.trainrunSections.forEach((trs) => {
-      if (trs.sourceNodeId === trs.targetNodeId) {
-        errornousTrainrunSections.push(trs);
-      }
-    });
+    const errornousTrainrunSections: TrainrunSectionDto[] = netzgrafikDto.trainrunSections.filter(
+      (trs) => trs.sourceNodeId === trs.targetNodeId,
+    );
+
+    if (errornousTrainrunSections.length === 0) {
+      // early exit - no errornous trainrun sections found - nothing to do
+      return;
+    }
 
     // delete all errornous trainrun sections with identical source and target nodes
     errornousTrainrunSections.forEach((trs) => {

--- a/src/app/utils/data-migration.ts
+++ b/src/app/utils/data-migration.ts
@@ -115,9 +115,12 @@ export class DataMigration {
     netzgrafikDto: NetzgrafikDto,
     logger?: LogService,
   ) {
-    // Ensures that all trainrun sections have different source and target nodes. This function is important
-    // to maintain the relationship between the trainrun section and the nodes correctly and to
-    // avoid errors.
+    // Ensures that all trainrun sections have different source and target nodes - when not 
+    // remove the trainrun section and all related node links (ports and transitions).
+    // This is important to maintain correct relationships between trainrun sections and nodes
+    // and to avoid errors. Corrupted data can be generated when using an older version of the Netzgrafik Editor
+    // where this fix had not yet been deployed:
+    // https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/issues/851
     const errornousTrainrunSections: TrainrunSectionDto[] = [];
     netzgrafikDto.trainrunSections.forEach((trs) => {
       if (trs.sourceNodeId === trs.targetNodeId) {

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -73,6 +73,9 @@
         },
         "version-control": {
           "new-name-comment": "Neuer Name: {$name}"
+        },
+        "data-service": {
+          "deleted-trainrun-sections": "{$PH} Zuglaufabschnitte mit identischem Start- und Zielknoten wurden gelöscht. Dies wurde durch einen Fehler in einer älteren Version des Editors verursacht. Bitte prüfen Sie Ihre Netzgrafik auf Korrektheit."
         }
       },
       "ui": {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -73,6 +73,9 @@
         },
         "version-control": {
           "new-name-comment": "New name: {$PH}"
+        },
+        "data-service": {
+          "deleted-trainrun-sections": "Deleted {$PH} trainrun sections with identical source and target nodes. This was caused by a bug in an older version of the editor. Please check your netzgrafik for correctness."
         }
       },
       "ui": {

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -73,6 +73,9 @@
         },
         "version-control": {
           "new-name-comment": "Nouveau nom : {$PH}"
+        },
+        "data-service": {
+          "deleted-trainrun-sections": "{$PH} sections de trainrun avec des nœuds source et cible identiques ont été supprimées. Cela a été causé par un bug dans une ancienne version de l'éditeur. Veuillez vérifier l'exactitude de votre netzgrafik."
         }
       },
       "ui": {


### PR DESCRIPTION
This PR adds a migration safeguard that removes invalid trainrun sections where source and target nodes are identical before normal DTO migration runs.
It also cleans up related node ports and transitions, and removes trainruns that become orphaned after those invalid sections are deleted.
A localized warning message is emitted when affected sections are found, and the corresponding translations were added to de, en, and fr language files.
A focused unit test was introduced to verify that invalid sections and their dependent references are correctly removed.
Finally, build and targeted tests were executed successfully to confirm that the migration path remains stable and the fix resolves the reported issue.