### PR TITLE
fix(note-dialog): theme link popup for dark mode

### DIFF
--- a/src/app/view/dialogs/note-dialog/htmlEditor/html-editor.component.scss
+++ b/src/app/view/dialogs/note-dialog/htmlEditor/html-editor.component.scss
@@ -36,6 +36,25 @@
     background: var(--sbb-header-lean-background-color);
     color: var(--NODE_TEXT_FOCUS);
   }
+
+  // Theme the link popup for dark mode. ngx-editor defaults its popup
+  // background to white and leaves inputs unstyled, so in dark mode the
+  // popup and its URL field render white-on-white (see issue #752).
+  .NgxEditor__Popup {
+    --ngx-editor-popup-bg-color: var(--sbb-header-lean-background-color);
+    color: var(--NODE_TEXT_FOCUS);
+
+    .NgxEditor__Popup--Label {
+      color: var(--NODE_TEXT_FOCUS);
+    }
+
+    input[type="text"],
+    input[type="url"] {
+      background: var(--sbb-header-lean-background-color);
+      color: var(--NODE_TEXT_FOCUS);
+      border: 1px solid var(--sbb-header-lean-border-bottom-color);
+    }
+  }
 }
 
 ::ng-deep div.ngx-html-editor-color-buttons {


### PR DESCRIPTION
Closes #752

## Problem
When creating a note in dark mode and clicking the link button, the popup renders white-on-white: the popup background is white and the URL input has light text, making the field invisible unless highlighted.

## Root cause
`ngx-editor` defaults `--ngx-editor-popup-bg-color` to white and ships the popup inputs unstyled. The editor SCSS themes `.NgxEditor__MenuBar` and `.NgxEditor__Content` with the SBB dark-aware variables but never themed the link popup.

## Fix
Theme `.NgxEditor__Popup`, its label, and the text/url inputs using the same SBB variables already used elsewhere in this component (`--sbb-header-lean-background-color`, `--NODE_TEXT_FOCUS`, `--sbb-header-lean-border-bottom-color`). CSS-only, scoped to the note html-editor component.

## Testing
Switch to dark mode, create a note, click the link toolbar button, and confirm the popup and URL field are legible.