### PR TITLE
experimental! feat(view): make editor background rastering grid visible

### DIFF
--- a/src/app/view/editor-main-view/data-views/editor.view.ts
+++ b/src/app/view/editor-main-view/data-views/editor.view.ts
@@ -45,9 +45,13 @@ import {
 } from "../../../data-structures/business.data.structures";
 import {TrainrunSectionText} from "../../../data-structures/technical.data.structures";
 import {AutoLayoutService} from "../../../services/util/auto-layout.service";
+import {RASTERING_BASIC_GRID_SIZE} from "../../rastering/definitions";
 
 export class EditorView implements SVGMouseControllerObserver {
   static svgName = "graphContainer";
+  private static readonly RASTER_GRID_PATTERN_ID = "editor-raster-grid-pattern";
+  private static readonly RASTER_GRID_DEFS_ID = "editor-raster-grid-defs";
+  private static readonly RASTER_GRID_SPAN = 100000;
   editorMode: EditorMode = EditorMode.NetzgrafikEditing;
   controller: EditorMainViewComponent;
   svgMouseController: SVGMouseController;
@@ -590,6 +594,7 @@ export class EditorView implements SVGMouseControllerObserver {
     this.rootContainer = this.svgMouseController.init(
       this.uiInteractionService.getViewboxProperties(EditorView.svgName),
     );
+    this.createVisibleRasterGrid();
     this.notesView.setGroup(this.rootContainer.append(StaticDomTags.GROUP_SVG));
     this.nodesView.setGroup(this.rootContainer.append(StaticDomTags.GROUP_SVG));
     this.transitionsView.setGroup(this.rootContainer.append(StaticDomTags.GROUP_SVG));
@@ -598,6 +603,48 @@ export class EditorView implements SVGMouseControllerObserver {
     TrainrunSectionPreviewLineView.setGroup(this.rootContainer);
     TrainrunSectionPreviewLineView.setConnectionGroup(this.rootContainer);
     MultiSelectRenderer.setGroup(this.rootContainer);
+  }
+
+  private createVisibleRasterGrid() {
+    const rootContainerNode = this.rootContainer.node();
+    if (rootContainerNode === null) {
+      return;
+    }
+
+    const ownerSvgElement = rootContainerNode.ownerSVGElement;
+    if (ownerSvgElement === null) {
+      return;
+    }
+
+    const ownerSvgSelection = d3.select(ownerSvgElement);
+    ownerSvgSelection.select(`defs#${EditorView.RASTER_GRID_DEFS_ID}`).remove();
+
+    const defs = ownerSvgSelection.append("defs").attr("id", EditorView.RASTER_GRID_DEFS_ID);
+    const gridSize = RASTERING_BASIC_GRID_SIZE;
+
+    const pattern = defs
+      .append("pattern")
+      .attr("id", EditorView.RASTER_GRID_PATTERN_ID)
+      .attr("patternUnits", "userSpaceOnUse")
+      .attr("width", gridSize)
+      .attr("height", gridSize)
+      .attr("x", 0)
+      .attr("y", 0);
+
+    pattern
+      .append("path")
+      .attr("class", "editor_raster_grid_line")
+      .attr("d", `M ${gridSize} 0 L 0 0 0 ${gridSize}`)
+      .attr("fill", "none");
+
+    this.rootContainer
+      .append("rect")
+      .attr("class", "editor_raster_grid")
+      .attr("x", -EditorView.RASTER_GRID_SPAN)
+      .attr("y", -EditorView.RASTER_GRID_SPAN)
+      .attr("width", 2 * EditorView.RASTER_GRID_SPAN)
+      .attr("height", 2 * EditorView.RASTER_GRID_SPAN)
+      .attr("fill", `url(#${EditorView.RASTER_GRID_PATTERN_ID})`);
   }
 
   onEarlyReturnFromMousemove(event: MouseEvent): boolean {

--- a/src/app/view/editor-main-view/editor-main-view.component.scss
+++ b/src/app/view/editor-main-view/editor-main-view.component.scss
@@ -28,6 +28,18 @@
   background: $COLOR_BACKGROUND;
 }
 
+::ng-deep .editor_raster_grid {
+  pointer-events: none;
+}
+
+::ng-deep .editor_raster_grid_line {
+  stroke: $COLOR_STRECKENGRAPHIK_LINE_GRID_X;
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+  opacity: 0.35;
+  shape-rendering: crispEdges;
+}
+
 ::ng-deep .enforce_disable_all_pointer_events {
   pointer-events: none;
   opacity: 0.25;


### PR DESCRIPTION
<img width="1919" height="916" alt="image" src="https://github.com/user-attachments/assets/7a768958-afaf-4db4-8a61-4a7661969c57" />


The snapping implementation lies on a 32px raster. This commit creates a grid to mimic the same raster as a background layer.

When zooming out below 100%, the grid stroke width is less than 1px. Adding `vector-effect: non-scaling-stroke;` makes it still visible.

This layer should probably only be shown when the user's moving an object. Or make it as an option. This can be done later on.

Some useful information about the different objects' size: https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/blob/main/src/app/view/rastering/definitions.ts#L1

This draft PR is part of an experimental design refinement with @thibautsailly.