### PR TITLE
Eliminates implicit any to enable `noImplicitAny`

### DIFF
--- a/src/app/core/i18n/i18n.service.ts
+++ b/src/app/core/i18n/i18n.service.ts
@@ -2,13 +2,15 @@ import {Injectable} from "@angular/core";
 import {registerLocaleData} from "@angular/common";
 import {loadTranslations} from "@angular/localize";
 
+type NestedTranslations = {[key: string]: string | NestedTranslations};
+
 @Injectable({
   providedIn: "root",
 })
 export class I18nService {
   readonly allowedLanguages = ["en", "fr", "de"];
   private currentLanguage: string = this.getLanguageFromStorage() || this.detectNavigatorLanguage();
-  translations: any = {};
+  translations: Record<string, string> = {};
 
   get language(): string {
     return this.currentLanguage;
@@ -63,10 +65,10 @@ export class I18nService {
   //   "app.models...": ...,
   //   "app.models...": ...
   // }
-  private flattenTranslations(translations: any): any {
-    const flattenedTranslations = {};
+  private flattenTranslations(translations: NestedTranslations): Record<string, string> {
+    const flattenedTranslations: Record<string, string> = {};
 
-    function flatten(obj, prefix = "") {
+    function flatten(obj: NestedTranslations, prefix = "") {
       for (const key in obj) {
         if (typeof obj[key] === "string") {
           flattenedTranslations[prefix + key] = obj[key];
@@ -81,7 +83,7 @@ export class I18nService {
   }
 
   // Used for the pipe and allowing parameters
-  translate(key: string, params?: any): string {
+  translate(key: string, params?: Record<string, string>): string {
     let translation = this.translations[key] || key;
 
     if (params) {

--- a/src/app/core/i18n/translate.pipe.ts
+++ b/src/app/core/i18n/translate.pipe.ts
@@ -9,7 +9,7 @@ import {I18nService} from "./i18n.service";
 export class TranslatePipe implements PipeTransform {
   constructor(private i18nService: I18nService) {}
 
-  transform(key: string, params?: any): string {
+  transform(key: string, params?: Record<string, string>): string {
     return this.i18nService.translate(key, params);
   }
 }

--- a/src/app/models/filterSettings.model.ts
+++ b/src/app/models/filterSettings.model.ts
@@ -21,24 +21,24 @@ export class FilterSetting {
   public filterTrainrunLabels: number[];
   public filterDirectionArrows: boolean;
   public filterAsymmetryArrows: boolean;
-  public filterArrivalDepartureTime;
-  public filterTravelTime;
+  public filterArrivalDepartureTime: boolean;
+  public filterTravelTime: boolean;
   public filterBackwardTravelTime: boolean;
-  public filterTrainrunName;
-  public filterConnections;
-  public filterShowNonStopTime;
+  public filterTrainrunName: boolean;
+  public filterConnections: boolean;
+  public filterShowNonStopTime: boolean;
   public filterTrainrunCategory: TrainrunCategory[];
   public filterTrainrunFrequency: TrainrunFrequency[];
   public filterTrainrunTimeCategory: TrainrunTimeCategory[];
   public filterDirection: Direction[];
   public filterSymmetry: boolean[];
-  public filterAllEmptyNodes;
-  public filterAllNonStopNodes;
+  public filterAllEmptyNodes: boolean;
+  public filterAllNonStopNodes: boolean;
   public displayNodesFullName: boolean;
-  public filterNotes;
-  public timeDisplayPrecision;
-  public isTemporaryDisableFilteringOfItemsInView;
-  public temporaryEmptyAndNonStopFilteringSwitchedOff;
+  public filterNotes: boolean;
+  public timeDisplayPrecision: number;
+  public isTemporaryDisableFilteringOfItemsInView: boolean;
+  public temporaryEmptyAndNonStopFilteringSwitchedOff: boolean;
 
   constructor(
     {
@@ -147,7 +147,7 @@ export class FilterSetting {
   areFilteringAttributesEqual(fs: FilterSetting): boolean {
     const self = this.getDto();
     let eq = true;
-    Object.keys(self).forEach((key) => {
+    (Object.keys(self) as (keyof FilterSettingDto)[]).forEach((key) => {
       if (key !== FilterSetting.isTemporaryDisableFilteringOfItemsInViewAttribute) {
         if (JSON.stringify(this[key]) !== JSON.stringify(fs[key])) {
           eq = false;
@@ -158,14 +158,10 @@ export class FilterSetting {
   }
 
   copyFilteringAttributes(fs: FilterSetting) {
-    Object.keys(this).forEach((key) => {
+    (Object.keys(this) as (keyof FilterSettingDto)[]).forEach((key) => {
       if (this[key] !== fs[key]) {
         if (key !== FilterSetting.isTemporaryDisableFilteringOfItemsInViewAttribute) {
-          if (Array.isArray(fs[key])) {
-            this[key] = Object.assign([], fs[key]);
-          } else {
-            this[key] = fs[key];
-          }
+          Object.assign(this, {[key]: Array.isArray(fs[key]) ? [...fs[key]] : fs[key]});
         }
       }
     });

--- a/src/app/perlenkette/perlenkette.component.ts
+++ b/src/app/perlenkette/perlenkette.component.ts
@@ -275,9 +275,7 @@ export class PerlenketteComponent implements AfterContentChecked, OnDestroy {
   signalHeightChanged(height: number, pathItem: PerlenketteItem) {
     this.perlenketteRenderingElementsHeight.push([pathItem, height]);
     this.renderedElementsHeight = 0;
-    this.perlenketteRenderingElementsHeight.forEach((pItem, idx) => {
-      const el = pItem[0];
-      const height = pItem[1];
+    this.perlenketteRenderingElementsHeight.forEach(([_, height]) => {
       this.renderedElementsHeight += height;
     });
   }

--- a/src/app/perlenkette/perlenkette.component.ts
+++ b/src/app/perlenkette/perlenkette.component.ts
@@ -344,17 +344,12 @@ export class PerlenketteComponent implements AfterContentChecked, OnDestroy {
 
   private getGotoCurrentY(pathItem: PerlenketteItem) {
     let currentY = 0;
-    let next = true;
-    this.perlenketteRenderingElementsHeight.forEach((pItem, idx) => {
-      const el = pItem[0];
-      const height = pItem[1];
+    for (const [el, height] of this.perlenketteRenderingElementsHeight) {
       if (el === pathItem) {
-        next = false;
+        break;
       }
-      if (next) {
-        currentY += height;
-      }
-    });
+      currentY += height;
+    }
     return currentY;
   }
 

--- a/src/app/perlenkette/perlenkette.component.ts
+++ b/src/app/perlenkette/perlenkette.component.ts
@@ -397,30 +397,8 @@ export class PerlenketteComponent implements AfterContentChecked, OnDestroy {
     event.stopImmediatePropagation();
     const delta = Math.min(64, Math.max(-64, event.deltaY));
     const currentEl: PerlenketteNode = this.getClosestPerlenketteItem();
-    if (delta > 0) {
-      let newPos = 0;
-      this.perlenketteRenderingElementsHeight.forEach((pItem, idx) => {
-        const el = pItem[0];
-        const height = pItem[1];
-        newPos += height;
-        if (el.isPerlenketteNode()) {
-          if (el === currentEl) {
-            this.updateSvgPointY(el, this.svgPoint.getY() + delta);
-          }
-        }
-      });
-    } else {
-      let newPos = 0;
-      this.perlenketteRenderingElementsHeight.forEach((pItem, idx) => {
-        const el = pItem[0];
-        const height = pItem[1];
-        newPos += height;
-        if (el.isPerlenketteNode()) {
-          if (el === currentEl) {
-            this.updateSvgPointY(el, this.svgPoint.getY() + delta);
-          }
-        }
-      });
+    if (currentEl !== undefined) {
+      this.updateSvgPointY(currentEl, this.svgPoint.getY() + delta);
     }
   }
 

--- a/src/app/perlenkette/perlenkette.component.ts
+++ b/src/app/perlenkette/perlenkette.component.ts
@@ -240,19 +240,10 @@ export class PerlenketteComponent implements AfterContentChecked, OnDestroy {
   getClosestPerlenketteItem(): PerlenketteNode {
     let retEl: PerlenketteNode = this.perlenketteRenderingElementsHeight.keys()[0];
     let currentY = 0;
-    this.perlenketteRenderingElementsHeight.forEach((pItem, idx) => {
-      const el = pItem[0];
-      const height = pItem[1];
+    this.perlenketteRenderingElementsHeight.forEach(([el, height]) => {
       const offY = this.svgPoint.getY() + this.contentHeight / 4;
-      if (el.isPerlenketteNode()) {
-        if (currentY < Math.max(0, offY) + height) {
-          if (retEl === undefined || currentY < Math.max(0, offY)) {
-            retEl = el.getPerlenketteNode();
-          }
-          if (Math.max(0, offY) - currentY < Math.max(0, offY) + height - currentY) {
-            retEl = el.getPerlenketteNode();
-          }
-        }
+      if (el.isPerlenketteNode() && currentY < Math.max(0, offY) + height) {
+        retEl = el.getPerlenketteNode();
       }
       currentY += height;
     });

--- a/src/app/perlenkette/perlenkette.component.ts
+++ b/src/app/perlenkette/perlenkette.component.ts
@@ -237,8 +237,8 @@ export class PerlenketteComponent implements AfterContentChecked, OnDestroy {
     return ret;
   }
 
-  getClosestPerlenketteItem(): PerlenketteNode {
-    let retEl: PerlenketteNode = this.perlenketteRenderingElementsHeight.keys()[0];
+  getClosestPerlenketteItem(): PerlenketteNode | undefined {
+    let retEl: PerlenketteNode | undefined = undefined;
     let currentY = 0;
     this.perlenketteRenderingElementsHeight.forEach(([el, height]) => {
       const offY = this.svgPoint.getY() + this.contentHeight / 4;

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
@@ -141,16 +141,18 @@ export class OriginDestinationComponent implements OnInit, AfterViewInit, OnDest
     const origins = this.matrixData.map((d) => d.originId);
     const destinations = this.matrixData.map((d) => d.destinationId);
     const uniqueOriginsDestinations = [...new Set([...origins, ...destinations])];
-    const diagonalData: OriginDestination[] = uniqueOriginsDestinations.map((nodeId) => ({
-      origin: this.nodeService.getNodeFromId(nodeId).getBetriebspunktName(),
-      destination: this.nodeService.getNodeFromId(nodeId).getBetriebspunktName(),
-      originId: nodeId,
-      destinationId: nodeId,
-      totalCost: undefined,
-      travelTime: undefined,
-      transfers: undefined,
-      found: false,
-    }));
+    const diagonalData: OriginDestination[] = uniqueOriginsDestinations.map(
+      (nodeId): OriginDestination => ({
+        origin: this.nodeService.getNodeFromId(nodeId).getBetriebspunktName(),
+        destination: this.nodeService.getNodeFromId(nodeId).getBetriebspunktName(),
+        originId: nodeId,
+        destinationId: nodeId,
+        totalCost: undefined,
+        travelTime: undefined,
+        transfers: undefined,
+        found: false,
+      }),
+    );
     this.matrixData = [...this.matrixData, ...diagonalData];
   }
 

--- a/src/app/services/data/basedata.service.ts
+++ b/src/app/services/data/basedata.service.ts
@@ -158,7 +158,10 @@ export class BaseDataService {
     }
   }
 
-  private getCsvValueWithAliases(row: any, column: CsvColumnGroup): any {
+  private getCsvValueWithAliases(
+    row: Record<string, string>,
+    column: CsvColumnGroup,
+  ): string | undefined {
     if (row[column.canonicalName] !== undefined) {
       return row[column.canonicalName];
     }
@@ -169,7 +172,10 @@ export class BaseDataService {
     return undefined;
   }
 
-  private parseNoHaltFromCsvWithAliases(row: any, column: CsvColumnGroup): boolean {
+  private parseNoHaltFromCsvWithAliases(
+    row: Record<string, string>,
+    column: CsvColumnGroup,
+  ): boolean {
     if (row[column.canonicalName] !== undefined) {
       return BaseDataService.parseTimeAsFloat(row[column.canonicalName]) === 1;
     }
@@ -185,7 +191,7 @@ export class BaseDataService {
     return this.importUsedLegacyColumns;
   }
 
-  static validateCsvColumns(rows: any[]): void {
+  static validateCsvColumns(rows: Record<string, string>[]): void {
     if (rows.length === 0) {
       return;
     }
@@ -210,7 +216,7 @@ export class BaseDataService {
     }
   }
 
-  setBaseData(baseDataDto) {
+  setBaseData(baseDataDto: Record<string, string>[]) {
     this.importUsedLegacyColumns = false;
     BaseDataService.validateCsvColumns(baseDataDto);
     this.baseDataStore.baseData = baseDataDto.map((row) => {

--- a/src/app/services/data/basedata.service.ts
+++ b/src/app/services/data/basedata.service.ts
@@ -158,13 +158,6 @@ export class BaseDataService {
     }
   }
 
-  private static getCsvValue(row: any, canonicalName: string, legacyName?: string): any {
-    if (row[canonicalName] !== undefined) {
-      return row[canonicalName];
-    }
-    return legacyName !== undefined ? row[legacyName] : undefined;
-  }
-
   private getCsvValueWithAliases(row: any, column: CsvColumnGroup): any {
     if (row[column.canonicalName] !== undefined) {
       return row[column.canonicalName];

--- a/src/app/services/ui/navigation.service.ts
+++ b/src/app/services/ui/navigation.service.ts
@@ -19,15 +19,15 @@ export class NavigationService {
     this.router.navigate(this.getRouteToVariants(projectId));
   }
 
-  getRouteToEditor(projectId: number, variantId: number): any[] {
+  getRouteToEditor(projectId: number, variantId: number): (string | number)[] {
     return ["/projects", projectId, "variants", variantId];
   }
 
-  getRouteToVariants(projectId: number): any[] {
+  getRouteToVariants(projectId: number): (string | number)[] {
     return ["/projects", projectId];
   }
 
-  getRouteToProjects(): any[] {
+  getRouteToProjects(): string[] {
     return ["/"];
   }
 }

--- a/src/app/streckengrafik/components/slider/path-slider-track-segments/path-slider-track-segments.component.ts
+++ b/src/app/streckengrafik/components/slider/path-slider-track-segments/path-slider-track-segments.component.ts
@@ -33,7 +33,7 @@ export class PathSliderTrackSegmentsComponent {
       const nbrTracks = minTracks ? sts.minNbrTracks : sts.nbrTracks;
       if (nbrTracks <= maxNbrTracks2show) {
         for (let i = 0; i < nbrTracks; i++) {
-          const p = this.zeroPoint + this.makePositionSymmetric(i, sts.nbrTracks) * 3;
+          const p = this.zeroPoint + this.makePositionSymmetric(i) * 3;
           const d: string =
             "" +
             (index !== 0 ? " M " + startAt + "," + this.zeroPoint + " L " : " M ") +
@@ -63,7 +63,7 @@ export class PathSliderTrackSegmentsComponent {
       return [];
     }
 
-    const retData = [];
+    const retData: {x1: number; x2: number; y1: number; y2: number; nbr: number; d: string}[] = [];
     ps.trackData.sectionTrackSegments.forEach((sts: TrackSegments, index: number) => {
       const startAt = Math.max(0.0, sts.startPos * this.path.zoomedXPath());
       const endAt = Math.min(sts.endPos * this.path.zoomedXPath(), this.path.zoomedXPath());
@@ -72,7 +72,7 @@ export class PathSliderTrackSegmentsComponent {
       const nbrTracks = minTracks ? sts.minNbrTracks : sts.nbrTracks;
       if (nbrTracks > maxNbrTracks2show) {
         for (let i = 0; i < sts.nbrTracks; i++) {
-          const p = this.zeroPoint + this.makePositionSymmetric(i, sts.nbrTracks) * 3;
+          const p = this.zeroPoint + this.makePositionSymmetric(i) * 3;
           y1 = Math.min(y1, p);
           y2 = Math.max(y2, p);
         }
@@ -114,7 +114,7 @@ export class PathSliderTrackSegmentsComponent {
     return retData;
   }
 
-  private makePositionSymmetric(mainTrackIdx: number, nbrTracks): number {
+  private makePositionSymmetric(mainTrackIdx: number): number {
     if (mainTrackIdx === 0) {
       return 1;
     }

--- a/src/app/streckengrafik/components/slider/path-slider/path-slider.component.html
+++ b/src/app/streckengrafik/components/slider/path-slider/path-slider.component.html
@@ -1,6 +1,5 @@
 <div>
   <svg
-    #svg
     xmlns="http://www.w3.org/2000/svg"
     [attr.viewBox]="viewBox"
     xmlns="http://www.w3.org/2000/svg"

--- a/src/app/streckengrafik/components/slider/path-slider/path-slider.component.ts
+++ b/src/app/streckengrafik/components/slider/path-slider/path-slider.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnDestroy, ViewChild} from "@angular/core";
+import {Component, Input, OnDestroy} from "@angular/core";
 import {Subject} from "rxjs";
 import {ResizeChangeInfo} from "../../../model/util/resizeChangeInfo";
 import {ViewBoxChangeInfo} from "../../../model/util/viewBoxChangeInfo";
@@ -23,9 +23,6 @@ export class PathSliderComponent implements OnDestroy {
 
   @Input()
   showRailTrackSlider = true;
-
-  @ViewChild("svg")
-  svgRef: any;
 
   viewBox: string;
 

--- a/src/app/streckengrafik/model/streckengrafik-model/sg-path-node.ts
+++ b/src/app/streckengrafik/model/streckengrafik-model/sg-path-node.ts
@@ -17,7 +17,7 @@ export class SgPathNode implements SgPath {
     public departureTrainrunSectionId: number,
     public arrivalTrainrunSectionId: number,
     public trackData: TrackData,
-    public filter,
+    public filter: boolean,
     public trackOccupier = false,
     public xZoom: number = 0,
     public startPosition: number = 0,

--- a/src/app/streckengrafik/model/streckengrafik-model/sg-path-section.ts
+++ b/src/app/streckengrafik/model/streckengrafik-model/sg-path-section.ts
@@ -17,7 +17,7 @@ export class SgPathSection implements SgPath {
     public departureNodeShortName: string,
     public arrivalNodeShortName: string,
     public trackData: TrackData,
-    public filter,
+    public filter: boolean,
     public trackOccupier = false,
     public xZoom: number = 0,
     public startPosition: number = 0,

--- a/src/app/streckengrafik/services/sg-6-track.service.ts
+++ b/src/app/streckengrafik/services/sg-6-track.service.ts
@@ -106,7 +106,7 @@ export class Sg6TrackService implements OnDestroy {
     /*
     This method collects all trainrun sections and maps them into the sectionsOfInterest-Map to get fast access
      */
-    const sectionsOfInterest = new Map<string, any[]>();
+    const sectionsOfInterest = new Map<string, {item: SgTrainrunItem; trainrun: SgTrainrun}[]>();
     trainrunItems.forEach((ts) => {
       ts.sgTrainrunItems.forEach((trainrunItem: SgTrainrunItem) => {
         if (trainrunItem.isSection()) {
@@ -137,7 +137,9 @@ export class Sg6TrackService implements OnDestroy {
     return {key: sectionKey, node1: node1, node2: node2};
   }
 
-  private getDistanceGridResolutionInfo(sectionData: any[]) {
+  private getDistanceGridResolutionInfo(
+    sectionData: {item: SgTrainrunItem; trainrun: SgTrainrun}[],
+  ) {
     let nDistanceCells = 1;
     sectionData.forEach((d) => {
       const item: SgTrainrunItem = d.item;
@@ -150,9 +152,9 @@ export class Sg6TrackService implements OnDestroy {
   private mergeDistanceCellGridResoultionToBigSegment(
     tracksMatrix: number[],
     nDistanceCells: number,
-  ): any[] {
+  ): [number, number, number][] {
     // unroll the data to segments
-    const tracks: any[] = [];
+    const tracks: [number, number, number][] = [];
     let nbrTracks: number = undefined;
     let from = 0.0;
     for (let distCellIdx = 0; distCellIdx < nDistanceCells; distCellIdx++) {
@@ -169,7 +171,7 @@ export class Sg6TrackService implements OnDestroy {
     }
 
     // compress the number of sections
-    const compactTracks: any[] = [];
+    const compactTracks: [number, number, number][] = [];
     let start = 0;
     let end = 0;
     let value = tracks[0][2];
@@ -187,11 +189,11 @@ export class Sg6TrackService implements OnDestroy {
   }
 
   private extractSectionTracks(
-    sectionsOfInterest: Map<string, any[]>,
+    sectionsOfInterest: Map<string, {item: SgTrainrunItem; trainrun: SgTrainrun}[]>,
     distRes = 15, // Res 4s
     timeRes = 15, // Res 4s
   ) {
-    const sectionsTracks = new Map<string, number[]>();
+    const sectionsTracks = new Map<string, [number, number, number][]>();
     for (const keyNodeId of sectionsOfInterest.keys()) {
       // ------------------------------------------------------------------------------------------------------------------
       // step 1 -> get trainrun data (aligned to section)
@@ -833,7 +835,7 @@ export class Sg6TrackService implements OnDestroy {
 
   private makeTrackSymmetric(
     nodeTracksMap: Map<number, PathNodeNeighbour[]>,
-    separateForwardBackwardTracks,
+    separateForwardBackwardTracks: boolean,
   ) {
     if (!separateForwardBackwardTracks) {
       return;
@@ -927,7 +929,7 @@ export class Sg6TrackService implements OnDestroy {
 
   private updateTracksForAllPathNodes(
     nodeTracksMap: Map<number, PathNodeNeighbour[]>,
-    separateForwardBackwardTracks,
+    separateForwardBackwardTracks: boolean,
   ) {
     for (const keyNodeId of nodeTracksMap.keys()) {
       const tracks = nodeTracksMap.get(keyNodeId);
@@ -1039,7 +1041,7 @@ export class Sg6TrackService implements OnDestroy {
 
   private mapTrackToTop(
     trainrunItems: SgTrainrun[],
-    sectionTrackMap: Map<string, number[]>,
+    sectionTrackMap: Map<string, [number, number, number][]>,
     separateForwardBackwardTracks: boolean,
   ) {
     const maxTrackMap = new Map<string, TrackData>();
@@ -1141,7 +1143,11 @@ export class Sg6TrackService implements OnDestroy {
     });
   }
 
-  private convertTrackSegments(trackSegements: number[], backward: boolean, initMaxTracks: number) {
+  private convertTrackSegments(
+    trackSegements: [number, number, number][],
+    backward: boolean,
+    initMaxTracks: number,
+  ) {
     const convertedTrackSegments: TrackSegments[] = [];
     let maxTracks = initMaxTracks;
     trackSegements.forEach((trackSeg) => {

--- a/src/app/view/card-grid/card/card.component.ts
+++ b/src/app/view/card-grid/card/card.component.ts
@@ -16,7 +16,7 @@ export class CardComponent {
   subtitle?: string;
 
   @Input()
-  route?: string | any[];
+  route?: string | (string | number)[];
 
   @Input()
   icon?: string;
@@ -27,7 +27,7 @@ export class CardComponent {
   @Input()
   actions?: Observable<SlotAction[]>;
 
-  openLink(route: string | any[]) {
+  openLink(route: string | (string | number)[]) {
     const element: HTMLElement = document.getElementById(
       this.getCardComponentRouterLinkId(route),
     ) as HTMLElement;
@@ -40,7 +40,7 @@ export class CardComponent {
     event$.stopPropagation();
   }
 
-  getCardComponentRouterLinkId(route: string | any[]): string {
+  getCardComponentRouterLinkId(route: string | (string | number)[]): string {
     if (typeof route === "string") {
       return "CardComponentRouterLink_s_" + route;
     }

--- a/src/app/view/dialogs/basedata-dialog/basedata-dialog.component.ts
+++ b/src/app/view/dialogs/basedata-dialog/basedata-dialog.component.ts
@@ -16,7 +16,7 @@ import {Subject} from "rxjs";
 })
 export class BaseDataDialogComponent implements OnDestroy {
   @ViewChild("baseDataTemplate", {static: true})
-  baseDataTemplate: TemplateRef<any>;
+  baseDataTemplate: TemplateRef<void>;
   public baseData: BaseData[] = [];
   displayedColumns: string[] = [
     "betriebspunktName",

--- a/src/app/view/dialogs/confirmation-dialog/confirmation-dialog.component.ts
+++ b/src/app/view/dialogs/confirmation-dialog/confirmation-dialog.component.ts
@@ -37,7 +37,7 @@ export class ConfirmationDialogParameter {
 })
 export class ConfirmationDialogComponent implements OnDestroy {
   @ViewChild("confirmationDialogTemplate", {static: true})
-  confirmationDialogTemplate: TemplateRef<any>;
+  confirmationDialogTemplate: TemplateRef<void>;
 
   public dialogTitle: string;
   public dialogContent: string;

--- a/src/app/view/dialogs/note-dialog/note-dialog.component.ts
+++ b/src/app/view/dialogs/note-dialog/note-dialog.component.ts
@@ -42,7 +42,7 @@ export class NoteDialogParameter {
 })
 export class NoteDialogComponent implements OnDestroy {
   @ViewChild("noteEditorTabsViewTemplate", {static: true})
-  noteEditorTabsViewTemplate: TemplateRef<any>;
+  noteEditorTabsViewTemplate: TemplateRef<void>;
 
   public data: NoteDialogParameter = null;
 

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component.ts
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component.ts
@@ -61,7 +61,7 @@ export class TrainrunDialogParameter {
 })
 export class TrainrunAndSectionDialogComponent implements OnDestroy {
   @ViewChild("trainrunAndSectionEditorTabsViewTemplate", {static: true})
-  trainrunAndSectionEditorTabsViewTemplate: TemplateRef<any>;
+  trainrunAndSectionEditorTabsViewTemplate: TemplateRef<void>;
 
   public selectedTrainrun: Trainrun;
   public nextStopLeftNodeName: string;

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -2748,7 +2748,7 @@ export class TrainrunSectionsView {
 
   private createNewTrainrunSectionAfterPinDropped(
     event: MouseEvent,
-    endNode: any,
+    endNode: Node,
     trainrunSection: TrainrunSection,
   ) {
     if (this.editorView.trainrunSectionPreviewLineView.getMode() === PreviewLineMode.NotDragging) {
@@ -2761,7 +2761,7 @@ export class TrainrunSectionsView {
       return;
     }
 
-    const startNode: any = this.editorView.trainrunSectionPreviewLineView.getStartNode();
+    const startNode = this.editorView.trainrunSectionPreviewLineView.getStartNode();
     if (startNode === endNode) {
       this.editorView.trainrunSectionPreviewLineView.stopPreviewLine();
       return;

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -1,6 +1,6 @@
 import {parse} from "papaparse";
 import {Component, ElementRef, ViewChild} from "@angular/core";
-import * as svg from "save-svg-as-png";
+import {SvgExportOptions, svgAsDataUri, saveSvgAsPng} from "save-svg-as-png";
 import {DataService} from "../../services/data/data.service";
 import {TrainrunService} from "../../services/data/trainrun.service";
 import {NodeService} from "../../services/data/node.service";
@@ -33,7 +33,7 @@ import {MathUtils} from "src/app/utils/math";
 
 interface ContainertoExportData {
   documentToExport: HTMLElement;
-  exportParameter: any;
+  exportParameter: SvgExportOptions;
   essentialProps: string[];
 }
 
@@ -149,9 +149,8 @@ export class EditorToolsViewComponent {
     const scaleToTargetWidth = 2000 / containerInfo.exportParameter.width;
     containerInfo.exportParameter.scale = scaleToTargetWidth;
 
-    svg
-      .svgAsDataUri(containerInfo.documentToExport, containerInfo.exportParameter)
-      .then((uri: string) => {
+    svgAsDataUri(containerInfo.documentToExport, containerInfo.exportParameter).then(
+      (uri: string) => {
         const a = document.createElement("a");
         document.body.appendChild(a);
         a.href = uri;
@@ -160,7 +159,8 @@ export class EditorToolsViewComponent {
         URL.revokeObjectURL(a.href);
         a.remove();
         this.levelOfDetailService.enableLevelOfDetailRendering();
-      });
+      },
+    );
   }
 
   onExportContainerAsPNG() {
@@ -172,7 +172,7 @@ export class EditorToolsViewComponent {
     const containerInfo = this.getContainerToExport();
     this.prepareStyleForExport(containerInfo);
 
-    svg.saveSvgAsPng(
+    saveSvgAsPng(
       containerInfo.documentToExport,
       this.getFilenameToExport() + ".png",
       containerInfo.exportParameter,

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -86,7 +86,7 @@ export class EditorToolsViewComponent {
       let netzgrafikDto: any;
       try {
         netzgrafikDto = JSON.parse(reader.result.toString());
-      } catch (err: any) {
+      } catch {
         const msg = $localize`:@@app.view.editor-side-view.editor-tools-view-component.import-netzgrafik-error:JSON error`;
         this.logger.error(msg);
         return;
@@ -149,16 +149,18 @@ export class EditorToolsViewComponent {
     const scaleToTargetWidth = 2000 / containerInfo.exportParameter.width;
     containerInfo.exportParameter.scale = scaleToTargetWidth;
 
-    svg.svgAsDataUri(containerInfo.documentToExport, containerInfo.exportParameter).then((uri) => {
-      const a = document.createElement("a");
-      document.body.appendChild(a);
-      a.href = uri;
-      a.download = this.getFilenameToExport() + ".svg";
-      a.click();
-      URL.revokeObjectURL(a.href);
-      a.remove();
-      this.levelOfDetailService.enableLevelOfDetailRendering();
-    });
+    svg
+      .svgAsDataUri(containerInfo.documentToExport, containerInfo.exportParameter)
+      .then((uri: string) => {
+        const a = document.createElement("a");
+        document.body.appendChild(a);
+        a.href = uri;
+        a.download = this.getFilenameToExport() + ".svg";
+        a.click();
+        URL.revokeObjectURL(a.href);
+        a.remove();
+        this.levelOfDetailService.enableLevelOfDetailRendering();
+      });
   }
 
   onExportContainerAsPNG() {
@@ -192,7 +194,7 @@ export class EditorToolsViewComponent {
     const file = fileInput.files[0];
     const reader = new FileReader();
     reader.onload = () => {
-      const finalResult = parse(reader.result.toString(), {
+      const finalResult = parse<Record<string, string>>(reader.result.toString(), {
         header: true,
         delimiter: ";",
       });

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,19 @@
+declare module "save-svg-as-png" {
+  export interface SvgExportOptions {
+    encoderOptions?: number;
+    scale?: number;
+    left?: number;
+    top?: number;
+    width?: number;
+    height?: number;
+    backgroundColor?: string;
+  }
+
+  export function svgAsDataUri(el: Element, options?: SvgExportOptions): Promise<string>;
+
+  export function saveSvgAsPng(
+    el: Element,
+    name: string,
+    options?: SvgExportOptions,
+  ): Promise<void>;
+}

--- a/src/integration-testing/basedata.service.test.spec.ts
+++ b/src/integration-testing/basedata.service.test.spec.ts
@@ -82,7 +82,7 @@ describe("NodeService Test", () => {
       "AA;Aarau;2;Mitte;2;0;2;0;2;0;0;1;0;1;0.2;4;SBB;-209.4991625;-427.021373;1\n" +
       "ABE;Aarberg;4;Mitte; ;1; ;1; ;1; ;1; ;1;0;0;;0;0;0\n";
 
-    const finalResult = parse(baseDataCSV, {header: true, delimiter: ";"});
+    const finalResult = parse<Record<string, string>>(baseDataCSV, {header: true, delimiter: ";"});
     baseDataService.setBaseData(finalResult.data);
     const aa = baseDataService.getBaseDataByBetriebspunktName("AA");
     expect(aa.getRegions()[0]).toBe("Mitte");
@@ -117,7 +117,10 @@ describe("NodeService Test", () => {
       "ZAZ;Umsteigezeit;Labels;XCoord;YCoord;Create\n" +
       "AA;Aarau;2;Mitte;2;1;2;1;2;1;0;0;0;0;0.2;4;SBB;-209.4991625;-427.021373;1\n";
 
-    const finalResult = parse(legacyBaseDataCSV, {header: true, delimiter: ";"});
+    const finalResult = parse<Record<string, string>>(legacyBaseDataCSV, {
+      header: true,
+      delimiter: ";",
+    });
     baseDataService.setBaseData(finalResult.data);
 
     const aa = baseDataService.getBaseDataByBetriebspunktName("AA");
@@ -134,7 +137,7 @@ describe("NodeService Test", () => {
       "ZAZ (Train dispatching time);ConnectionTime;Labels;XCoord;YCoord;Create\n" +
       "AA;Aarau;2;Mitte;2;2;2;0;0;0.2;4;SBB;-209.4991625;-427.021373;1\n";
 
-    const finalResult = parse(baseDataWithoutPassingThroughStationCSV, {
+    const finalResult = parse<Record<string, string>>(baseDataWithoutPassingThroughStationCSV, {
       header: true,
       delimiter: ";",
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "typeRoots": ["node_modules/@types"],
     "lib": ["es2023", "dom"],
     "resolveJsonModule": true,
-    "useDefineForClassFields": false
+    "useDefineForClassFields": false,
+    "noImplicitAny": true
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,


### PR DESCRIPTION
Replaces all implicit and some explicit `any` types with specific types, simplifying and cleaning up some code around.
Enable `noImplicitAny`.

The typing of `save-svg-as-png` requested the creation of new `.d.ts` file because it is an untyped module and doesn't have a `@types/save-svg-as-png`.
We should [replace this module]( https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/issues/1167) soon anyway.