### PR TITLE
fix(view): Perlenkette times positions (Left/Right hand traffic)

### DIFF
--- a/src/app/perlenkette/perlenkette-section/perlenkette-section.component.html
+++ b/src/app/perlenkette/perlenkette-section/perlenkette-section.component.html
@@ -74,7 +74,7 @@
               (click)="switchSectionView($event, 'stops')"
               x="0"
               y="0"
-              class="edge_text TrainrunSectionNumberOfStops end_text"
+              class="edge_text TrainrunSectionNumberOfStops"
               style="font-size: 12px"
               [ngClass]="'UI_DIALOG ColorRef_' + perlenketteTrainrun.colorRef"
             >
@@ -166,9 +166,12 @@
         <text
           x="0"
           y="0"
-          class="edge_text end_text leftArrivalTime"
+          class="edge_text leftArrivalTime"
           [ngClass]="
-            'UI_DIALOG ColorRef_' + perlenketteTrainrun.colorRef + getLeftArrivalTimeClassTag()
+            'UI_DIALOG ColorRef_' +
+            perlenketteTrainrun.colorRef +
+            getLeftArrivalTimeClassTag() +
+            getTextAnchorForTimeElement('leftArrivalTime')
           "
           (click)="switchSectionView($event, 'leftArrivalTime')"
         >
@@ -176,16 +179,19 @@
         </text>
       </g>
       <g
-        [attr.transform]="getTimeTransform('rightDepartureTime')"
+        [attr.transform]="getTimeTransform('leftDepartureTime')"
         *ngIf="showArrivalAndDepartureTime() && isRightSideDisplayed()"
       >
         <text
           (click)="switchSectionView($event, 'leftDepartureTime')"
           x="0"
           y="0"
-          class="edge_text start_text leftDepartureTime"
+          class="edge_text leftDepartureTime"
           [ngClass]="
-            'UI_DIALOG ColorRef_' + perlenketteTrainrun.colorRef + getLeftDepartureTimeClassTag()
+            'UI_DIALOG ColorRef_' +
+            perlenketteTrainrun.colorRef +
+            getLeftDepartureTimeClassTag() +
+            getTextAnchorForTimeElement('leftDepartureTime')
           "
         >
           {{ getLeftDepartureTime() }}
@@ -196,7 +202,7 @@
           <text
             x="0"
             y="0"
-            class="edge_text start_text travelTime"
+            class="edge_text travelTime"
             [ngClass]="'UI_DIALOG ColorRef_' + perlenketteTrainrun.colorRef"
             (click)="switchSectionView($event, 'travelTime')"
           >
@@ -209,7 +215,7 @@
           <text
             x="0"
             y="0"
-            class="edge_text start_text bottomTravelTime"
+            class="edge_text bottomTravelTime"
             [ngClass]="'UI_DIALOG ColorRef_' + perlenketteTrainrun.colorRef"
             (click)="switchSectionView($event, 'bottomTravelTime')"
           >
@@ -218,15 +224,18 @@
         </g>
       </g>
       <g
-        [attr.transform]="getTimeTransform('leftDepartureTime')"
+        [attr.transform]="getTimeTransform('rightDepartureTime')"
         *ngIf="showArrivalAndDepartureTime() && isLeftSideDisplayed()"
       >
         <text
           x="0"
           y="0"
-          class="edge_text end_text rightDepartureTime"
+          class="edge_text rightDepartureTime"
           [ngClass]="
-            'UI_DIALOG ColorRef_' + perlenketteTrainrun.colorRef + getRightDepartureTimeClassTag()
+            'UI_DIALOG ColorRef_' +
+            perlenketteTrainrun.colorRef +
+            getRightDepartureTimeClassTag() +
+            getTextAnchorForTimeElement('rightDepartureTime')
           "
           (click)="switchSectionView($event, 'rightDepartureTime')"
         >
@@ -240,9 +249,12 @@
         <text
           x="0"
           y="0"
-          class="edge_text start_text rightArrivalTime"
+          class="edge_text rightArrivalTime"
           [ngClass]="
