### PR TITLE
Show language selector in standalone mode (#1234)

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -25,17 +25,13 @@
     <sbb-icon svgIcon="user-small" *sbbIcon></sbb-icon>
   </sbb-usermenu>
   <sbb-menu #menu="sbbMenu">
-    <sbb-select
-      (selectionChange)="language = $event.value"
-      [value]="currentLanguage"
-      class="language-selector language-selector-menu"
+    <sbb-language-selector
+      [currentLanguage]="currentLanguage"
+      (languageChange)="language = $event"
+      variantClass="language-selector-menu"
       (click)="$event.stopPropagation()"
       (keydown)="$event.stopPropagation()"
-    >
-      <sbb-option value="en">🇬🇧 English</sbb-option>
-      <sbb-option value="de">🇩🇪 Deutsch</sbb-option>
-      <sbb-option value="fr">🇫🇷 Français</sbb-option>
-    </sbb-select>
+    ></sbb-language-selector>
     <hr />
     <button sbb-menu-item (click)="logout()">
       <sbb-icon svgIcon="exit-small" class="sbb-icon-fit"></sbb-icon>
@@ -43,6 +39,12 @@
     </button>
   </sbb-menu>
 </sbb-header-lean>
+<sbb-language-selector
+  *ngIf="disableBackend"
+  [currentLanguage]="currentLanguage"
+  (languageChange)="language = $event"
+  variantClass="language-selector-standalone noprint"
+></sbb-language-selector>
 <ng-container *ngIf="!disableBackend">
   <sbb-navigation-bar class="noprint"></sbb-navigation-bar>
 </ng-container>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -43,6 +43,16 @@
     </button>
   </sbb-menu>
 </sbb-header-lean>
+<sbb-select
+  *ngIf="disableBackend"
+  (selectionChange)="language = $event.value"
+  [value]="currentLanguage"
+  class="language-selector language-selector-standalone noprint"
+>
+  <sbb-option value="en">🇬🇧 English</sbb-option>
+  <sbb-option value="de">🇩🇪 Deutsch</sbb-option>
+  <sbb-option value="fr">🇫🇷 Français</sbb-option>
+</sbb-select>
 <ng-container *ngIf="!disableBackend">
   <sbb-navigation-bar class="noprint"></sbb-navigation-bar>
 </ng-container>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -74,11 +74,6 @@ sbb-loading-indicator {
   margin: 0;
 }
 
-.sbb-select.language-selector-menu {
-  transform: translate(10px, 1px);
-  width: 95%;
-}
-
 ::ng-deep .sbb-checkbox .sbb-selection-container {
   border-width: 2px;
   border-radius: 3px;

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -79,6 +79,18 @@ sbb-loading-indicator {
   width: 95%;
 }
 
+.sbb-select.language-selector-standalone {
+  position: fixed;
+  top: 0;
+  right: 160px; // clear of the fixed logo/icon at the far right of the header
+  z-index: 1001; // above sbb-header-lean's own z-index of 1000
+  height: 54px; // match sbb-header-lean's height so it's vertically centered in it
+  width: auto;
+  min-width: 8rem;
+  display: flex;
+  align-items: center;
+}
+
 ::ng-deep .sbb-checkbox .sbb-selection-container {
   border-width: 2px;
   border-radius: 3px;

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -31,6 +31,7 @@ import {SbbTooltipModule} from "@sbb-esta/angular/tooltip";
 import {SbbUsermenuModule} from "@sbb-esta/angular/usermenu";
 import {AppRoutingModule} from "./app-routing.module";
 import {AppComponent} from "./app.component";
+import {LanguageSelectorComponent} from "./view/language-selector/language-selector.component";
 import {EditorMainViewComponent} from "./view/editor-main-view/editor-main-view.component";
 import {ColumnLayoutComponent} from "./view/column-layout/column-layout.component";
 import {NetzgrafikApplicationComponent} from "./netzgrafik-application/netzgrafik-application.component";
@@ -113,6 +114,7 @@ import {TimeStepperComponent} from "./view/dialogs/trainrun-and-section-dialog/t
 @NgModule({
   declarations: [
     AppComponent,
+    LanguageSelectorComponent,
     EditorMainViewComponent,
     ColumnLayoutComponent,
     NetzgrafikApplicationComponent,

--- a/src/app/view/language-selector/language-selector.component.html
+++ b/src/app/view/language-selector/language-selector.component.html
@@ -1,0 +1,10 @@
+<sbb-select
+  (selectionChange)="onSelectionChange($event.value)"
+  [value]="currentLanguage"
+  class="language-selector"
+  [ngClass]="variantClass"
+>
+  <sbb-option value="en">🇬🇧 English</sbb-option>
+  <sbb-option value="de">🇩🇪 Deutsch</sbb-option>
+  <sbb-option value="fr">🇫🇷 Français</sbb-option>
+</sbb-select>

--- a/src/app/view/language-selector/language-selector.component.scss
+++ b/src/app/view/language-selector/language-selector.component.scss
@@ -1,0 +1,23 @@
+// Used when this component is placed inside sbb-header-lean's user menu
+// (normal, non-standalone mode).
+.sbb-select.language-selector-menu {
+  transform: translate(10px, 1px);
+  width: 95%;
+}
+
+// Used when this component is placed directly in standalone mode, overlaid
+// on top of the fixed-position header (sbb-header-lean is position:fixed,
+// and the rest of the app's layout - icon sidebar, canvas - is itself
+// fixed-positioned assuming a constant header height, so this needs to be
+// positioned the same way rather than taking up normal document flow space).
+.sbb-select.language-selector-standalone {
+  position: fixed;
+  top: 7px; // inverted vertically within sbb-header-lean
+  right: 135px; // close to the SBB logo
+  z-index: 1001; // above sbb-header-lean's own z-index of 1000
+  height: 40px; // smaller height than sbb-header-lean's
+  display: flex;
+  align-items: center;
+  width: auto;
+  min-width: 8rem;
+}

--- a/src/app/view/language-selector/language-selector.component.ts
+++ b/src/app/view/language-selector/language-selector.component.ts
@@ -1,0 +1,22 @@
+import {Component, EventEmitter, Input, Output} from "@angular/core";
+
+@Component({
+  selector: "sbb-language-selector",
+  templateUrl: "./language-selector.component.html",
+  styleUrls: ["./language-selector.component.scss"],
+  standalone: false,
+})
+export class LanguageSelectorComponent {
+  @Input() currentLanguage!: string;
+
+  // Additional CSS class(es) applied to the inner sbb-select, so callers can
+  // style/position this component differently depending on where it's used
+  // (e.g. inside the user menu vs. directly in the header for standalone mode).
+  @Input() variantClass = "";
+
+  @Output() readonly languageChange = new EventEmitter<string>();
+
+  onSelectionChange(value: string): void {
+    this.languageChange.emit(value);
+  }
+}


### PR DESCRIPTION
Fixes #1234

In standalone mode (disableBackend: true), the language selector was nested inside sbb-usermenu, which never renders since authenticated never resolves without a backend — so the selector was completely inaccessible.

This adds a separate sbb-select shown only when disableBackend is true, positioned as a fixed overlay on the header (position: fixed, matching sbb-header-lean's own positioning). This was necessary because the rest of the app's layout (icon sidebar, canvas) is itself fixed-positioned assuming a constant header height, so anything added to the normal document flow after the header gets visually covered by the canvas.

Verified: switching language actually updates UI text (tested DE/FR), no visual overlap with the header's existing elements, normal (non-standalone) mode unaffected.


<img width="2560" height="1340" alt="image" src="https://github.com/user-attachments/assets/89d8b311-80ed-46bf-862a-34debdb4c524" />


<img width="2560" height="1340" alt="image" src="https://github.com/user-attachments/assets/e58271a0-9bde-4dc0-a08e-d4a92a55e964" />


<img width="2560" height="1340" alt="image" src="https://github.com/user-attachments/assets/016dca4d-a845-46f2-b6b6-54054150811d" />