-            'UI_DIALOG ColorRef_' + perlenketteTrainrun.colorRef + getRightArrivalTimeClassTag()
+            'UI_DIALOG ColorRef_' +
+            perlenketteTrainrun.colorRef +
+            getRightArrivalTimeClassTag() +
+            getTextAnchorForTimeElement('rightArrivalTime')
           "
           (click)="switchSectionView($event, 'rightArrivalTime')"
         >
@@ -785,7 +797,7 @@
                   x="0"
                   y="0"
                   style="fill: var(--COLOR_Edit); font-size: 16px"
-                  class="edge_text TrainrunSectionNumberOfStops end_text"
+                  class="edge_text TrainrunSectionNumberOfStops"
                   [ngClass]="'UI_DIALOG ColorRef_' + perlenketteTrainrun.colorRef"
                 >
                   {{ stationNumberArray.length }}

--- a/src/app/perlenkette/perlenkette-section/perlenkette-section.component.scss
+++ b/src/app/perlenkette/perlenkette-section/perlenkette-section.component.scss
@@ -15,14 +15,12 @@ svg {
   pointer-events: none;
 }
 
-.start_text {
+.anchor_start {
   text-anchor: start !important;
-  cursor: pointer;
 }
 
-.end_text {
+.anchor_end {
   text-anchor: end !important;
-  cursor: pointer;
 }
 
 svg text.edge_text:hover {

--- a/src/app/perlenkette/perlenkette-section/perlenkette-section.component.ts
+++ b/src/app/perlenkette/perlenkette-section/perlenkette-section.component.ts
@@ -36,25 +36,24 @@ import {TrafficSide} from "src/app/data-structures/business.data.structures";
 
 const timeCoordinates = {
   leftHand: {
-    leftDepartureTime: {x: 124, y: 164},
+    leftDepartureTime: {x: 149, y: 32},
     leftArrivalTime: {x: 124, y: 18},
-    rightDepartureTime: {x: 149, y: 32},
+    rightDepartureTime: {x: 124, y: 164},
     rightArrivalTime: {x: 149, y: 178},
     travelTime: {x: 121, y: 93},
-    travelTimeAsymmetry: {x: 155, y: 93},
-    bottomTravelTime: {x: 121, y: 100},
+    travelTimeAsymmetry: {x: 155, y: 105},
+    bottomTravelTime: {x: 121, y: 86},
   },
   rightHand: {
-    leftDepartureTime: {x: 166, y: 164},
-    leftArrivalTime: {x: 166, y: 18},
-    rightDepartureTime: {x: 108, y: 32},
-    rightArrivalTime: {x: 108, y: 178},
+    leftDepartureTime: {x: 124, y: 32},
+    leftArrivalTime: {x: 149, y: 18},
+    rightDepartureTime: {x: 149, y: 164},
+    rightArrivalTime: {x: 124, y: 178},
     travelTime: {x: 155, y: 93},
-    travelTimeAsymmetry: {x: 121, y: 93},
-    bottomTravelTime: {x: 155, y: 100},
+    travelTimeAsymmetry: {x: 121, y: 105},
+    bottomTravelTime: {x: 155, y: 86},
   },
 };
-
 type KeyOfTimeCoordinates = keyof (
   typeof timeCoordinates.leftHand | typeof timeCoordinates.rightHand
 );
@@ -859,5 +858,14 @@ export class PerlenketteSectionComponent implements OnInit, AfterContentInit, On
     } else {
       return direction === "sourceToTarget" ? "targetToSource" : "sourceToTarget";
     }
+  }
+
+  getTextAnchorForTimeElement(element: KeyOfTimeCoordinates): "anchor_start" | "anchor_end" {
+    const isLeftHandTraffic = this.trafficSide === "leftHand";
+
+    if (element === "leftDepartureTime" || element === "rightArrivalTime") {
+      return isLeftHandTraffic ? "anchor_start" : "anchor_end";
+    }
+    return isLeftHandTraffic ? "anchor_end" : "anchor_start";
   }
 }


### PR DESCRIPTION
The `text-anchor: start !important;` artifact made the left/right text positions in the Perlenkette weird.

The proposed changes make these symmetrical.