### PR TITLE
Enable no unused rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -57,9 +57,10 @@ export default defineConfig([
         },
       ],
       "@typescript-eslint/no-unused-vars": [
-        "off",
+        "error",
         {
-          args: "all",
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
         },
       ],
       "@typescript-eslint/no-deprecated": "warn",

--- a/src/app/perlenkette/perlenkette-node/perlenkette-node.component.html
+++ b/src/app/perlenkette/perlenkette-node/perlenkette-node.component.html
@@ -125,9 +125,9 @@
               class="edge_text station start layer0"
               style="stroke-width: 6px"
               (click)="selectConnection(connection)"
-              [ngClass]="[getTextNameOrTimeClassTag(connection, connectionGrpKey, 0)]"
+              [ngClass]="[getTextNameOrTimeClassTag(connection, 0)]"
             >
-              {{ getTextNameOrTime(connection, connectionGrpKey, 0) }}
+              {{ getTextNameOrTime(connection, 0) }}
             </text>
             <text
               [attr.x]="getTrainrunNameFieldPosition()"
@@ -135,9 +135,9 @@
               dominant-baseline="text-after-edge"
               class="edge_text station start"
               (click)="selectConnection(connection)"
-              [ngClass]="[getTextNameOrTimeClassTag(connection, connectionGrpKey, 0)]"
+              [ngClass]="[getTextNameOrTimeClassTag(connection, 0)]"
             >
-              {{ getTextNameOrTime(connection, connectionGrpKey, 0) }}
+              {{ getTextNameOrTime(connection, 0) }}
             </text>
 
             <text
@@ -149,9 +149,9 @@
               class="edge_text station end layer0"
               (click)="selectConnection(connection)"
               style="stroke-width: 6px"
-              [ngClass]="[getTextNameOrTimeClassTag(connection, connectionGrpKey, 1)]"
+              [ngClass]="[getTextNameOrTimeClassTag(connection, 1)]"
             >
-              {{ getTextNameOrTime(connection, connectionGrpKey, 1) }}
+              {{ getTextNameOrTime(connection, 1) }}
             </text>
             <text
               *ngIf="filterService.isFilterArrivalDepartureTimeEnabled()"
@@ -161,9 +161,9 @@
               dominant-baseline="text-after-edge"
               class="edge_text station end"
               (click)="selectConnection(connection)"
-              [ngClass]="[getTextNameOrTimeClassTag(connection, connectionGrpKey, 1)]"
+              [ngClass]="[getTextNameOrTimeClassTag(connection, 1)]"
             >
-              {{ getTextNameOrTime(connection, connectionGrpKey, 1) }}
+              {{ getTextNameOrTime(connection, 1) }}
             </text>
 
             <text
@@ -173,9 +173,9 @@
               class="edge_text end station layer0"
               (click)="selectConnection(connection)"
               style="stroke-width: 6px"
-              [ngClass]="[getTextTerminalStationlassTag(connection, connectionGrpKey, 0)]"
+              [ngClass]="[getTextTerminalStationlassTag(connection, 0)]"
             >
-              {{ getTextTerminalStation(connection, connectionGrpKey, 0) }}
+              {{ getTextTerminalStation(connection, 0) }}
             </text>
             <text
               [attr.x]="getFromStationNameFieldPosition()"
@@ -183,9 +183,9 @@
               dominant-baseline="text-after-edge"
               class="edge_text end station"
               (click)="selectConnection(connection)"
-              [ngClass]="[getTextTerminalStationlassTag(connection, connectionGrpKey, 0)]"
+              [ngClass]="[getTextTerminalStationlassTag(connection, 0)]"
             >
-              {{ getTextTerminalStation(connection, connectionGrpKey, 0) }}
+              {{ getTextTerminalStation(connection, 0) }}
             </text>
 
             <text
@@ -196,9 +196,9 @@
               class="edge_text start station layer0"
               (click)="selectConnection(connection)"
               style="stroke-width: 6px"
-              [ngClass]="[getTextTerminalStationlassTag(connection, connectionGrpKey, 1)]"
+              [ngClass]="[getTextTerminalStationlassTag(connection, 1)]"
             >
-              {{ getTextTerminalStation(connection, connectionGrpKey, 1) }}
+              {{ getTextTerminalStation(connection, 1) }}
             </text>
             <text
               [attr.x]="getToStationNameFieldPosition()"
@@ -207,9 +207,9 @@
               dominant-baseline="text-after-edge"
               class="edge_text start station"
               (click)="selectConnection(connection)"
-              [ngClass]="[getTextTerminalStationlassTag(connection, connectionGrpKey, 1)]"
+              [ngClass]="[getTextTerminalStationlassTag(connection, 1)]"
             >
-              {{ getTextTerminalStation(connection, connectionGrpKey, 1) }}
+              {{ getTextTerminalStation(connection, 1) }}
             </text>
           </g>
         </ng-container>

--- a/src/app/perlenkette/perlenkette-node/perlenkette-node.component.ts
+++ b/src/app/perlenkette/perlenkette-node/perlenkette-node.component.ts
@@ -185,11 +185,11 @@ export class PerlenketteNodeComponent implements OnInit, AfterViewInit {
     return topLen + 0.5;
   }
 
-  getTextTerminalStation(connection: PerlenketteConnection, connectionGrpKey: number, pos: number) {
+  getTextTerminalStation(connection: PerlenketteConnection, pos: number) {
     return pos === 0 ? connection.terminalStationBackward : connection.terminalStation;
   }
 
-  getTextNameOrTime(connection: PerlenketteConnection, connectionGrpKey: number, pos: number) {
+  getTextNameOrTime(connection: PerlenketteConnection, pos: number) {
     return pos === 0
       ? connection.categoryShortName + "" + connection.title
       : "" +
@@ -234,11 +234,7 @@ export class PerlenketteNodeComponent implements OnInit, AfterViewInit {
     );
   }
 
-  getTextNameOrTimeClassTag(
-    connection: PerlenketteConnection,
-    connectionGrpKey: number,
-    pos: number,
-  ): string {
+  getTextNameOrTimeClassTag(connection: PerlenketteConnection, pos: number): string {
     let retVal = this.getColoringClassTag(connection);
     if (pos !== 0 && this.isNonStopTransition(connection)) {
       retVal = retVal + " " + StaticDomTags.TAG_WARNING;
@@ -247,11 +243,7 @@ export class PerlenketteNodeComponent implements OnInit, AfterViewInit {
     return pos === 0 ? retVal + " TrainrunName" : retVal + " RemainingTime";
   }
 
-  getTextTerminalStationlassTag(
-    connection: PerlenketteConnection,
-    connectionGrpKey: number,
-    pos: number,
-  ): string {
+  getTextTerminalStationlassTag(connection: PerlenketteConnection, pos: number): string {
     const retVal = this.getColoringClassTag(connection);
     return pos === 0 ? retVal + " FROM" : retVal + " TO";
   }

--- a/src/app/perlenkette/perlenkette-section/perlenkette-section.component.ts
+++ b/src/app/perlenkette/perlenkette-section/perlenkette-section.component.ts
@@ -118,7 +118,7 @@ export class PerlenketteSectionComponent implements OnInit, AfterContentInit, On
     this.numberOfStops = this.perlenketteSection.numberOfStops;
     this.stationNumberArray = Array(this.perlenketteSection.numberOfStops)
       .fill(1)
-      .map((x, i) => i + 1);
+      .map((_, i) => i + 1);
     this.trainrunSection = this.trainrunSectionService.getTrainrunSectionFromId(
       this.perlenketteSection.trainrunSectionId,
     );

--- a/src/app/perlenkette/perlenkette.component.ts
+++ b/src/app/perlenkette/perlenkette.component.ts
@@ -252,7 +252,7 @@ export class PerlenketteComponent implements AfterContentChecked, OnDestroy {
     if (event.buttons > 0) {
       let currentY = this.svgPoint.getY();
       currentY -= event.movementY;
-      this.updateSvgPointY(undefined, currentY);
+      this.updateSvgPointY(currentY);
     }
     event.stopPropagation();
   }
@@ -351,7 +351,7 @@ export class PerlenketteComponent implements AfterContentChecked, OnDestroy {
 
   goto(pathItem: PerlenketteItem) {
     const currentY = this.getGotoCurrentY(pathItem);
-    this.updateSvgPointY(pathItem, currentY - this.contentHeight / 4);
+    this.updateSvgPointY(currentY - this.contentHeight / 4);
     const offset = new Vec2D(this.contentWidth / 2, 0);
     this.moveNetzgrafikEditorFocalViewPoint(pathItem, offset);
   }
@@ -371,7 +371,7 @@ export class PerlenketteComponent implements AfterContentChecked, OnDestroy {
       });
       const delta = pItemHeight !== undefined ? pItemHeight[1] : 0;
       const currentY = this.getGotoCurrentY(pathItem) + delta;
-      this.updateSvgPointY(pathItem, currentY - this.contentHeight / 4);
+      this.updateSvgPointY(currentY - this.contentHeight / 4);
     }
   }
 
@@ -396,11 +396,11 @@ export class PerlenketteComponent implements AfterContentChecked, OnDestroy {
     const delta = Math.min(64, Math.max(-64, event.deltaY));
     const currentEl: PerlenketteNode = this.getClosestPerlenketteItem();
     if (currentEl !== undefined) {
-      this.updateSvgPointY(currentEl, this.svgPoint.getY() + delta);
+      this.updateSvgPointY(this.svgPoint.getY() + delta);
     }
   }
 
-  private updateSvgPointY(pathItem: PerlenketteItem, y: number) {
+  private updateSvgPointY(y: number) {
     this.svgPoint.setY(
       Math.max(-this.contentHeight / 4, Math.min(this.renderedElementsHeight - 48, y)),
     );

--- a/src/app/perlenkette/perlenkette.component.ts
+++ b/src/app/perlenkette/perlenkette.component.ts
@@ -23,8 +23,6 @@ import {NodeService} from "../services/data/node.service";
 import {takeUntil} from "rxjs/operators";
 import {PerlenketteConnection} from "./model/perlenketteConnection";
 import {VersionControlService} from "../services/data/version-control.service";
-import {Direction} from "../data-structures/business.data.structures";
-import {TrainrunsectionHelper} from "../services/util/trainrunsection.helper";
 import {TrainrunSectionService} from "../services/data/trainrunsection.service";
 import {TrainrunService} from "../services/data/trainrun.service";
 

--- a/src/app/perlenkette/service/load-perlenkette.service.ts
+++ b/src/app/perlenkette/service/load-perlenkette.service.ts
@@ -38,21 +38,19 @@ export class LoadPerlenketteService implements OnDestroy {
       this.render();
     });
 
-    this.trainrunSectionService.trainrunSections
-      .pipe(takeUntil(this.destroyed$))
-      .subscribe((trainrunsSection) => {
-        this.render();
-      });
-
-    this.nodeService.transitions.pipe(takeUntil(this.destroyed$)).subscribe((transition) => {
+    this.trainrunSectionService.trainrunSections.pipe(takeUntil(this.destroyed$)).subscribe(() => {
       this.render();
     });
 
-    this.nodeService.nodes.pipe(takeUntil(this.destroyed$)).subscribe((node) => {
+    this.nodeService.transitions.pipe(takeUntil(this.destroyed$)).subscribe(() => {
       this.render();
     });
 
-    this.nodeService.connections.pipe(takeUntil(this.destroyed$)).subscribe((connection) => {
+    this.nodeService.nodes.pipe(takeUntil(this.destroyed$)).subscribe(() => {
+      this.render();
+    });
+
+    this.nodeService.connections.pipe(takeUntil(this.destroyed$)).subscribe(() => {
       this.render();
     });
   }

--- a/src/app/perlenkette/service/load-perlenkette.service.ts
+++ b/src/app/perlenkette/service/load-perlenkette.service.ts
@@ -15,7 +15,6 @@ import {Node} from "../../models/node.model";
 import {TrainrunSectionService} from "../../services/data/trainrunsection.service";
 import {NodeService} from "../../services/data/node.service";
 import {FilterService} from "../../services/ui/filter.service";
-import {TrainrunSection} from "../../models/trainrunsection.model";
 
 @Injectable({
   providedIn: "root",

--- a/src/app/sample-netzgrafik/netzgrafik.default.spec.ts
+++ b/src/app/sample-netzgrafik/netzgrafik.default.spec.ts
@@ -47,7 +47,7 @@ describe("NetzgrafikDefault", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,

--- a/src/app/sample-netzgrafik/netzgrafik.default.spec.ts
+++ b/src/app/sample-netzgrafik/netzgrafik.default.spec.ts
@@ -1,4 +1,3 @@
-import netzgrafikDefaultJson from "./netzgrafik_default.json";
 import {NetzgrafikDefault} from "./netzgrafik.default";
 import {DataService} from "../services/data/data.service";
 import {LogPublishersService} from "../logger/log.publishers.service";

--- a/src/app/services/data/copy.service.spec.ts
+++ b/src/app/services/data/copy.service.spec.ts
@@ -60,7 +60,7 @@ describe("CopyService", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,
@@ -188,7 +188,7 @@ describe("CopyService", () => {
     nodeService.selectNode(2);
     noteService.selectNote(3);
 
-    const copiedNetzgrafik = copyService.copyCurrentVisibleNetzgrafik();
+    copyService.copyCurrentVisibleNetzgrafik();
     uiInteractionService.setEditorMode(EditorMode.NetzgrafikEditing);
     nodeService.deleteAllVisibleNodes();
     noteService.deleteAllVisibleNotes();

--- a/src/app/services/data/copy.service.spec.ts
+++ b/src/app/services/data/copy.service.spec.ts
@@ -5,8 +5,6 @@ import {TrainrunService} from "../data/trainrun.service";
 import {TrainrunSectionService} from "../data/trainrunsection.service";
 import {BaseDataService} from "../data/basedata.service";
 import {NoteService} from "../data/note.service";
-import {Node} from "../../models/node.model";
-import {TrainrunSection} from "../../models/trainrunsection.model";
 import {LogService} from "../../logger/log.service";
 import {LogPublishersService} from "../../logger/log.publishers.service";
 import {LabelGroupService} from "../data/labelgroup.service";
@@ -28,8 +26,6 @@ describe("CopyService", () => {
   let trainrunSectionService: TrainrunSectionService;
   let baseDataService: BaseDataService;
   let noteService: NoteService;
-  let nodes: Node[] = null;
-  let trainrunSections: TrainrunSection[] = null;
   let logService: LogService = null;
   let logPublishersService: LogPublishersService = null;
   let labelGroupService: LabelGroupService = null;
@@ -72,10 +68,6 @@ describe("CopyService", () => {
       labelGroupService,
       filterService,
       netzgrafikColoringService,
-    );
-    nodeService.nodes.subscribe((updatesNodes) => (nodes = updatesNodes));
-    trainrunSectionService.trainrunSections.subscribe(
-      (updatesTrainrunSections) => (trainrunSections = updatesTrainrunSections),
     );
 
     loadPerlenketteService = new LoadPerlenketteService(

--- a/src/app/services/data/data.service.ts
+++ b/src/app/services/data/data.service.ts
@@ -225,7 +225,7 @@ export class DataService implements OnDestroy {
       (trainrunCategory) => trainrunCategory.id === categoryId,
     );
     if (found === undefined) {
-      return this.netzgrafikDtoStore.netzgrafikDto.metadata.trainrunCategories.find((freq) => true);
+      return this.netzgrafikDtoStore.netzgrafikDto.metadata.trainrunCategories.find(() => true);
     }
     return found;
   }
@@ -235,9 +235,7 @@ export class DataService implements OnDestroy {
       (trainrunFrequency) => trainrunFrequency.id === frequencyId,
     );
     if (found === undefined) {
-      return this.netzgrafikDtoStore.netzgrafikDto.metadata.trainrunFrequencies.find(
-        (freq) => true,
-      );
+      return this.netzgrafikDtoStore.netzgrafikDto.metadata.trainrunFrequencies.find(() => true);
     }
     return found;
   }
@@ -247,9 +245,7 @@ export class DataService implements OnDestroy {
       (trainrunTimeCategory) => trainrunTimeCategory.id === timeCategoryId,
     );
     if (found === undefined) {
-      return this.netzgrafikDtoStore.netzgrafikDto.metadata.trainrunTimeCategories.find(
-        (freq) => true,
-      );
+      return this.netzgrafikDtoStore.netzgrafikDto.metadata.trainrunTimeCategories.find(() => true);
     }
     return found;
   }

--- a/src/app/services/data/is-trainrun-selected.service.spec.ts
+++ b/src/app/services/data/is-trainrun-selected.service.spec.ts
@@ -52,7 +52,7 @@ describe("IsTrainrunSelectedService", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,

--- a/src/app/services/data/netzgrafikColoring.service.spec.ts
+++ b/src/app/services/data/netzgrafikColoring.service.spec.ts
@@ -5,8 +5,6 @@ import {TrainrunService} from "../data/trainrun.service";
 import {TrainrunSectionService} from "../data/trainrunsection.service";
 import {BaseDataService} from "../data/basedata.service";
 import {NoteService} from "../data/note.service";
-import {Node} from "../../models/node.model";
-import {TrainrunSection} from "../../models/trainrunsection.model";
 import {LogService} from "../../logger/log.service";
 import {LogPublishersService} from "../../logger/log.publishers.service";
 import {LabelGroupService} from "../data/labelgroup.service";
@@ -27,8 +25,6 @@ describe("NetzgraphikColoringService", () => {
   let trainrunSectionService: TrainrunSectionService;
   let baseDataService: BaseDataService;
   let noteService: NoteService;
-  let nodes: Node[] = null;
-  let trainrunSections: TrainrunSection[] = null;
   let logService: LogService = null;
   let logPublishersService: LogPublishersService = null;
   let labelGroupService: LabelGroupService = null;
@@ -71,10 +67,6 @@ describe("NetzgraphikColoringService", () => {
       labelGroupService,
       filterService,
       netzgrafikColoringService,
-    );
-    nodeService.nodes.subscribe((updatesNodes) => (nodes = updatesNodes));
-    trainrunSectionService.trainrunSections.subscribe(
-      (updatesTrainrunSections) => (trainrunSections = updatesTrainrunSections),
     );
 
     loadPerlenketteService = new LoadPerlenketteService(

--- a/src/app/services/data/netzgrafikColoring.service.spec.ts
+++ b/src/app/services/data/netzgrafikColoring.service.spec.ts
@@ -59,7 +59,7 @@ describe("NetzgraphikColoringService", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,
@@ -119,9 +119,8 @@ describe("NetzgraphikColoringService", () => {
 
   it("test NetzgrafikColor.createDefaultColorForNotExistingColors", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
-    const loadedNetzgrafik = dataService.getNetzgrafikDto();
     netzgrafikColoringService.generateColors();
-    const styles = netzgrafikColoringService.generateGlobalStyles(
+    netzgrafikColoringService.generateGlobalStyles(
       dataService.getTrainrunCategories(),
       trainrunSectionService.getTrainrunSections(),
     );
@@ -143,7 +142,6 @@ describe("NetzgraphikColoringService", () => {
 
   it("test NetzgrafikColor.generateColors", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
-    const loadedNetzgrafik = dataService.getNetzgrafikDto();
 
     netzgrafikColoringService.createDefaultColorForNotExistingColors("Adrian");
     netzgrafikColoringService.generateColors();
@@ -153,7 +151,6 @@ describe("NetzgraphikColoringService", () => {
 
   it("test NetzgrafikColor.changeColorRef", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
-    const loadedNetzgrafik = dataService.getNetzgrafikDto();
 
     netzgrafikColoringService.createDefaultColorForNotExistingColors("Adrian");
     const v1 = netzgrafikColoringService.getNetzgrafikColor("Adrian");

--- a/src/app/services/data/netzgrafikColoring.service.ts
+++ b/src/app/services/data/netzgrafikColoring.service.ts
@@ -3,7 +3,6 @@ import {BehaviorSubject} from "rxjs";
 import {NetzgrafikColorDto, TrainrunCategory} from "../../data-structures/business.data.structures";
 import {StaticDomTags} from "../../view/editor-main-view/data-views/static.dom.tags";
 import {NetzgrafikColor} from "../../models/netzgrafikColor.model";
-import {LogService} from "../../logger/log.service";
 import {TrainrunSection} from "../../models/trainrunsection.model";
 import {ColorRefType} from "../../data-structures/technical.data.structures";
 
@@ -21,7 +20,7 @@ export class NetzgrafikColoringService {
   private isDarkMode = false;
   private generatedStyleSheets: CSSStyleSheet[];
 
-  constructor(private logService: LogService) {
+  constructor() {
     this.generateColors();
   }
 
@@ -364,7 +363,6 @@ export class NetzgrafikColoringService {
   generateGlobalStyles(
     trainrunCategories: TrainrunCategory[],
     trainrunSections: TrainrunSection[],
-    verbose = false,
   ) {
     // collect all used colorRefs
     const colorRefs = this.collectColorRefs(trainrunCategories, trainrunSections);

--- a/src/app/services/data/node.service.ts
+++ b/src/app/services/data/node.service.ts
@@ -224,7 +224,7 @@ export class NodeService implements OnDestroy {
     });
   }
 
-  duplicateNode(nodeId: number, enforceUpdate = true): Node {
+  duplicateNode(nodeId: number): Node {
     const node = this.getNodeFromId(nodeId);
     const newNode = this.addNodeWithPosition(
       node.getPositionX(),
@@ -606,11 +606,7 @@ export class NodeService implements OnDestroy {
     );
   }
 
-  checkExistsNoCycleTrainrunAfterFreePortsConnecting(
-    node: Node,
-    port1: Port,
-    port2: Port,
-  ): boolean {
+  checkExistsNoCycleTrainrunAfterFreePortsConnecting(port1: Port, port2: Port): boolean {
     const checkPort1 = this.trainrunService.isStartEqualsEndNode(
       port1.getTrainrunSection().getId(),
     );
@@ -625,22 +621,14 @@ export class NodeService implements OnDestroy {
     if (freePorts.length <= 1) {
       return;
     }
-    if (this.checkExistsNoCycleTrainrunAfterFreePortsConnecting(node, freePorts[0], freePorts[1])) {
+    if (this.checkExistsNoCycleTrainrunAfterFreePortsConnecting(freePorts[0], freePorts[1])) {
       node.addTransitionAndComputeRouting(freePorts[0], freePorts[1], trainrun, isNonStop);
     } else {
       if (freePorts.length === 3) {
-        if (
-          this.checkExistsNoCycleTrainrunAfterFreePortsConnecting(node, freePorts[0], freePorts[2])
-        ) {
+        if (this.checkExistsNoCycleTrainrunAfterFreePortsConnecting(freePorts[0], freePorts[2])) {
           node.addTransitionAndComputeRouting(freePorts[0], freePorts[2], trainrun, isNonStop);
         } else {
-          if (
-            this.checkExistsNoCycleTrainrunAfterFreePortsConnecting(
-              node,
-              freePorts[1],
-              freePorts[2],
-            )
-          ) {
+          if (this.checkExistsNoCycleTrainrunAfterFreePortsConnecting(freePorts[1], freePorts[2])) {
             node.addTransitionAndComputeRouting(freePorts[1], freePorts[2], trainrun, isNonStop);
           }
         }

--- a/src/app/services/data/note.service.ts
+++ b/src/app/services/data/note.service.ts
@@ -312,24 +312,14 @@ export class NoteService {
     return this.notesStore.notes.map((note) => note.getDto());
   }
 
-  moveSelectedNotes(
-    deltaPositionX: number,
-    deltaPositionY: number,
-    round: number,
-    dragEnd: boolean,
-  ) {
+  moveSelectedNotes(deltaPositionX: number, deltaPositionY: number, round: number) {
     const notesToUpdate = this.getSelectedNotes();
     notesToUpdate.forEach((note) => {
       const newPosition = NoteService.alginNoteToRaster(
         new Vec2D(note.getPositionX() + deltaPositionX, note.getPositionY() + deltaPositionY),
         round,
       );
-      this.changeNotePositionWithoutUpdate(
-        note.getId(),
-        newPosition.getX(),
-        newPosition.getY(),
-        dragEnd,
-      );
+      this.changeNotePositionWithoutUpdate(note.getId(), newPosition.getX(), newPosition.getY());
       this.operation.emit(new NoteOperation(OperationType.update, note));
     });
     this.notesUpdated();
@@ -343,7 +333,6 @@ export class NoteService {
     nodeId: number,
     newPositionX: number,
     newPositionY: number,
-    dragEnd: boolean,
   ) {
     const note = this.getNoteFromId(nodeId);
     if (note !== undefined) {

--- a/src/app/services/data/resource.service.spec.ts
+++ b/src/app/services/data/resource.service.spec.ts
@@ -5,8 +5,6 @@ import {TrainrunService} from "../data/trainrun.service";
 import {TrainrunSectionService} from "../data/trainrunsection.service";
 import {BaseDataService} from "../data/basedata.service";
 import {NoteService} from "../data/note.service";
-import {Node} from "../../models/node.model";
-import {TrainrunSection} from "../../models/trainrunsection.model";
 import {LogService} from "../../logger/log.service";
 import {LogPublishersService} from "../../logger/log.publishers.service";
 import {LabelGroupService} from "../data/labelgroup.service";
@@ -27,8 +25,6 @@ describe("ResourceService", () => {
   let trainrunSectionService: TrainrunSectionService;
   let baseDataService: BaseDataService;
   let noteService: NoteService;
-  let nodes: Node[] = null;
-  let trainrunSections: TrainrunSection[] = null;
   let logService: LogService = null;
   let logPublishersService: LogPublishersService = null;
   let labelGroupService: LabelGroupService = null;
@@ -71,10 +67,6 @@ describe("ResourceService", () => {
       labelGroupService,
       filterService,
       netzgrafikColoringService,
-    );
-    nodeService.nodes.subscribe((updatesNodes) => (nodes = updatesNodes));
-    trainrunSectionService.trainrunSections.subscribe(
-      (updatesTrainrunSections) => (trainrunSections = updatesTrainrunSections),
     );
 
     loadPerlenketteService = new LoadPerlenketteService(

--- a/src/app/services/data/resource.service.spec.ts
+++ b/src/app/services/data/resource.service.spec.ts
@@ -59,7 +59,7 @@ describe("ResourceService", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,
@@ -119,7 +119,6 @@ describe("ResourceService", () => {
 
   it("test - resource and node 1:1 link", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
-    const loadedNetzgrafik = dataService.getNetzgrafikDto();
     const allNodeResourceIds: number[] = [];
     nodeService.getNodes().forEach((n) => {
       const res = resourceService.getResource(n.getResourceId());
@@ -148,7 +147,6 @@ describe("ResourceService", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
     const nodeOfInterest = nodeService.getNodes()[1];
     nodeService.deleteNode(nodeOfInterest.getId());
-    const res = resourceService.getResource(nodeOfInterest.getResourceId());
     expect(nodeService.getNodes().length).toBe(resourceService.getResources().length);
   });
 });

--- a/src/app/services/data/resource.service.ts
+++ b/src/app/services/data/resource.service.ts
@@ -2,7 +2,6 @@ import {Injectable} from "@angular/core";
 import {BehaviorSubject} from "rxjs";
 import {Resource} from "../../models/resource.model";
 import {ResourceDto} from "../../data-structures/business.data.structures";
-import {Node} from "../../models/node.model";
 
 @Injectable({
   providedIn: "root",

--- a/src/app/services/data/trainrun-section-times.service.spec.ts
+++ b/src/app/services/data/trainrun-section-times.service.spec.ts
@@ -56,7 +56,7 @@ describe("TrainrunSectionTimesService", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,
@@ -421,8 +421,8 @@ describe("TrainrunSectionTimesService", () => {
         rightAsymmetry,
       };
       const optionsDesc = Object.entries(options)
-        .filter(([option, enabled]) => enabled)
-        .map(([option, enabled]) => `with ${option}`)
+        .filter(([_, enabled]) => enabled)
+        .map(([option]) => `with ${option}`)
         .join(" ");
       it(`set ${key} to ${value} ${optionsDesc}`, () => {
         const ts = trainrunSectionService.getTrainrunSectionFromId(trainrunSectionId);
@@ -439,7 +439,6 @@ describe("TrainrunSectionTimesService", () => {
 
         // Apply the symmetry update, if any
         if (leftAsymmetry || rightAsymmetry) {
-          const symmetryStructure = trainrunSectionTimesService.getSymmetryStructure();
           trainrunSectionTimesService.onLeftNodeSymmetryToggle(!leftAsymmetry);
           trainrunSectionTimesService.onRightNodeSymmetryToggle(!rightAsymmetry);
         }

--- a/src/app/services/data/trainrun-section-times.service.spec.ts
+++ b/src/app/services/data/trainrun-section-times.service.spec.ts
@@ -6,8 +6,6 @@ import {TrainrunSectionService} from "../data/trainrunsection.service";
 import {BaseDataService} from "../data/basedata.service";
 import {NoteService} from "../data/note.service";
 import {DirectedTrainrunSectionProxy} from "../util/trainrun.iterator";
-import {Node} from "../../models/node.model";
-import {TrainrunSection} from "../../models/trainrunsection.model";
 import {LogService} from "../../logger/log.service";
 import {LogPublishersService} from "../../logger/log.publishers.service";
 import {LabelGroupService} from "../data/labelgroup.service";
@@ -26,8 +24,6 @@ describe("TrainrunSectionTimesService", () => {
   let trainrunSectionService: TrainrunSectionService;
   let baseDataService: BaseDataService;
   let noteService: NoteService;
-  let nodes: Node[];
-  let trainrunSections: TrainrunSection[];
   let logService: LogService;
   let logPublishersService: LogPublishersService;
   let labelGroupService: LabelGroupService;
@@ -80,11 +76,6 @@ describe("TrainrunSectionTimesService", () => {
       trainrunSectionService,
       filterService,
       loadPerlenketteService,
-    );
-
-    nodeService.nodes.subscribe((updatesNodes) => (nodes = updatesNodes));
-    trainrunSectionService.trainrunSections.subscribe(
-      (updatesTrainrunSections) => (trainrunSections = updatesTrainrunSections),
     );
 
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());

--- a/src/app/services/data/trainrun.service.spec.ts
+++ b/src/app/services/data/trainrun.service.spec.ts
@@ -51,7 +51,7 @@ describe("TrainrunService", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,
@@ -166,8 +166,6 @@ describe("TrainrunService", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
     const ts = trainrunSectionService.getTrainrunSectionFromId(1);
     const t = ts.getTrainrun();
-    const n1 = nodeService.getNodeFromId(ts.getSourceNodeId());
-    const n2 = nodeService.getNodeFromId(ts.getTargetNodeId());
     const copied = trainrunService.duplicateTrainrunAndSections(t.getId());
     const ts1 = trainrunSectionService.getAllTrainrunSectionsForTrainrun(t.getId());
     const ts2 = trainrunSectionService.getAllTrainrunSectionsForTrainrun(copied.getId());
@@ -182,8 +180,6 @@ describe("TrainrunService", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
     const ts = trainrunSectionService.getTrainrunSectionFromId(1);
     const t = ts.getTrainrun();
-    const n1 = nodeService.getNodeFromId(ts.getSourceNodeId());
-    const n2 = nodeService.getNodeFromId(ts.getTargetNodeId());
     const labelsList = ["a", "e", "25", "04", "78"];
     trainrunService.setLabels(t.getId(), labelsList);
     labelsList.forEach((label, index) => {
@@ -316,21 +312,13 @@ describe("TrainrunService", () => {
 
     trainrunSectionService.deleteTrainrunSection(4);
 
-    const ts5: TrainrunSection = trainrunSectionService.getTrainrunSectionFromId(5);
     const ts7: TrainrunSection = trainrunSectionService.getTrainrunSectionFromId(7);
     trainrunService.setTrainrunAsSelected(ts7.getId());
-    const ts7a = trainrunSectionService.createTrainrunSection(0, 1);
-    const ts7b = trainrunSectionService.createTrainrunSection(1, 3);
+    trainrunSectionService.createTrainrunSection(0, 1);
+    trainrunSectionService.createTrainrunSection(1, 3);
     trainrunService.unselectAllTrainruns();
 
     const node2: Node = nodeService.getNodeFromId(2);
-
-    const trainrunSections5 = trainrunSectionService.getAllTrainrunSectionsForTrainrun(
-      ts5.getTrainrunId(),
-    );
-    const trainrunSections7 = trainrunSectionService.getAllTrainrunSectionsForTrainrun(
-      ts7.getTrainrunId(),
-    );
 
     trainrunService.combineTwoTrainruns(
       node2,

--- a/src/app/services/data/trainrun.service.spec.ts
+++ b/src/app/services/data/trainrun.service.spec.ts
@@ -23,8 +23,6 @@ describe("TrainrunService", () => {
   let trainrunSectionService: TrainrunSectionService;
   let baseDataService: BaseDataService;
   let noteService: NoteService;
-  let nodes: Node[] = null;
-  let trainrunSections: TrainrunSection[] = null;
   let logService: LogService = null;
   let logPublishersService: LogPublishersService = null;
   let labelGroupService: LabelGroupService = null;
@@ -63,11 +61,6 @@ describe("TrainrunService", () => {
       labelGroupService,
       filterService,
       netzgrafikColoringService,
-    );
-
-    nodeService.nodes.subscribe((updatesNodes) => (nodes = updatesNodes));
-    trainrunSectionService.trainrunSections.subscribe(
-      (updatesTrainrunSections) => (trainrunSections = updatesTrainrunSections),
     );
   });
 

--- a/src/app/services/data/trainrun.service.ts
+++ b/src/app/services/data/trainrun.service.ts
@@ -200,7 +200,6 @@ export class TrainrunService {
     frequency: TrainrunFrequency,
     offset: number,
   ): number {
-    const oldFreq = trainrun.getFrequency();
     const newFreq = frequency.frequency;
 
     const freqOffset = (frequency.offset + offset) % newFreq;
@@ -364,7 +363,7 @@ export class TrainrunService {
     const port1 = node.getPort(portId1);
     const port2 = node.getPort(portId2);
     const trainrunSection2 = port2.getTrainrunSection();
-    const newTrainrun = this.duplicateTrainrun(trainrunSection2.getTrainrunId(), false, "-2");
+    const newTrainrun = this.duplicateTrainrun(trainrunSection2.getTrainrunId(), "-2");
 
     trainrunSection2.setTrainrun(newTrainrun);
     const iterator = this.getIterator(node, trainrunSection2);
@@ -513,7 +512,7 @@ export class TrainrunService {
     this.nodeService.transitionsUpdated();
   }
 
-  duplicateTrainrun(trainrunId: number, enforceUpdate = true, postfix = " COPY"): Trainrun {
+  duplicateTrainrun(trainrunId: number, postfix = " COPY"): Trainrun {
     const trainrun = this.getTrainrunFromId(trainrunId);
     const copiedtrainrun = new Trainrun();
     copiedtrainrun.setTrainrunCategory(trainrun.getTrainrunCategory());
@@ -531,7 +530,7 @@ export class TrainrunService {
     enforceUpdate = true,
     postfix = " COPY",
   ): Trainrun {
-    const copiedtrainrun = this.duplicateTrainrun(trainrunId, enforceUpdate, postfix);
+    const copiedtrainrun = this.duplicateTrainrun(trainrunId, postfix);
     this.trainrunSectionService.copyAllTrainrunSectionsForTrainrun(
       trainrunId,
       copiedtrainrun.getId(),

--- a/src/app/services/data/trainrunsection.service.spec.ts
+++ b/src/app/services/data/trainrunsection.service.spec.ts
@@ -51,7 +51,7 @@ describe("TrainrunSectionService", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,
@@ -90,7 +90,6 @@ describe("TrainrunSectionService", () => {
 
   it("TrainrunSectionService.setTrainrunSectionAsSelected", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
-    const ts = trainrunSectionService.getTrainrunSectionFromId(1);
     expect(trainrunSectionService.getSelectedTrainrunSection()).toBe(null);
     trainrunSectionService.setTrainrunSectionAsSelected(0);
     expect(trainrunSectionService.getSelectedTrainrunSection().getId()).toBe(0);
@@ -133,9 +132,9 @@ describe("TrainrunSectionService", () => {
     const nodeD = nodeService.addNodeWithPosition(0, 3, "D");
     const nodeE = nodeService.addNodeWithPosition(0, 4, "E");
     const tsAB = trainrunSectionService.createTrainrunSection(nodeA.getId(), nodeB.getId());
-    const tsBC = trainrunSectionService.createTrainrunSection(nodeB.getId(), nodeC.getId());
-    const tsCD = trainrunSectionService.createTrainrunSection(nodeC.getId(), nodeD.getId());
-    const tsDE = trainrunSectionService.createTrainrunSection(nodeD.getId(), nodeE.getId());
+    trainrunSectionService.createTrainrunSection(nodeB.getId(), nodeC.getId());
+    trainrunSectionService.createTrainrunSection(nodeC.getId(), nodeD.getId());
+    trainrunSectionService.createTrainrunSection(nodeD.getId(), nodeE.getId());
     const tsEA = trainrunSectionService.createTrainrunSection(nodeE.getId(), nodeA.getId());
 
     expect(nodeA.getTransitions().length).toBe(0);

--- a/src/app/services/data/trainrunsection.service.ts
+++ b/src/app/services/data/trainrunsection.service.ts
@@ -19,11 +19,7 @@ import {LogService} from "../../logger/log.service";
 import {Transition} from "../../models/transition.model";
 import {takeUntil} from "rxjs/operators";
 import {FilterService} from "../ui/filter.service";
-import {
-  DirectedTrainrunSectionProxy,
-  TrainrunSectionNodePair,
-  TrainrunIterator,
-} from "../util/trainrun.iterator";
+import {DirectedTrainrunSectionProxy, TrainrunIterator} from "../util/trainrun.iterator";
 import {Operation, OperationType, TrainrunOperation} from "../../models/operation.model";
 
 interface DepartureAndArrivalTimes {

--- a/src/app/services/data/undo.service.spec.ts
+++ b/src/app/services/data/undo.service.spec.ts
@@ -5,8 +5,6 @@ import {TrainrunService} from "../data/trainrun.service";
 import {TrainrunSectionService} from "../data/trainrunsection.service";
 import {BaseDataService} from "../data/basedata.service";
 import {NoteService} from "../data/note.service";
-import {Node} from "../../models/node.model";
-import {TrainrunSection} from "../../models/trainrunsection.model";
 import {LogService} from "../../logger/log.service";
 import {LogPublishersService} from "../../logger/log.publishers.service";
 import {LabelGroupService} from "../data/labelgroup.service";
@@ -27,8 +25,6 @@ describe("UndoService", () => {
   let trainrunSectionService: TrainrunSectionService;
   let baseDataService: BaseDataService;
   let noteService: NoteService;
-  let nodes: Node[] = null;
-  let trainrunSections: TrainrunSection[] = null;
   let logService: LogService = null;
   let logPublishersService: LogPublishersService = null;
   let labelGroupService: LabelGroupService = null;
@@ -67,11 +63,6 @@ describe("UndoService", () => {
       labelGroupService,
       filterService,
       netzgrafikColoringService,
-    );
-
-    nodeService.nodes.subscribe((updatesNodes) => (nodes = updatesNodes));
-    trainrunSectionService.trainrunSections.subscribe(
-      (updatesTrainrunSections) => (trainrunSections = updatesTrainrunSections),
     );
   });
 

--- a/src/app/services/data/undo.service.spec.ts
+++ b/src/app/services/data/undo.service.spec.ts
@@ -55,7 +55,7 @@ describe("UndoService", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,
@@ -284,7 +284,7 @@ describe("UndoService", () => {
     noteService.getNotes().forEach((note: Note) => {
       notePos.push(new Vec2D(note.getPositionX(), note.getPositionY()));
     });
-    noteService.moveSelectedNotes(10, 8, 1, false);
+    noteService.moveSelectedNotes(10, 8, 1);
     noteService.getNotes().forEach((note: Note, index: number) => {
       if (index < 2) {
         expect(notePos[index].getX() + 10).toBe(note.getPositionX());
@@ -295,7 +295,7 @@ describe("UndoService", () => {
       }
     });
 
-    noteService.moveSelectedNotes(2, 5, 1, true);
+    noteService.moveSelectedNotes(2, 5, 1);
 
     noteService.getNotes().forEach((note: Note, index: number) => {
       if (index < 2) {

--- a/src/app/services/ui/filter.service.spec.ts
+++ b/src/app/services/ui/filter.service.spec.ts
@@ -55,7 +55,7 @@ describe("FilterService", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,
@@ -373,7 +373,7 @@ describe("FilterService", () => {
     const defaultFilterSettings = filterService.getActiveFilterSetting();
     const copiedFS = defaultFilterSettings.copy();
     copiedFS.id = copiedFS.id + 10;
-    const fs = new FilterSetting(copiedFS.getDto());
+    new FilterSetting(copiedFS.getDto());
     expect(new FilterSetting().id).toBe(copiedFS.id + 1);
   });
 

--- a/src/app/services/ui/filter.service.spec.ts
+++ b/src/app/services/ui/filter.service.spec.ts
@@ -13,7 +13,6 @@ import {LabelGroupService} from "../data/labelgroup.service";
 import {LabelService} from "../data/label.service";
 import {NetzgrafikUnitTesting} from "../../../integration-testing/netzgrafik.unit.testing";
 import {FilterService} from "./filter.service";
-import {AnalyticsService} from "../analytics/analytics.service";
 import {NetzgrafikColoringService} from "../data/netzgrafikColoring.service";
 import {FilterSetting} from "../../models/filterSettings.model";
 
@@ -31,7 +30,6 @@ describe("FilterService", () => {
   let logPublishersService: LogPublishersService = null;
   let labelGroupService: LabelGroupService = null;
   let labelService: LabelService = null;
-  let analyticsService: AnalyticsService = null;
   let filterService: FilterService = null;
   let netzgrafikColoringService: NetzgrafikColoringService = null;
   let gotFilterChangedSignal = false;
@@ -69,7 +67,6 @@ describe("FilterService", () => {
       netzgrafikColoringService,
     );
     nodeService.nodes.subscribe((updatesNodes) => (nodes = updatesNodes));
-    analyticsService = new AnalyticsService(nodeService, trainrunSectionService, trainrunService);
 
     nodeService.nodes.subscribe((updatesNodes) => (nodes = updatesNodes));
     trainrunSectionService.trainrunSections.subscribe(

--- a/src/app/services/ui/ui.interaction.service.spec.ts
+++ b/src/app/services/ui/ui.interaction.service.spec.ts
@@ -61,7 +61,7 @@ describe("UiInteractionService", () => {
     );
     noteService = new NoteService(logService, labelService, filterService);
     analyticsService = new AnalyticsService(nodeService, trainrunSectionService, trainrunService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,
@@ -120,8 +120,8 @@ describe("UiInteractionService", () => {
   it("findClosestNodeToViewCenter", () => {
     nodeService.deleteAllVisibleNodes();
     const n1 = nodeService.addNodeWithPosition(100, 100, "Node1", "Node1", [], true);
-    const n2 = nodeService.addNodeWithPosition(200, 200, "Node2", "Node2", [], true);
-    const n3 = nodeService.addNodeWithPosition(300, 300, "Node3", "Node3", [], true);
+    nodeService.addNodeWithPosition(200, 200, "Node2", "Node2", [], true);
+    nodeService.addNodeWithPosition(300, 300, "Node3", "Node3", [], true);
     const viewboxProperties = uiInteractionService.getViewboxProperties(EditorView.svgName);
     uiInteractionService.setViewboxProperties(EditorView.svgName, viewboxProperties);
     expect(uiInteractionService.findClosestNodeToViewCenter(nodes)?.node?.getId()).toBe(n1.getId());

--- a/src/app/services/ui/ui.interaction.service.spec.ts
+++ b/src/app/services/ui/ui.interaction.service.spec.ts
@@ -6,13 +6,11 @@ import {TrainrunSectionService} from "../data/trainrunsection.service";
 import {BaseDataService} from "../data/basedata.service";
 import {NoteService} from "../data/note.service";
 import {Node} from "../../models/node.model";
-import {TrainrunSection} from "../../models/trainrunsection.model";
 import {LogService} from "../../logger/log.service";
 import {LogPublishersService} from "../../logger/log.publishers.service";
 import {LabelGroupService} from "../data/labelgroup.service";
 import {LabelService} from "../data/label.service";
 import {FilterService} from "./filter.service";
-import {AnalyticsService} from "../analytics/analytics.service";
 import {UiInteractionService} from "./ui.interaction.service";
 import {EditorView} from "../../view/editor-main-view/data-views/editor.view";
 import {EditorMode} from "../../view/editor-menu/editor-mode";
@@ -30,12 +28,10 @@ describe("UiInteractionService", () => {
   let baseDataService: BaseDataService;
   let noteService: NoteService;
   let nodes: Node[] = null;
-  let trainrunSections: TrainrunSection[] = null;
   let logService: LogService = null;
   let logPublishersService: LogPublishersService = null;
   let labelGroupService: LabelGroupService = null;
   let labelService: LabelService = null;
-  let analyticsService: AnalyticsService = null;
   let filterService: FilterService = null;
   let uiInteractionService: UiInteractionService = null;
   let netzgrafikColoringService: NetzgrafikColoringService = null;
@@ -60,7 +56,6 @@ describe("UiInteractionService", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    analyticsService = new AnalyticsService(nodeService, trainrunSectionService, trainrunService);
     netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
@@ -95,9 +90,6 @@ describe("UiInteractionService", () => {
     );
 
     nodeService.nodes.subscribe((updatesNodes) => (nodes = updatesNodes));
-    trainrunSectionService.trainrunSections.subscribe(
-      (updatesTrainrunSections) => (trainrunSections = updatesTrainrunSections),
-    );
   });
 
   it("checkFilterNodeLabels", () => {

--- a/src/app/services/ui/ui.interaction.service.ts
+++ b/src/app/services/ui/ui.interaction.service.ts
@@ -26,7 +26,6 @@ import {StreckengrafikRenderingType} from "../../view/themes/streckengrafik-rend
 import {NetzgrafikColoringService} from "../data/netzgrafikColoring.service";
 import {MainViewMode} from "../../view/filter-main-side-view/main-view-mode";
 import {TrainrunService} from "../data/trainrun.service";
-import {Trainrun} from "../../models/trainrun.model";
 import {Node} from "../../models/node.model";
 import {LoadPerlenketteService} from "../../perlenkette/service/load-perlenkette.service";
 import {TravelTimeCreationEstimatorType} from "../../view/themes/editor-trainrun-traveltime-creator-type";
@@ -136,7 +135,7 @@ export class UiInteractionService implements OnDestroy {
     this.loadActiveTheme();
 
     // listen for browser setting update
-    window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (event) => {
+    window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => {
       this.activeTheme = null;
       this.loadActiveTheme();
     });
@@ -158,17 +157,15 @@ export class UiInteractionService implements OnDestroy {
         this.showPerlenkette(informSelectedTrainrunClick);
       });
 
-    this.trainrunService.trainruns
-      .pipe(takeUntil(this.destroyed))
-      .subscribe((trainrun: Trainrun[]) => {
-        const st = trainrunService.getSelectedTrainrun();
-        if (st !== null) {
-          this.oldSelectedTrainrunId = st.getId();
-          return;
-        }
-        this.closePerlenkette();
-        this.oldSelectedTrainrunId = null;
-      });
+    this.trainrunService.trainruns.pipe(takeUntil(this.destroyed)).subscribe(() => {
+      const st = trainrunService.getSelectedTrainrun();
+      if (st !== null) {
+        this.oldSelectedTrainrunId = st.getId();
+        return;
+      }
+      this.closePerlenkette();
+      this.oldSelectedTrainrunId = null;
+    });
 
     this.baseDataService.baseDataObservable
       .pipe(takeUntil(this.destroyed))

--- a/src/app/services/util/auto-layout.service.spec.ts
+++ b/src/app/services/util/auto-layout.service.spec.ts
@@ -65,7 +65,7 @@ describe("AutoLayoutService", () => {
     );
 
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
 
     dataService = new DataService(
       resourceService,

--- a/src/app/services/util/connection.validator.ts
+++ b/src/app/services/util/connection.validator.ts
@@ -8,9 +8,6 @@ export class ConnectionValidator {
     const portId1 = connection.getPortId1();
     const portId2 = connection.getPortId2();
 
-    const port1 = node.getPort(portId1);
-    const port2 = node.getPort(portId2);
-
     const transitions = node
       .getTransitions()
       .filter(

--- a/src/app/services/util/position.transformation.service.spec.ts
+++ b/src/app/services/util/position.transformation.service.spec.ts
@@ -59,7 +59,7 @@ describe("PositionTransformationService", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,

--- a/src/app/services/util/position.transformation.service.spec.ts
+++ b/src/app/services/util/position.transformation.service.spec.ts
@@ -6,7 +6,6 @@ import {TrainrunSectionService} from "../../services/data/trainrunsection.servic
 import {BaseDataService} from "../../services/data/basedata.service";
 import {NoteService} from "../../services/data/note.service";
 import {Node} from "../../models/node.model";
-import {TrainrunSection} from "../../models/trainrunsection.model";
 import {LabelGroupService} from "../../services/data/labelgroup.service";
 import {LabelService} from "../data/label.service";
 import {NetzgrafikColoringService} from "../../services/data/netzgrafikColoring.service";
@@ -28,8 +27,6 @@ describe("PositionTransformationService", () => {
   let trainrunSectionService: TrainrunSectionService;
   let baseDataService: BaseDataService;
   let noteService: NoteService;
-  let nodes: Node[] = null;
-  let trainrunSections: TrainrunSection[] = null;
   let logService: LogService = null;
   let logPublishersService: LogPublishersService = null;
   let labelGroupService: LabelGroupService = null;
@@ -71,10 +68,6 @@ describe("PositionTransformationService", () => {
       labelGroupService,
       filterService,
       netzgrafikColoringService,
-    );
-    nodeService.nodes.subscribe((updatesNodes) => (nodes = updatesNodes));
-    trainrunSectionService.trainrunSections.subscribe(
-      (updatesTrainrunSections) => (trainrunSections = updatesTrainrunSections),
     );
 
     loadPerlenketteService = new LoadPerlenketteService(

--- a/src/app/services/util/position.transformation.service.ts
+++ b/src/app/services/util/position.transformation.service.ts
@@ -33,7 +33,7 @@ export class PositionTransformationService {
     );
     const focalNode: Node = this.getFocalNode(scaleCenterCoordinates);
 
-    this.nodeService.getNodes().forEach((n, index) => {
+    this.nodeService.getNodes().forEach((n) => {
       let newPos = new Vec2D(
         (n.getPositionX() - scaleCenterCoordinates.getX()) * factor + scaleCenterCoordinates.getX(),
         (n.getPositionY() - scaleCenterCoordinates.getY()) * factor + scaleCenterCoordinates.getY(),
@@ -49,7 +49,7 @@ export class PositionTransformationService {
       n.setPosition(newPos.getX(), newPos.getY());
     });
 
-    this.noteService.getNotes().forEach((n, index) => {
+    this.noteService.getNotes().forEach((n) => {
       let newPos = new Vec2D(
         (n.getPositionX() - scaleCenterCoordinates.getX()) * factor + scaleCenterCoordinates.getX(),
         (n.getPositionY() - scaleCenterCoordinates.getY()) * factor + scaleCenterCoordinates.getY(),
@@ -126,7 +126,7 @@ export class PositionTransformationService {
       scaleCenterCoordinates.setData(centerOfMass.getX(), centerOfMass.getY());
     }
 
-    nodes.forEach((n, index) => {
+    nodes.forEach((n) => {
       let newPos = new Vec2D(
         (n.getPositionX() + n.getNodeWidth() / 2.0 - scaleCenterCoordinates.getX()) * factor +
           scaleCenterCoordinates.getX() -
@@ -147,7 +147,7 @@ export class PositionTransformationService {
       n.setPosition(newPos.getX(), newPos.getY());
     });
 
-    notes.forEach((n, index) => {
+    notes.forEach((n) => {
       const newPos = new Vec2D(
         (n.getPositionX() + n.getWidth() / 2.0 - scaleCenterCoordinates.getX()) * factor +
           scaleCenterCoordinates.getX() -

--- a/src/app/services/util/trainrunsection.helper.spec.ts
+++ b/src/app/services/util/trainrunsection.helper.spec.ts
@@ -54,7 +54,7 @@ describe("TrainrunsectionHelper", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,
@@ -364,7 +364,6 @@ describe("TrainrunsectionHelper", () => {
   it("getSourceLock - 001", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
     const ts = trainrunSectionService.getTrainrunSectionFromId(1);
-    const nodes = trainrunService.getBothEndNodesWithTrainrunId(ts.getTrainrunId());
     const d = trainrunsectionHelper.getSourceLock(
       {
         leftLock: true,
@@ -379,7 +378,6 @@ describe("TrainrunsectionHelper", () => {
   it("getTargetLock - 001", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
     const ts = trainrunSectionService.getTrainrunSectionFromId(1);
-    const nodes = trainrunService.getBothEndNodesWithTrainrunId(ts.getTrainrunId());
 
     const d = trainrunsectionHelper.getTargetLock(
       {

--- a/src/app/services/util/trainrunsection.routing.ts
+++ b/src/app/services/util/trainrunsection.routing.ts
@@ -23,7 +23,6 @@ import {
 import {TrafficSide} from "../../data-structures/business.data.structures";
 import {Node} from "../../models/node.model";
 import {Port} from "../../models/port.model";
-import {TrainrunsectionHelper} from "./trainrunsection.helper";
 
 export class SimpleTrainrunSectionRouter {
   private static trafficSideType: TrafficSide = "leftHand";

--- a/src/app/services/util/transition.validator.spec.ts
+++ b/src/app/services/util/transition.validator.spec.ts
@@ -14,7 +14,6 @@ import {LabelService} from "../data/label.service";
 import {NetzgrafikUnitTesting} from "../../../integration-testing/netzgrafik.unit.testing";
 import {FilterService} from "../ui/filter.service";
 import {NetzgrafikColoringService} from "../data/netzgrafikColoring.service";
-import {TrainrunsectionHelper} from "./trainrunsection.helper";
 import {TransitionValidator} from "./transition.validator";
 import {Transition} from "../../models/transition.model";
 
@@ -34,7 +33,6 @@ describe("TransitionValidator", () => {
   let labelService: LabelService = null;
   let filterService: FilterService = null;
   let netzgrafikColoringService: NetzgrafikColoringService = null;
-  let trainrunsectionHelper: TrainrunsectionHelper = null;
 
   beforeEach(() => {
     baseDataService = new BaseDataService();
@@ -73,8 +71,6 @@ describe("TransitionValidator", () => {
     trainrunSectionService.trainrunSections.subscribe(
       (updatesTrainrunSections) => (trainrunSections = updatesTrainrunSections),
     );
-
-    trainrunsectionHelper = new TrainrunsectionHelper(trainrunService);
   });
 
   it("Test load data", () => {

--- a/src/app/services/util/transition.validator.spec.ts
+++ b/src/app/services/util/transition.validator.spec.ts
@@ -55,7 +55,7 @@ describe("TransitionValidator", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,
@@ -229,7 +229,6 @@ describe("TransitionValidator", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
     const ts1 = trainrunSectionService.getTrainrunSectionFromId(4);
     const ts2 = trainrunSectionService.getTrainrunSectionFromId(5);
-    const trainrun = trainrunService.getSelectedOrNewTrainrun();
     trainrunSectionService.createTrainrunSection(ts1.getSourceNodeId(), ts1.getTargetNodeId());
     const ts = trainrunSectionService.getSelectedTrainrunSection();
     trainrunSectionService.createTrainrunSection(ts2.getTargetNodeId(), ts.getSourceNodeId());
@@ -290,7 +289,6 @@ describe("TransitionValidator", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
     const ts1 = trainrunSectionService.getTrainrunSectionFromId(4);
     const ts2 = trainrunSectionService.getTrainrunSectionFromId(5);
-    const trainrun = trainrunService.getSelectedOrNewTrainrun();
     trainrunSectionService.createTrainrunSection(ts1.getTargetNodeId(), ts1.getSourceNodeId());
     const ts = trainrunSectionService.getSelectedTrainrunSection();
     trainrunSectionService.createTrainrunSection(ts.getSourceNodeId(), ts2.getTargetNodeId());
@@ -339,7 +337,6 @@ describe("TransitionValidator", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
     const ts1 = trainrunSectionService.getTrainrunSectionFromId(4);
     const ts2 = trainrunSectionService.getTrainrunSectionFromId(5);
-    const trainrun = trainrunService.getSelectedOrNewTrainrun();
     trainrunSectionService.createTrainrunSection(ts1.getTargetNodeId(), ts1.getSourceNodeId());
     trainrunSectionService.createTrainrunSection(ts2.getTargetNodeId(), ts2.getSourceNodeId());
     const ts = trainrunSectionService.getSelectedTrainrunSection();

--- a/src/app/streckengrafik/components/grid/path-grid/path-grid.component.html
+++ b/src/app/streckengrafik/components/grid/path-grid/path-grid.component.html
@@ -79,7 +79,7 @@
                 [attr.x]="0"
                 [attr.y]="0"
               >
-                {{ getTrackLabel(path, gridTrackPos) }}
+                {{ getTrackLabel(gridTrackPos) }}
                 <title>
                   {{ getTrackTitel(path, gridTrackPos) }}
                 </title>

--- a/src/app/streckengrafik/components/grid/path-grid/path-grid.component.ts
+++ b/src/app/streckengrafik/components/grid/path-grid/path-grid.component.ts
@@ -133,7 +133,7 @@ export class PathGridComponent implements OnInit, OnDestroy, AfterViewInit {
     return trackIdx < nodeTracks.length ? nodeTracks[trackIdx] : pathNode.trackData;
   }
 
-  getTrackLabel(path: SgPath, gridTrackPos: number): string {
+  getTrackLabel(gridTrackPos: number): string {
     const trackNbr = Math.round(1 + (gridTrackPos - this.trackWidth) / this.trackWidth);
     return "" + trackNbr;
   }

--- a/src/app/streckengrafik/components/slider/path-slider-track-segments/path-slider-track-segments.component.ts
+++ b/src/app/streckengrafik/components/slider/path-slider-track-segments/path-slider-track-segments.component.ts
@@ -64,7 +64,7 @@ export class PathSliderTrackSegmentsComponent {
     }
 
     const retData: {x1: number; x2: number; y1: number; y2: number; nbr: number; d: string}[] = [];
-    ps.trackData.sectionTrackSegments.forEach((sts: TrackSegments, index: number) => {
+    ps.trackData.sectionTrackSegments.forEach((sts: TrackSegments) => {
       const startAt = Math.max(0.0, sts.startPos * this.path.zoomedXPath());
       const endAt = Math.min(sts.endPos * this.path.zoomedXPath(), this.path.zoomedXPath());
       let y1 = this.zeroPoint;

--- a/src/app/streckengrafik/components/slider/time-slider/time-slider.component.ts
+++ b/src/app/streckengrafik/components/slider/time-slider/time-slider.component.ts
@@ -115,7 +115,6 @@ export class TimeSliderComponent implements OnInit, OnDestroy, UpdateCounterHand
       .getTimelineChangeObservable()
       .pipe(takeUntil(this.destroyed$))
       .subscribe((timeLinePos: number) => {
-        const changed = this.timelineChangeInfo !== timeLinePos;
         this.timelineChangeInfo = timeLinePos;
         if (!this.delayedRendering) {
           this.updateCounterCallback();
@@ -158,7 +157,7 @@ export class TimeSliderComponent implements OnInit, OnDestroy, UpdateCounterHand
   }
 
   @HostListener("mouseup", ["$event"])
-  public onMouseUp(event: MouseEvent) {
+  public onMouseUp() {
     if (this.lastMouseMoveButtons !== 0) {
       this.timeSliderService.stopHandleZoomPanning();
     }

--- a/src/app/streckengrafik/components/train-run-section/train-run-section.component.ts
+++ b/src/app/streckengrafik/components/train-run-section/train-run-section.component.ts
@@ -13,7 +13,7 @@ import {TrainrunBranchType} from "../../model/enum/trainrun-branch-type-type";
 import {Vec2D} from "../../../utils/vec2D";
 import {takeUntil} from "rxjs/operators";
 import {TimeSliderService} from "../../services/time-slider.service";
-import {interval, Subject, take} from "rxjs";
+import {Subject} from "rxjs";
 import {TrainrunSectionText} from "../../../data-structures/technical.data.structures";
 import {
   TrainrunDialogParameter,

--- a/src/app/streckengrafik/model/pathNode.ts
+++ b/src/app/streckengrafik/model/pathNode.ts
@@ -38,7 +38,7 @@ export class PathNode implements PathItem {
     return true;
   }
 
-  zommedXPath(xZoom: number) {
+  zommedXPath() {
     return this.xPath();
   }
 

--- a/src/app/streckengrafik/services/sg-1-load-trainrun-item.service.ts
+++ b/src/app/streckengrafik/services/sg-1-load-trainrun-item.service.ts
@@ -22,7 +22,6 @@ import {NodeService} from "../../services/data/node.service";
 import {TrainrunBranchType} from "../model/enum/trainrun-branch-type-type";
 import {MultiSelectNodeGraph} from "../../utils/multi-select-node-graph";
 import {Direction} from "src/app/data-structures/business.data.structures";
-import {TrainrunsectionHelper} from "src/app/services/util/trainrunsection.helper";
 
 @Injectable({
   providedIn: "root",

--- a/src/app/streckengrafik/services/sg-1-load-trainrun-item.service.ts
+++ b/src/app/streckengrafik/services/sg-1-load-trainrun-item.service.ts
@@ -148,7 +148,7 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
         // not support current trains with partial cancellations.
         const ts: TrainrunSection = this.trainrunSectionService
           .getAllTrainrunSectionsForTrainrun(selectedTrainrun.getId())
-          .find((ts) => true);
+          .find(() => true);
         const loadeddata = this.loadTrainrunItem(ts, true);
         this.cachedTrainrunItems = loadeddata.trainrunItem;
       }
@@ -193,7 +193,7 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
         : this.createLongestPathFromNodes(graph, nodes);
 
     // convert corridor to path elements
-    corridor.forEach((n, idx, nodArray) => {
+    corridor.forEach((_, idx, nodArray) => {
       if (idx > 0) {
         const e = edgeLists.find(
           (e) =>
@@ -657,12 +657,11 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
           // this part of code supports partial cancellations, e.g., trainrun runs from
           // A - B - C [ partial canceled ] D - E
           while (alltrainrunsections.length > 0) {
-            const ts: TrainrunSection = alltrainrunsections.find((ts) => true);
+            const ts: TrainrunSection = alltrainrunsections.find(() => true);
             const loadeddata = this.loadTrainrunItem(ts, false);
 
             // correct projections directions
             this.sortTrainrunItemAndRotateAlongTemplatePath(
-              trainrun,
               loadeddata.trainrunItem,
               templateTrainrunItem,
             );
@@ -680,7 +679,6 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
   }
 
   sortTrainrunItemAndRotateAlongTemplatePath(
-    trainrun: Trainrun,
     trainrunItem: TrainrunItem,
     templateTrainrunItem: TrainrunItem,
   ) {
@@ -690,7 +688,7 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
      There is sill an issue in the CODE - if the trainrun passes the second time a node, the in-/out
      branching edge will not all be rendered!
      */
-    this.classifyPathItem(trainrun, trainrunItem, templateTrainrunItem);
+    this.classifyPathItem(trainrunItem, templateTrainrunItem);
 
     const indicesForward: number[] = [];
     const indicesBackward: number[] = [];
@@ -793,7 +791,7 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
     swapIndF = swapIndF.filter((v, i, a) => a.indexOf(v) === i);
     swapIndB = swapIndB.filter((v, i, a) => a.indexOf(v) === i);
 
-    swapIndF.forEach((v, index) => {
+    swapIndF.forEach((_, index) => {
       if (swapIndF[index] >= 0) {
         if (index === 0) {
           if (
@@ -829,11 +827,7 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
     });
   }
 
-  classifyPathItem(
-    trainrun: Trainrun,
-    trainrunItem: TrainrunItem,
-    templateTrainrunItem: TrainrunItem,
-  ) {
+  classifyPathItem(trainrunItem: TrainrunItem, templateTrainrunItem: TrainrunItem) {
     trainrunItem.pathItems.forEach((item: PathItem) => {
       if (item.isSection()) {
         const section = item.getPathSection();

--- a/src/app/streckengrafik/services/sg-6-track.service.ts
+++ b/src/app/streckengrafik/services/sg-6-track.service.ts
@@ -73,36 +73,19 @@ export class Sg6TrackService implements OnDestroy {
     this.computeTrackAlignments(this.selectedTrainrun, separateForwardBackwardTracks);
 
     // calculate the required tracks "blocks" (section)
-    const separateForwardBackwardSectionTracks = false;
-    const sectionTrackMap = this.extractStreckenGleis(
-      this.selectedTrainrun.trainruns,
-      separateForwardBackwardSectionTracks,
-    );
-    this.mapTrackToTop(
-      this.selectedTrainrun.trainruns,
-      sectionTrackMap,
-      separateForwardBackwardSectionTracks,
-    );
+    const sectionTrackMap = this.extractStreckenGleis(this.selectedTrainrun.trainruns);
+    this.mapTrackToTop(this.selectedTrainrun.trainruns, sectionTrackMap);
 
     // update the rendering -> goto next pipeline step
     this.sgSelectedTrainrunSubject.next(this.selectedTrainrun);
   }
 
-  private extractStreckenGleis(
-    trainrunItems: SgTrainrun[],
-    separateForwardBackwardTracks: boolean,
-  ) {
-    const sectionsOfInterest = this.createSectionsOfInterestMap(
-      trainrunItems,
-      separateForwardBackwardTracks,
-    );
+  private extractStreckenGleis(trainrunItems: SgTrainrun[]) {
+    const sectionsOfInterest = this.createSectionsOfInterestMap(trainrunItems);
     return this.extractSectionTracks(sectionsOfInterest);
   }
 
-  private createSectionsOfInterestMap(
-    trainrunItems: SgTrainrun[],
-    separateForwardBackwardTracks: boolean,
-  ) {
+  private createSectionsOfInterestMap(trainrunItems: SgTrainrun[]) {
     /*
     This method collects all trainrun sections and maps them into the sectionsOfInterest-Map to get fast access
      */
@@ -112,7 +95,7 @@ export class Sg6TrackService implements OnDestroy {
         if (trainrunItem.isSection()) {
           const ps: SgTrainrunSection = trainrunItem.getTrainrunSection();
           if (ps.trainrunBranchType === TrainrunBranchType.Trainrun) {
-            const sectionKey = this.getSectionKey(ps, separateForwardBackwardTracks).key;
+            const sectionKey = this.getSectionKey(ps).key;
             const sOfI = sectionsOfInterest.get(sectionKey);
             if (sOfI === undefined) {
               sectionsOfInterest.set(sectionKey, []);
@@ -125,7 +108,7 @@ export class Sg6TrackService implements OnDestroy {
     return sectionsOfInterest;
   }
 
-  private getSectionKey(ps: SgTrainrunSection, separateForwardBackwardTracks: boolean) {
+  private getSectionKey(ps: SgTrainrunSection) {
     let node1 = ps.arrivalPathNode === undefined ? undefined : ps.arrivalPathNode.nodeId;
     let node2 = ps.departurePathNode === undefined ? undefined : ps.departurePathNode.nodeId;
     if (node1 > node2) {
@@ -648,7 +631,7 @@ export class Sg6TrackService implements OnDestroy {
     // Transform data
     // ------------------------------------------------------------------------------------------------------------------
     this.makeTrackSymmetric(trackInfoMap, separateForwardBackwardTracks);
-    this.updateTracksForAllPathNodes(trackInfoMap, separateForwardBackwardTracks);
+    this.updateTracksForAllPathNodes(trackInfoMap);
   }
 
   private updateStagingDwellAtEndpoints(pn: SgTrainrunNode) {
@@ -693,12 +676,7 @@ export class Sg6TrackService implements OnDestroy {
 
     // calculate the track occupency and create new tracks if no space is left to align a trainrun into a track
     let trackIdx = 0;
-    let trackOfInterest = this.estimateTrackOfInterest(
-      trackIdx,
-      item,
-      separateForwardBackwardTracks,
-      trackInfoMap,
-    );
+    let trackOfInterest = this.estimateTrackOfInterest(trackIdx, item, trackInfoMap);
     let trackData = nodeData.get(trackOfInterest);
     let isOccupied = true;
     while (isOccupied) {
@@ -745,12 +723,7 @@ export class Sg6TrackService implements OnDestroy {
       }
       if (isOccupied) {
         trackIdx += 1;
-        trackOfInterest = this.estimateTrackOfInterest(
-          trackIdx,
-          item,
-          separateForwardBackwardTracks,
-          trackInfoMap,
-        );
+        trackOfInterest = this.estimateTrackOfInterest(trackIdx, item, trackInfoMap);
         trackData = nodeData.get(trackOfInterest);
       }
     }
@@ -795,10 +768,7 @@ export class Sg6TrackService implements OnDestroy {
     });
   }
 
-  private makeTrackSymmetricUpdateTrackAlignment(
-    tracks: PathNodeNeighbour[],
-    separateForwardBackwardTracks: boolean,
-  ) {
+  private makeTrackSymmetricUpdateTrackAlignment(tracks: PathNodeNeighbour[]) {
     let trackItr = 0;
     let prevPn = tracks[0];
     let mainTrackIdx = -1;
@@ -817,11 +787,7 @@ export class Sg6TrackService implements OnDestroy {
       pn.trackNbr = trackItr;
       pn.mainTrackIdx = mainTrackIdx;
       pn.pathNodes.forEach((sgTN) => {
-        const curTrack = this.getTrackNumber(
-          pn.trackNbr,
-          sgTN.backward,
-          separateForwardBackwardTracks,
-        );
+        const curTrack = this.getTrackNumber(pn.trackNbr);
         sgTN.trackData.track = 1 + curTrack;
       });
       prevPn = pn;
@@ -845,10 +811,7 @@ export class Sg6TrackService implements OnDestroy {
       const tracks = this.makeTrackSymmetricSortTracks(nodeTracksMap.get(keyNodeId));
 
       // align train to reordered track (update track nbr)
-      const tracKInfo = this.makeTrackSymmetricUpdateTrackAlignment(
-        tracks,
-        separateForwardBackwardTracks,
-      );
+      const tracKInfo = this.makeTrackSymmetricUpdateTrackAlignment(tracks);
 
       // update track map
       nodeTracksMap.set(keyNodeId, tracks);
@@ -877,7 +840,6 @@ export class Sg6TrackService implements OnDestroy {
   private estimateTrackOfInterest(
     trackIdx: number,
     trainrunItem: SgTrainrunItem,
-    separateForwardBackwardTracks: boolean,
     nodeTracksMap: Map<number, PathNodeNeighbour[]>,
   ): number {
     if (!trainrunItem.isNode()) {
@@ -890,11 +852,7 @@ export class Sg6TrackService implements OnDestroy {
     if (nodeTracks === undefined) {
       nodeNeighbors.pathNodes.push(node);
       nodeTracksMap.set(node.nodeId, [nodeNeighbors]);
-      return this.getTrackNumber(
-        nodeNeighbors.trackNbr,
-        trainrunItem.backward,
-        separateForwardBackwardTracks,
-      );
+      return this.getTrackNumber(nodeNeighbors.trackNbr);
     }
 
     // find track
@@ -906,11 +864,7 @@ export class Sg6TrackService implements OnDestroy {
       nodeNeighbors.mainTrackIdx = foundTracks === undefined ? 0 : this.createNewTrack(foundTracks);
       nodeNeighbors.pathNodes.push(node);
       nodeTracks.push(nodeNeighbors);
-      return this.getTrackNumber(
-        nodeNeighbors.trackNbr,
-        trainrunItem.backward,
-        separateForwardBackwardTracks,
-      );
+      return this.getTrackNumber(nodeNeighbors.trackNbr);
     }
 
     const trackData = foundTracks[trackIdx];
@@ -920,26 +874,15 @@ export class Sg6TrackService implements OnDestroy {
       trackData.nodeId2 = nodeNeighbors.nodeId2;
     }
     trackData.pathNodes.push(node);
-    return this.getTrackNumber(
-      trackData.trackNbr,
-      trainrunItem.backward,
-      separateForwardBackwardTracks,
-    );
+    return this.getTrackNumber(trackData.trackNbr);
   }
 
-  private updateTracksForAllPathNodes(
-    nodeTracksMap: Map<number, PathNodeNeighbour[]>,
-    separateForwardBackwardTracks: boolean,
-  ) {
+  private updateTracksForAllPathNodes(nodeTracksMap: Map<number, PathNodeNeighbour[]>) {
     for (const keyNodeId of nodeTracksMap.keys()) {
       const tracks = nodeTracksMap.get(keyNodeId);
       const nodeTracks: TrackData[] = [];
       tracks.forEach((pn: PathNodeNeighbour) => {
-        const track1 = new TrackData(
-          this.getTrackNumber(pn.trackNbr, false, separateForwardBackwardTracks),
-          pn.nodeId1,
-          pn.nodeId2,
-        );
+        const track1 = new TrackData(this.getTrackNumber(pn.trackNbr), pn.nodeId1, pn.nodeId2);
         track1.setTrackGrp(pn.trackNbr);
         nodeTracks.push(track1);
       });
@@ -953,11 +896,7 @@ export class Sg6TrackService implements OnDestroy {
     }
   }
 
-  private getTrackNumber(
-    track: number,
-    backward: boolean,
-    separateForwardBackwardTracks: boolean,
-  ): number {
+  private getTrackNumber(track: number): number {
     return track;
   }
 
@@ -1042,7 +981,6 @@ export class Sg6TrackService implements OnDestroy {
   private mapTrackToTop(
     trainrunItems: SgTrainrun[],
     sectionTrackMap: Map<string, [number, number, number][]>,
-    separateForwardBackwardTracks: boolean,
   ) {
     const maxTrackMap = new Map<string, TrackData>();
     trainrunItems.forEach((trainrunItem) => {
@@ -1066,7 +1004,7 @@ export class Sg6TrackService implements OnDestroy {
         if (pathItem.isSection()) {
           const ps = pathItem.getTrainrunSection();
           if (ps.trainrunBranchType === TrainrunBranchType.Trainrun) {
-            const sectionKey = this.getSectionKey(ps, separateForwardBackwardTracks);
+            const sectionKey = this.getSectionKey(ps);
             const trackSegements = sectionTrackMap.get(sectionKey.key);
             if (trackSegements !== undefined) {
               const convertedTrackSegments: TrackSegments[] = this.convertTrackSegments(

--- a/src/app/streckengrafik/services/streckengrafik.services.spec.ts
+++ b/src/app/streckengrafik/services/streckengrafik.services.spec.ts
@@ -49,7 +49,6 @@ describe("StreckengrafikServicesTests", () => {
   let labelService: LabelService = null;
   let filterService: FilterService = null;
   let netzgrafikColoringService: NetzgrafikColoringService = null;
-  let gotFilterChangedSignal = false;
 
   let sg5FilterService: Sg5FilterService;
   let sg6TrackService: Sg6TrackService;
@@ -100,7 +99,6 @@ describe("StreckengrafikServicesTests", () => {
     trainrunSectionService.trainrunSections.subscribe(
       (updatesTrainrunSections) => (trainrunSections = updatesTrainrunSections),
     );
-    filterService.filter.subscribe(() => (gotFilterChangedSignal = true));
 
     loadPerlenketteService = new LoadPerlenketteService(
       trainrunService,

--- a/src/app/streckengrafik/services/streckengrafik.services.spec.ts
+++ b/src/app/streckengrafik/services/streckengrafik.services.spec.ts
@@ -81,7 +81,7 @@ describe("StreckengrafikServicesTests", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,

--- a/src/app/streckengrafik/services/util/streckengrafik-display-element.service.ts
+++ b/src/app/streckengrafik/services/util/streckengrafik-display-element.service.ts
@@ -1,5 +1,5 @@
 import {Injectable} from "@angular/core";
-import {BehaviorSubject, Observable, Subject} from "rxjs";
+import {BehaviorSubject, Observable} from "rxjs";
 
 @Injectable({
   providedIn: "root",

--- a/src/app/view/dialogs/basedata-dialog/basedata-dialog.component.ts
+++ b/src/app/view/dialogs/basedata-dialog/basedata-dialog.component.ts
@@ -103,6 +103,6 @@ export class BaseDataDialogComponent implements OnDestroy {
 
     this.dataSource = new SbbTableDataSource(baseDataConverted);
     const dialogConfig = BaseDataDialogComponent.getDialogConfig();
-    const dialogRef = this.dialog.open(this.baseDataTemplate, dialogConfig);
+    this.dialog.open(this.baseDataTemplate, dialogConfig);
   }
 }

--- a/src/app/view/dialogs/filterable-labels-dialog/filterable-label-dialog.component.ts
+++ b/src/app/view/dialogs/filterable-labels-dialog/filterable-label-dialog.component.ts
@@ -19,7 +19,7 @@ export class FilterableLabelDialogComponent implements OnDestroy {
   private destroyed = new Subject<void>();
   private deleteLabelCallback: ((originalLabel: string) => void) | null = null;
   private transferLabelCallback: ((originalLabel: string) => void) | null = null;
-  private saveLabelCallback: ((originalLabel: string, newLabel: string) => void) | null = null;
+  private saveLabelCallback: ((newLabel: string) => void) | null = null;
   private originalLabel: string;
   private currentDialog: SbbDialogRef<
     FilterableLabelDialogComponent,
@@ -105,7 +105,7 @@ export class FilterableLabelDialogComponent implements OnDestroy {
   private updateLabel() {
     this.formModel.tryGetValid();
     const labelValue: string = this.formModel.getControl("name").value;
-    this.saveLabelCallback(this.originalLabel, labelValue);
+    this.saveLabelCallback(labelValue);
     this.originalLabel = labelValue;
   }
 }

--- a/src/app/view/dialogs/filterable-labels-dialog/filterable-labels-form/filterable-label-form.component.ts
+++ b/src/app/view/dialogs/filterable-labels-dialog/filterable-labels-form/filterable-label-form.component.ts
@@ -31,7 +31,7 @@ export class FilterableLabelFormComponent implements OnInit {
 export interface FilterableLabelsFormComponentModel {
   name: string;
   dialogTitle: string;
-  saveLabelCallback: (originalLabel: string, newLabel: string) => void;
+  saveLabelCallback: (newLabel: string) => void;
   deleteLabelCallback: (originalLabel: string) => void;
   transferLabelCallback: (originalLabel: string) => void;
   updateLabelCallback?: (value: string) => void;

--- a/src/app/view/dialogs/note-dialog/htmlEditor/html-editor.component.html
+++ b/src/app/view/dialogs/note-dialog/htmlEditor/html-editor.component.html
@@ -16,7 +16,7 @@
         (click)="onColor(color)"
         [title]="getColorTitle(color)"
         [style]="getColorStyle(color)"
-        [ngClass]="{'NgxEditor__Color--Active': setActiveColor(color)}"
+        [ngClass]="{'NgxEditor__Color--Active': setActiveColor()}"
       >
         {{ getColorButtonText(color) }}
       </button>

--- a/src/app/view/dialogs/note-dialog/htmlEditor/html-editor.component.ts
+++ b/src/app/view/dialogs/note-dialog/htmlEditor/html-editor.component.ts
@@ -145,7 +145,7 @@ export class HtmlEditorComponent implements OnInit, OnDestroy {
     this.onUpdate();
   }
 
-  setActiveColor(colorStr: string): boolean {
+  setActiveColor(): boolean {
     return true;
   }
 

--- a/src/app/view/dialogs/note-dialog/note-dialog.component.html
+++ b/src/app/view/dialogs/note-dialog/note-dialog.component.html
@@ -2,7 +2,7 @@
   <div
     class="MainNoteTabViewDialog"
     sbbDialog
-    (mouseup)="onMouseUp($event)"
+    (mouseup)="onMouseUp()"
     (mousemove)="onMouseMove($event)"
     (mousedown)="onMouseDown($event)"
   >

--- a/src/app/view/dialogs/note-dialog/note-dialog.component.ts
+++ b/src/app/view/dialogs/note-dialog/note-dialog.component.ts
@@ -106,7 +106,7 @@ export class NoteDialogComponent implements OnDestroy {
     };
   }
 
-  onMouseUp(event: MouseEvent) {
+  onMouseUp() {
     this.dialogMovementLastPosition = undefined;
   }
 

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component.html
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component.html
@@ -2,14 +2,14 @@
   <div
     class="trainrun-dialog-container"
     sbbDialog
-    (mouseup)="onMouseUp($event)"
+    (mouseup)="onMouseUp()"
     (mousemove)="onMouseMove($event)"
     (mousedown)="onMouseDown($event)"
   >
     <div
       data-testid="train-run-tab-group"
       class="trainrun-dialog-tab-group"
-      (mouseup)="onMouseUp($event)"
+      (mouseup)="onMouseUp()"
       (mousemove)="onMouseMove($event)"
       (mousedown)="onMouseDown($event)"
     >
@@ -57,7 +57,7 @@
 
   <div
     class="dialog-drag-and-close-handle-area"
-    (mouseup)="onMouseUp($event)"
+    (mouseup)="onMouseUp()"
     (mousemove)="onMouseMove($event)"
     (mousedown)="onMouseDown($event)"
   >

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component.ts
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component.ts
@@ -13,7 +13,6 @@ import {TrainrunSectionService} from "../../../services/data/trainrunsection.ser
 import {UiInteractionService} from "../../../services/ui/ui.interaction.service";
 import {GeneralViewFunctions} from "../../util/generalViewFunctions";
 import {TrainrunsectionHelper} from "../../../services/util/trainrunsection.helper";
-import {Node} from "../../../models/node.model";
 import {Subject} from "rxjs";
 import {takeUntil} from "rxjs/operators";
 import {DataService} from "../../../services/data/data.service";

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component.ts
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component.ts
@@ -175,7 +175,7 @@ export class TrainrunAndSectionDialogComponent implements OnDestroy {
     };
   }
 
-  onMouseUp(event: MouseEvent) {
+  onMouseUp() {
     this.dialogMovementLastPosition = undefined;
   }
 

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrunsection-card/trainrun-section-card.component.ts
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrunsection-card/trainrun-section-card.component.ts
@@ -1,7 +1,6 @@
 import {AfterViewInit, ChangeDetectorRef, Component, Input, OnDestroy, OnInit} from "@angular/core";
 import {TrainrunSectionService} from "../../../../services/data/trainrunsection.service";
 import {TrainrunService} from "../../../../services/data/trainrun.service";
-import {TrainrunsectionHelper} from "../../../../services/util/trainrunsection.helper";
 import {takeUntil} from "rxjs/operators";
 import {Subject} from "rxjs";
 import {Node} from "../../../../models/node.model";

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrunsection-tab/trainrun-section-tab.component.ts
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrunsection-tab/trainrun-section-tab.component.ts
@@ -2,7 +2,6 @@ import {
   AfterViewInit,
   ChangeDetectorRef,
   Component,
-  ElementRef,
   Input,
   OnDestroy,
   ViewChild,
@@ -22,11 +21,7 @@ import {Subject} from "rxjs";
 import {LinePatternRefs} from "../../../../data-structures/business.data.structures";
 import {StaticDomTags} from "../../../editor-main-view/data-views/static.dom.tags";
 import {ColorRefType} from "../../../../data-structures/technical.data.structures";
-import {
-  TrainrunSectionTimesService,
-  LeftAndRightLockStructure,
-  LeftAndRightTimeStructure,
-} from "../../../../services/data/trainrun-section-times.service";
+import {TrainrunSectionTimesService} from "../../../../services/data/trainrun-section-times.service";
 import {VersionControlService} from "../../../../services/data/version-control.service";
 import {ToggleSwitchButtonComponent} from "../../../toggle-switch-button/toggle-switch-button.component";
 import {TimeStepperComponent} from "./time-stepper/time-stepper.component";

--- a/src/app/view/editor-edit-tools-view-component/label-drop-list/label-drop-list.component.html
+++ b/src/app/view/editor-edit-tools-view-component/label-drop-list/label-drop-list.component.html
@@ -20,9 +20,7 @@
                 cdkDropList
                 cdkDropListOrientation="horizontal"
                 [cdkDropListData]="[labelObject]"
-                (cdkDropListDropped)="
-                  dropLabelElement($event, labelObject.getId(), labelGrp.getId())
-                "
+                (cdkDropListDropped)="dropLabelElement($event, labelGrp.getId())"
               >
                 <button
                   class="TrainrunDialog EditorToolButton NodeLabel"
@@ -41,7 +39,7 @@
                 cdkDropList
                 cdkDropListSortingDisabled="true"
                 [cdkDropListData]="labelService.getLabelsFromLabelGroupId(labelGrp.getId())"
-                (cdkDropListDropped)="dropLabelElement($event, -1, labelGrp.getId())"
+                (cdkDropListDropped)="dropLabelElement($event, labelGrp.getId())"
               ></div>
             </ng-container>
           </div>

--- a/src/app/view/editor-edit-tools-view-component/label-drop-list/label-drop-list.component.ts
+++ b/src/app/view/editor-edit-tools-view-component/label-drop-list/label-drop-list.component.ts
@@ -91,7 +91,7 @@ export class LabelDropListComponent implements OnInit, OnDestroy {
           : labelObject.getLabelRef() === LabelRef.Note
             ? $localize`:@@app.view.editor-edit-tools-view-component.label-drop-list.notes:Notes`
             : $localize`:@@app.view.editor-edit-tools-view-component.label-drop-list.nodes:Nodes`,
-      saveLabelCallback: (refLabel, updatedLabel) =>
+      saveLabelCallback: (updatedLabel) =>
         this.labelService.updateLabel(labelObject.getId(), updatedLabel),
       deleteLabelCallback: (refLabel) => {
         if (labelObject.getLabelRef() === LabelRef.Trainrun) {
@@ -114,7 +114,7 @@ export class LabelDropListComponent implements OnInit, OnDestroy {
     FilterableLabelDialogComponent.open(this.dialog, callbackObject);
   }
 
-  dropLabelElement(event: CdkDragDrop<Label[]>, labelId: number, grpId: number) {
+  dropLabelElement(event: CdkDragDrop<Label[]>, grpId: number) {
     if (event.previousContainer === event.container) {
       return;
     } else {

--- a/src/app/view/editor-main-view/data-views/connections.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/connections.view.spec.ts
@@ -60,7 +60,7 @@ describe("Connections View", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,

--- a/src/app/view/editor-main-view/data-views/connections.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/connections.view.spec.ts
@@ -5,18 +5,12 @@ import {TrainrunService} from "../../../services/data/trainrun.service";
 import {TrainrunSectionService} from "../../../services/data/trainrunsection.service";
 import {BaseDataService} from "../../../services/data/basedata.service";
 import {NoteService} from "../../../services/data/note.service";
-import {Node} from "../../../models/node.model";
-import {TrainrunSection} from "../../../models/trainrunsection.model";
 import {LabelGroupService} from "../../../services/data/labelgroup.service";
 import {LabelService} from "../../../services/data/label.service";
 import {NetzgrafikColoringService} from "../../../services/data/netzgrafikColoring.service";
-import {UndoService} from "../../../services/data/undo.service";
-import {CopyService} from "../../../services/data/copy.service";
 import {LogService} from "../../../logger/log.service";
 import {LogPublishersService} from "../../../logger/log.publishers.service";
 import {FilterService} from "../../../services/ui/filter.service";
-import {UiInteractionService} from "../../../services/ui/ui.interaction.service";
-import {LoadPerlenketteService} from "../../../perlenkette/service/load-perlenkette.service";
 import {NetzgrafikUnitTesting} from "../../../../integration-testing/netzgrafik.unit.testing";
 import {ConnectionsView} from "./connections.view";
 
@@ -28,18 +22,12 @@ describe("Connections View", () => {
   let trainrunSectionService: TrainrunSectionService;
   let baseDataService: BaseDataService;
   let noteService: NoteService;
-  let nodes: Node[] = null;
-  let trainrunSections: TrainrunSection[] = null;
   let logService: LogService = null;
   let logPublishersService: LogPublishersService = null;
   let labelGroupService: LabelGroupService = null;
   let labelService: LabelService = null;
   let filterService: FilterService = null;
   let netzgrafikColoringService: NetzgrafikColoringService = null;
-  let copyService: CopyService = null;
-  let uiInteractionService: UiInteractionService = null;
-  let loadPerlenketteService: LoadPerlenketteService = null;
-  let undoService: UndoService = null;
 
   beforeEach(() => {
     baseDataService = new BaseDataService();
@@ -72,48 +60,6 @@ describe("Connections View", () => {
       labelGroupService,
       filterService,
       netzgrafikColoringService,
-    );
-    nodeService.nodes.subscribe((updatesNodes) => (nodes = updatesNodes));
-    trainrunSectionService.trainrunSections.subscribe(
-      (updatesTrainrunSections) => (trainrunSections = updatesTrainrunSections),
-    );
-
-    loadPerlenketteService = new LoadPerlenketteService(
-      trainrunService,
-      trainrunSectionService,
-      nodeService,
-      filterService,
-    );
-
-    uiInteractionService = new UiInteractionService(
-      filterService,
-      nodeService,
-      noteService,
-      baseDataService,
-      trainrunSectionService,
-      trainrunService,
-      netzgrafikColoringService,
-      loadPerlenketteService,
-      dataService,
-    );
-
-    undoService = new UndoService(
-      dataService,
-      nodeService,
-      noteService,
-      trainrunService,
-      filterService,
-    );
-
-    copyService = new CopyService(
-      dataService,
-      trainrunService,
-      trainrunSectionService,
-      nodeService,
-      noteService,
-      filterService,
-      uiInteractionService,
-      undoService,
     );
   });
 

--- a/src/app/view/editor-main-view/data-views/connections.view.ts
+++ b/src/app/view/editor-main-view/data-views/connections.view.ts
@@ -143,13 +143,13 @@ export class ConnectionsView {
       )
       .classed(StaticDomTags.TAG_SELECTED, (c: ConnectionsViewObject) => c.connection.selected())
       .on("mouseover", (event: MouseEvent, c: ConnectionsViewObject) =>
-        this.onConnectionMouseover(event, c.connection, c.node),
+        this.onConnectionMouseover(event, c.node),
       )
       .on("mouseout", (event: MouseEvent, c: ConnectionsViewObject) =>
-        this.onConnectionMouseout(event, c.connection, c.node),
+        this.onConnectionMouseout(event, c.node),
       )
       .on("mouseup", (event: MouseEvent, c: ConnectionsViewObject) =>
-        this.onConnectionMouseup(event, c.connection, c.node),
+        this.onConnectionMouseup(event, c.node),
       );
   }
 
@@ -159,14 +159,10 @@ export class ConnectionsView {
   ) {
     const draggable = d3
       .drag<SVGElement, ConnectionsViewObject>()
-      .on("start", (event: ConnectionDragEvent, cv: ConnectionsViewObject) =>
-        this.onConnectionPinDragStart(event, cv.connection),
-      )
-      .on("drag", (event: ConnectionDragEvent, cv: ConnectionsViewObject) =>
-        this.onConnectionPinDragged(event, cv.connection),
-      )
-      .on("end", (event: ConnectionDragEvent, cv: ConnectionsViewObject) =>
-        this.onConnectionPinDragEnd(event, cv.connection, cv.node),
+      .on("start", (event: ConnectionDragEvent) => this.onConnectionPinDragStart(event))
+      .on("drag", (event: ConnectionDragEvent) => this.onConnectionPinDragged(event))
+      .on("end", (_, cv: ConnectionsViewObject) =>
+        this.onConnectionPinDragEnd(cv.connection, cv.node),
       );
 
     drawingGroup
@@ -184,13 +180,13 @@ export class ConnectionsView {
       )
       .classed(StaticDomTags.TAG_SELECTED, (c: ConnectionsViewObject) => c.connection.selected())
       .on("mouseover", (event: MouseEvent, cv: ConnectionsViewObject) =>
-        this.onConnectionPinMouseover(event, cv.connection, cv.node),
+        this.onConnectionPinMouseover(event, cv.node),
       )
       .on("mouseout", (event: MouseEvent, cv: ConnectionsViewObject) =>
-        this.onConnectionPinMouseout(event, cv.connection, cv.node),
+        this.onConnectionPinMouseout(event, cv.node),
       )
       .on("mouseup", (event: MouseEvent, cv: ConnectionsViewObject) =>
-        this.onConnectionMouseup(event, cv.connection, cv.node),
+        this.onConnectionMouseup(event, cv.node),
       )
       .call(draggable)
       .classed(StaticDomTags.TAG_WARNING, (cv: ConnectionsViewObject) =>
@@ -306,7 +302,7 @@ export class ConnectionsView {
       }
       case LevelOfDetail.LEVEL0: {
         //statements;
-        this.makeConnectionLOD0(groupEnter);
+        this.makeConnectionLOD0();
         break;
       }
       default: {
@@ -342,41 +338,39 @@ export class ConnectionsView {
     this.createConnectionCurve(groupEnter);
   }
 
-  makeConnectionLOD0(
-    groupEnter: d3.Selection<SVGElement, ConnectionsViewObject, Element, undefined>,
-  ) {}
+  makeConnectionLOD0() {}
 
-  onConnectionMouseup(event: MouseEvent, connection: Connection, node: Node) {
+  onConnectionMouseup(event: MouseEvent, node: Node) {
     event.stopPropagation();
     this.editorView.nodesView.handleMouseUpEvent(event, node);
   }
 
-  onConnectionMouseover(event: MouseEvent, connection: Connection, node: Node) {
+  onConnectionMouseover(event: MouseEvent, node: Node) {
     this.editorView.nodesView.hoverNodeDockable(event, node);
   }
 
-  onConnectionMouseout(event: MouseEvent, connection: Connection, node: Node) {
+  onConnectionMouseout(event: MouseEvent, node: Node) {
     this.editorView.nodesView.unhoverNodeDockable(event, node);
   }
 
-  onConnectionPinMouseover(event: MouseEvent, connection: Connection, node: Node) {
+  onConnectionPinMouseover(event: MouseEvent, node: Node) {
     d3.select(D3Utils.getMouseEventCurrentTarget(event)).classed(StaticDomTags.TAG_HOVER, true);
     this.editorView.nodesView.hoverNodeDockable(event, node);
   }
 
-  onConnectionPinMouseout(event: MouseEvent, connection: Connection, node: Node) {
+  onConnectionPinMouseout(event: MouseEvent, node: Node) {
     d3.select(D3Utils.getMouseEventCurrentTarget(event)).classed(StaticDomTags.TAG_HOVER, false);
     this.editorView.nodesView.unhoverNodeDockable(event, node);
   }
 
-  onConnectionPinDragStart(event: ConnectionDragEvent, connection: Connection) {
+  onConnectionPinDragStart(event: ConnectionDragEvent) {
     const domObj = D3Utils.getMouseEventCurrentTarget(event.sourceEvent);
     this.dragDomObj = domObj;
     d3.select(domObj).classed(StaticDomTags.CONNECTION_PIN_DRAGGING, true);
     D3Utils.disableTrainrunSectionForEventHandling();
   }
 
-  onConnectionPinDragged(event: ConnectionDragEvent, connection: Connection) {
+  onConnectionPinDragged(event: ConnectionDragEvent) {
     const obj = d3.select(this.dragDomObj);
     obj.classed(StaticDomTags.CONNECTION_PIN_DRAGGING, true);
     const currentMousePosition = this.editorView.svgMouseController.getCurrentMousePosition(
@@ -386,7 +380,7 @@ export class ConnectionsView {
     obj.attr("cy", currentMousePosition.getY());
   }
 
-  onConnectionPinDragEnd(event: ConnectionDragEvent, connection: Connection, node: Node) {
+  onConnectionPinDragEnd(connection: Connection, node: Node) {
     D3Utils.resetTrainrunSectionForEventHandling();
     const domObj = this.dragDomObj;
     this.dragDomObj = null;

--- a/src/app/view/editor-main-view/data-views/d3.utils.spec.ts
+++ b/src/app/view/editor-main-view/data-views/d3.utils.spec.ts
@@ -5,8 +5,6 @@ import {TrainrunService} from "../../../services/data/trainrun.service";
 import {TrainrunSectionService} from "../../../services/data/trainrunsection.service";
 import {BaseDataService} from "../../../services/data/basedata.service";
 import {NoteService} from "../../../services/data/note.service";
-import {Node} from "../../../models/node.model";
-import {TrainrunSection} from "../../../models/trainrunsection.model";
 import {LabelGroupService} from "../../../services/data/labelgroup.service";
 import {LabelService} from "../../../services/data/label.service";
 import {NetzgrafikColoringService} from "../../../services/data/netzgrafikColoring.service";
@@ -35,8 +33,6 @@ describe("3d.Utils.tests", () => {
   let trainrunSectionService: TrainrunSectionService;
   let baseDataService: BaseDataService;
   let noteService: NoteService;
-  let nodes: Node[] = null;
-  let trainrunSections: TrainrunSection[] = null;
   let logService: LogService = null;
   let logPublishersService: LogPublishersService = null;
   let labelGroupService: LabelGroupService = null;
@@ -47,7 +43,6 @@ describe("3d.Utils.tests", () => {
   let uiInteractionService: UiInteractionService = null;
   let loadPerlenketteService: LoadPerlenketteService = null;
   let undoService: UndoService = null;
-  let editorView: EditorView = null;
 
   beforeEach(() => {
     baseDataService = new BaseDataService();
@@ -80,10 +75,6 @@ describe("3d.Utils.tests", () => {
       labelGroupService,
       filterService,
       netzgrafikColoringService,
-    );
-    nodeService.nodes.subscribe((updatesNodes) => (nodes = updatesNodes));
-    trainrunSectionService.trainrunSections.subscribe(
-      (updatesTrainrunSections) => (trainrunSections = updatesTrainrunSections),
     );
 
     loadPerlenketteService = new LoadPerlenketteService(
@@ -185,7 +176,6 @@ describe("3d.Utils.tests", () => {
       autoLayoutService,
     );
     controller.bindViewToServices();
-    editorView = controller.editorView;
   });
 
   it("NotesView.convertText", () => {

--- a/src/app/view/editor-main-view/data-views/d3.utils.spec.ts
+++ b/src/app/view/editor-main-view/data-views/d3.utils.spec.ts
@@ -68,7 +68,7 @@ describe("3d.Utils.tests", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,

--- a/src/app/view/editor-main-view/data-views/d3.utils.ts
+++ b/src/app/view/editor-main-view/data-views/d3.utils.ts
@@ -284,7 +284,7 @@ export class D3Utils {
     return v;
   }
 
-  static doGrayoutTrainrunSectionPin(trainrunSection: TrainrunSection, node: Node) {
+  static doGrayoutTrainrunSectionPin(_trainrunSection: TrainrunSection, _node: Node) {
     // Performance ISSUE : TODO - this special effect hast to be overworked. It's really slow!
     /*
     d3.selectAll(StaticDomTags.EDGE_LINE_PIN_DOM_REF)

--- a/src/app/view/editor-main-view/data-views/data.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/data.view.spec.ts
@@ -5,8 +5,6 @@ import {TrainrunService} from "../../../services/data/trainrun.service";
 import {TrainrunSectionService} from "../../../services/data/trainrunsection.service";
 import {BaseDataService} from "../../../services/data/basedata.service";
 import {NoteService} from "../../../services/data/note.service";
-import {Node} from "../../../models/node.model";
-import {TrainrunSection} from "../../../models/trainrunsection.model";
 import {LabelGroupService} from "../../../services/data/labelgroup.service";
 import {LabelService} from "../../../services/data/label.service";
 import {NetzgrafikColoringService} from "../../../services/data/netzgrafikColoring.service";
@@ -39,8 +37,6 @@ describe("Editor-DataView", () => {
   let trainrunSectionService: TrainrunSectionService;
   let baseDataService: BaseDataService;
   let noteService: NoteService;
-  let nodes: Node[] = null;
-  let trainrunSections: TrainrunSection[] = null;
   let logService: LogService = null;
   let logPublishersService: LogPublishersService = null;
   let labelGroupService: LabelGroupService = null;
@@ -84,10 +80,6 @@ describe("Editor-DataView", () => {
       labelGroupService,
       filterService,
       netzgrafikColoringService,
-    );
-    nodeService.nodes.subscribe((updatesNodes) => (nodes = updatesNodes));
-    trainrunSectionService.trainrunSections.subscribe(
-      (updatesTrainrunSections) => (trainrunSections = updatesTrainrunSections),
     );
 
     loadPerlenketteService = new LoadPerlenketteService(

--- a/src/app/view/editor-main-view/data-views/data.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/data.view.spec.ts
@@ -72,7 +72,7 @@ describe("Editor-DataView", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,

--- a/src/app/view/editor-main-view/data-views/editor.keyEvents.ts
+++ b/src/app/view/editor-main-view/data-views/editor.keyEvents.ts
@@ -27,7 +27,6 @@ import {Trainrun} from "../../../models/trainrun.model";
 import {PositionTransformationService} from "../../../services/util/position.transformation.service";
 import {AutoLayoutService} from "../../../services/util/auto-layout.service";
 import {Vec2D} from "../../../utils/vec2D";
-import {PortAlignment} from "../../../data-structures/technical.data.structures";
 import {TrainrunSectionViewObject} from "./trainrunSectionViewObject";
 import {NoteViewObject} from "./noteViewObject";
 import {NodeViewObject} from "./nodeViewObject";

--- a/src/app/view/editor-main-view/data-views/editor.view.ts
+++ b/src/app/view/editor-main-view/data-views/editor.view.ts
@@ -89,8 +89,7 @@ export class EditorView implements SVGMouseControllerObserver {
     | ((deltaPositionX: number, deltaPositionY: number, round: number, dragEnd: boolean) => void)
     | null = null;
   moveSelectedNotes:
-    | ((deltaPositionX: number, deltaPositionY: number, round: number, dragEnd: boolean) => void)
-    | null = null;
+    ((deltaPositionX: number, deltaPositionY: number, round: number) => void) | null = null;
   showNodeInformation: ((node: Node) => void) | null = null;
   showTrainrunInformation: ((trainrunSection: TrainrunSection, position: Vec2D) => void) | null =
     null;
@@ -298,12 +297,7 @@ export class EditorView implements SVGMouseControllerObserver {
   }
 
   bindMoveSelectedNotes(
-    callback: (
-      deltaPositionX: number,
-      deltaPositionY: number,
-      round: number,
-      dragEnd: boolean,
-    ) => void,
+    callback: (deltaPositionX: number, deltaPositionY: number, round: number) => void,
   ) {
     this.moveSelectedNotes = callback;
   }

--- a/src/app/view/editor-main-view/data-views/nodes.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/nodes.view.spec.ts
@@ -67,7 +67,7 @@ describe("Nodes-View", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,
@@ -192,6 +192,6 @@ describe("Nodes-View", () => {
   it("nodesView construction test", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
     const nodesView = new NodesView(editorView);
-    const data = nodesView.createViewNodeDataObjects(nodeService.getNodes());
+    nodesView.createViewNodeDataObjects(nodeService.getNodes());
   });
 });

--- a/src/app/view/editor-main-view/data-views/nodes.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/nodes.view.spec.ts
@@ -5,8 +5,6 @@ import {TrainrunService} from "../../../services/data/trainrun.service";
 import {TrainrunSectionService} from "../../../services/data/trainrunsection.service";
 import {BaseDataService} from "../../../services/data/basedata.service";
 import {NoteService} from "../../../services/data/note.service";
-import {Node} from "../../../models/node.model";
-import {TrainrunSection} from "../../../models/trainrunsection.model";
 import {LabelGroupService} from "../../../services/data/labelgroup.service";
 import {LabelService} from "../../../services/data/label.service";
 import {NetzgrafikColoringService} from "../../../services/data/netzgrafikColoring.service";
@@ -34,8 +32,6 @@ describe("Nodes-View", () => {
   let trainrunSectionService: TrainrunSectionService;
   let baseDataService: BaseDataService;
   let noteService: NoteService;
-  let nodes: Node[] = null;
-  let trainrunSections: TrainrunSection[] = null;
   let logService: LogService = null;
   let logPublishersService: LogPublishersService = null;
   let labelGroupService: LabelGroupService = null;
@@ -79,10 +75,6 @@ describe("Nodes-View", () => {
       labelGroupService,
       filterService,
       netzgrafikColoringService,
-    );
-    nodeService.nodes.subscribe((updatesNodes) => (nodes = updatesNodes));
-    trainrunSectionService.trainrunSections.subscribe(
-      (updatesTrainrunSections) => (trainrunSections = updatesTrainrunSections),
     );
 
     loadPerlenketteService = new LoadPerlenketteService(

--- a/src/app/view/editor-main-view/data-views/nodes.view.ts
+++ b/src/app/view/editor-main-view/data-views/nodes.view.ts
@@ -371,7 +371,7 @@ export class NodesView {
       .attr("class", StaticDomTags.NODE_HOVER_DRAG_AREA_BACKGROUND_CLASS)
       .classed(StaticDomTags.TAG_SELECTED, (n: NodeViewObject) => n.node.selected())
       .attr(StaticDomTags.NODE_ID, (n: NodeViewObject) => n.node.getId())
-      .attr("transform", (n: NodeViewObject) => "translate(-32.5,1)")
+      .attr("transform", () => "translate(-32.5,1)")
       .attr("width", 28)
       .attr("height", 28)
       .attr("x", 2)
@@ -996,7 +996,7 @@ export class NodesView {
     newPosition.setData(newPosition.getX(), newPosition.getY());
 
     this.editorView.moveSelectedNodes(newPosition.getX(), newPosition.getY(), round, dragEnd);
-    this.editorView.moveSelectedNotes(newPosition.getX(), newPosition.getY(), round, dragEnd);
+    this.editorView.moveSelectedNotes(newPosition.getX(), newPosition.getY(), round);
 
     // update the drag mouse position (previous for next dragging step)
     this.dragPreviousMousePosition = currentMousePosition;

--- a/src/app/view/editor-main-view/data-views/notes.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/notes.view.spec.ts
@@ -5,8 +5,6 @@ import {TrainrunService} from "../../../services/data/trainrun.service";
 import {TrainrunSectionService} from "../../../services/data/trainrunsection.service";
 import {BaseDataService} from "../../../services/data/basedata.service";
 import {NoteService} from "../../../services/data/note.service";
-import {Node} from "../../../models/node.model";
-import {TrainrunSection} from "../../../models/trainrunsection.model";
 import {LabelGroupService} from "../../../services/data/labelgroup.service";
 import {LabelService} from "../../../services/data/label.service";
 import {NetzgrafikColoringService} from "../../../services/data/netzgrafikColoring.service";
@@ -34,8 +32,6 @@ describe("Notes-View", () => {
   let trainrunSectionService: TrainrunSectionService;
   let baseDataService: BaseDataService;
   let noteService: NoteService;
-  let nodes: Node[] = null;
-  let trainrunSections: TrainrunSection[] = null;
   let logService: LogService = null;
   let logPublishersService: LogPublishersService = null;
   let labelGroupService: LabelGroupService = null;
@@ -79,10 +75,6 @@ describe("Notes-View", () => {
       labelGroupService,
       filterService,
       netzgrafikColoringService,
-    );
-    nodeService.nodes.subscribe((updatesNodes) => (nodes = updatesNodes));
-    trainrunSectionService.trainrunSections.subscribe(
-      (updatesTrainrunSections) => (trainrunSections = updatesTrainrunSections),
     );
 
     loadPerlenketteService = new LoadPerlenketteService(

--- a/src/app/view/editor-main-view/data-views/notes.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/notes.view.spec.ts
@@ -67,7 +67,7 @@ describe("Notes-View", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,
@@ -190,7 +190,7 @@ describe("Notes-View", () => {
 
   it("notesView constructor test", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
-    const notesView = new NotesView(editorView);
+    new NotesView(editorView);
   });
 
   it("NotesView.convertText", () => {

--- a/src/app/view/editor-main-view/data-views/notes.view.ts
+++ b/src/app/view/editor-main-view/data-views/notes.view.ts
@@ -29,7 +29,7 @@ export class NotesView {
   constructor(private editorView: EditorView) {
     this.draggable = d3
       .drag<SVGElement, NoteViewObject>()
-      .on("start", (event: NoteDragEvent, n: NoteViewObject) => this.onNoteDragStart(event, n.note))
+      .on("start", (event: NoteDragEvent) => this.onNoteDragStart(event))
       .on("drag", (event: NoteDragEvent, n: NoteViewObject) => this.onNoteDragged(event, n.note))
       .on("end", (event: NoteDragEvent, n: NoteViewObject) => this.onNoteDragEnd(event, n.note));
     this.dragPreviousMousePosition = new Vec2D();
@@ -225,10 +225,8 @@ export class NotesView {
 
     added
       .call(this.draggable)
-      .on("mouseout", (event: MouseEvent, n: NoteViewObject) => this.onNoteMouseout(event, n.note))
-      .on("mouseover", (event: MouseEvent, n: NoteViewObject) =>
-        this.onNoteMouseover(event, n.note),
-      );
+      .on("mouseout", (_, n: NoteViewObject) => this.onNoteMouseout(n.note))
+      .on("mouseover", (_, n: NoteViewObject) => this.onNoteMouseover(n.note));
   }
 
   private makeNoteRoot(groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>) {
@@ -249,10 +247,8 @@ export class NotesView {
         this.onNoteMousedown(event, n.note),
       )
       .on("mouseup", (event: MouseEvent, n: NoteViewObject) => this.onNoteMouseup(event, n.note))
-      .on("mouseout", (event: MouseEvent, n: NoteViewObject) => this.onNoteMouseout(event, n.note))
-      .on("mouseover", (event: MouseEvent, n: NoteViewObject) =>
-        this.onNoteMouseover(event, n.note),
-      );
+      .on("mouseout", (_, n: NoteViewObject) => this.onNoteMouseout(n.note))
+      .on("mouseover", (_, n: NoteViewObject) => this.onNoteMouseover(n.note));
   }
 
   private makeNoteTitleArea(
@@ -275,10 +271,8 @@ export class NotesView {
         this.onNoteMousedown(event, n.note),
       )
       .on("mouseup", (event: MouseEvent, n: NoteViewObject) => this.onNoteMouseup(event, n.note))
-      .on("mouseout", (event: MouseEvent, n: NoteViewObject) => this.onNoteMouseout(event, n.note))
-      .on("mouseover", (event: MouseEvent, n: NoteViewObject) =>
-        this.onNoteMouseover(event, n.note),
-      );
+      .on("mouseout", (_, n: NoteViewObject) => this.onNoteMouseout(n.note))
+      .on("mouseover", (_, n: NoteViewObject) => this.onNoteMouseover(n.note));
   }
 
   private makeNoteTextArea(
@@ -304,10 +298,8 @@ export class NotesView {
         this.onNoteMousedown(event, n.note),
       )
       .on("mouseup", (event: MouseEvent, n: NoteViewObject) => this.onNoteMouseup(event, n.note))
-      .on("mouseout", (event: MouseEvent, n: NoteViewObject) => this.onNoteMouseout(event, n.note))
-      .on("mouseover", (event: MouseEvent, n: NoteViewObject) =>
-        this.onNoteMouseover(event, n.note),
-      );
+      .on("mouseout", (_, n: NoteViewObject) => this.onNoteMouseout(n.note))
+      .on("mouseover", (_, n: NoteViewObject) => this.onNoteMouseover(n.note));
   }
 
   private makeNoteTitleAreaText(
@@ -323,10 +315,8 @@ export class NotesView {
       .on("mousedown", (event: MouseEvent, n: NoteViewObject) =>
         this.onNoteMousedown(event, n.note),
       )
-      .on("mouseout", (event: MouseEvent, n: NoteViewObject) => this.onNoteMouseout(event, n.note))
-      .on("mouseover", (event: MouseEvent, n: NoteViewObject) =>
-        this.onNoteMouseover(event, n.note),
-      );
+      .on("mouseout", (_, n: NoteViewObject) => this.onNoteMouseout(n.note))
+      .on("mouseover", (_, n: NoteViewObject) => this.onNoteMouseover(n.note));
   }
 
   private makeNoteText(groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>) {
@@ -340,10 +330,8 @@ export class NotesView {
       .on("mousedown", (event: MouseEvent, n: NoteViewObject) =>
         this.onNoteMousedown(event, n.note),
       )
-      .on("mouseout", (event: MouseEvent, n: NoteViewObject) => this.onNoteMouseout(event, n.note))
-      .on("mouseover", (event: MouseEvent, n: NoteViewObject) =>
-        this.onNoteMouseover(event, n.note),
-      );
+      .on("mouseout", (_, n: NoteViewObject) => this.onNoteMouseout(n.note))
+      .on("mouseover", (_, n: NoteViewObject) => this.onNoteMouseover(n.note));
   }
 
   private makeNoteDragAreaBackground(
@@ -355,7 +343,7 @@ export class NotesView {
       .attr("class", StaticDomTags.NOTE_HOVER_DRAG_AREA_BACKGROUND_CLASS)
       .classed(StaticDomTags.TAG_SELECTED, (n: NoteViewObject) => n.note.selected())
       .attr(StaticDomTags.NOTE_ID, (n: NoteViewObject) => n.note.getId())
-      .attr("transform", (n: NoteViewObject) => "translate(-50,-20)")
+      .attr("transform", () => "translate(-50,-20)")
       .attr("width", 28)
       .attr("height", 28)
       .attr("x", 0)
@@ -366,12 +354,8 @@ export class NotesView {
     }
 
     added
-      .on("mouseout", (event: MouseEvent, n: NoteViewObject) =>
-        this.onNoteMouseoutDragButton(event, n.note),
-      )
-      .on("mouseover", (event: MouseEvent, n: NoteViewObject) =>
-        this.onNoteMouseoverDragButton(event, n.note),
-      )
+      .on("mouseout", (_, n: NoteViewObject) => this.onNoteMouseoutDragButton(n.note))
+      .on("mouseover", (_, n: NoteViewObject) => this.onNoteMouseoverDragButton(n.note))
       .call(this.draggable);
   }
 
@@ -395,13 +379,9 @@ export class NotesView {
           "3.5-3.5.353-.354-.353-.354-3.5-3.5-.707.708L19.043 11H12V3.967l2.997 " +
           "3.029.711-.704-3.853-3.894Z",
       )
-      .attr("transform", (n: NoteViewObject) => "translate(-45,-15),scale(1.0)")
-      .on("mouseout", (event: MouseEvent, n: NoteViewObject) =>
-        this.onNoteMouseoutDragButton(event, n.note),
-      )
-      .on("mouseover", (event: MouseEvent, n: NoteViewObject) =>
-        this.onNoteMouseoverDragButton(event, n.note),
-      )
+      .attr("transform", () => "translate(-45,-15),scale(1.0)")
+      .on("mouseout", (_, n: NoteViewObject) => this.onNoteMouseoutDragButton(n.note))
+      .on("mouseover", (_, n: NoteViewObject) => this.onNoteMouseoverDragButton(n.note))
       .call(this.draggable);
   }
 
@@ -452,11 +432,11 @@ export class NotesView {
     this.editorView.editNote(note.getId(), clickPosition);
   }
 
-  onNoteMouseout(event: MouseEvent, note: Note) {
+  onNoteMouseout(note: Note) {
     this.unhoverNote(note);
   }
 
-  onNoteMouseover(event: MouseEvent, note: Note) {
+  onNoteMouseover(note: Note) {
     if (this.editorView.trainrunSectionPreviewLineView.getMode() !== PreviewLineMode.NotDragging) {
       return;
     }
@@ -470,18 +450,18 @@ export class NotesView {
     this.hoverNote(note);
   }
 
-  onNoteMouseoverDragButton(event: MouseEvent, note: Note) {
-    this.onNoteMouseover(event, note);
+  onNoteMouseoverDragButton(note: Note) {
+    this.onNoteMouseover(note);
     d3.selectAll(StaticDomTags.NOTE_HOVER_DRAG_AREA_DOM_REF)
       .filter((n: NoteViewObject) => n.note.getId() === note.getId())
       .classed(StaticDomTags.TAG_HOVER, true);
   }
 
-  onNoteMouseoutDragButton(event: MouseEvent, note: Note) {
+  onNoteMouseoutDragButton(note: Note) {
     d3.selectAll(StaticDomTags.NOTE_HOVER_DRAG_AREA_DOM_REF)
       .filter((n: NoteViewObject) => n.note.getId() === note.getId())
       .classed(StaticDomTags.TAG_HOVER, false);
-    this.onNoteMouseout(event, note);
+    this.onNoteMouseout(note);
   }
 
   hoverNote(note: Note) {
@@ -502,7 +482,7 @@ export class NotesView {
       .classed(StaticDomTags.TAG_HOVER, false);
   }
 
-  onNoteDragStart(event: NoteDragEvent, note: Note) {
+  onNoteDragStart(event: NoteDragEvent) {
     const domObj = D3Utils.getMouseEventCurrentTarget(event.sourceEvent);
     this.dragDomObj = domObj;
     d3.select(domObj).classed(StaticDomTags.TAG_HOVER, true);
@@ -537,7 +517,7 @@ export class NotesView {
 
     if (this.editorView.editorMode === EditorMode.MultiNodeMoving) {
       this.editorView.moveSelectedNodes(newPosition.getX(), newPosition.getY(), round, dragEnd);
-      this.editorView.moveSelectedNotes(newPosition.getX(), newPosition.getY(), round, dragEnd);
+      this.editorView.moveSelectedNotes(newPosition.getX(), newPosition.getY(), round);
     } else {
       this.editorView.moveNote(noteId, newPosition, round, dragEnd);
     }

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.spec.ts
@@ -5,8 +5,6 @@ import {TrainrunService} from "../../../services/data/trainrun.service";
 import {TrainrunSectionService} from "../../../services/data/trainrunsection.service";
 import {BaseDataService} from "../../../services/data/basedata.service";
 import {NoteService} from "../../../services/data/note.service";
-import {Node} from "../../../models/node.model";
-import {TrainrunSection} from "../../../models/trainrunsection.model";
 import {LabelGroupService} from "../../../services/data/labelgroup.service";
 import {LabelService} from "../../../services/data/label.service";
 import {NetzgrafikColoringService} from "../../../services/data/netzgrafikColoring.service";
@@ -36,8 +34,6 @@ describe("TrainrunSection-View", () => {
   let trainrunSectionService: TrainrunSectionService;
   let baseDataService: BaseDataService;
   let noteService: NoteService;
-  let nodes: Node[] = null;
-  let trainrunSections: TrainrunSection[] = null;
   let logService: LogService = null;
   let logPublishersService: LogPublishersService = null;
   let labelGroupService: LabelGroupService = null;
@@ -81,10 +77,6 @@ describe("TrainrunSection-View", () => {
       labelGroupService,
       filterService,
       netzgrafikColoringService,
-    );
-    nodeService.nodes.subscribe((updatesNodes) => (nodes = updatesNodes));
-    trainrunSectionService.trainrunSections.subscribe(
-      (updatesTrainrunSections) => (trainrunSections = updatesTrainrunSections),
     );
 
     loadPerlenketteService = new LoadPerlenketteService(

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.spec.ts
@@ -69,7 +69,7 @@ describe("TrainrunSection-View", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -1157,8 +1157,8 @@ export class TrainrunSectionsView {
         .on("mouseover", (event: MouseEvent, d: TrainrunSectionViewObject) => {
           this.onTrainrunSectionMouseoverPath(event, d.trainrunSection);
         })
-        .on("mouseout", (event: MouseEvent, d: TrainrunSectionViewObject) => {
-          this.onTrainrunSectionMouseoutPath(event, d.trainrunSection);
+        .on("mouseout", (_, d: TrainrunSectionViewObject) => {
+          this.onTrainrunSectionMouseoutPath(d.trainrunSection);
         });
     });
   }
@@ -1232,8 +1232,8 @@ export class TrainrunSectionsView {
         .on("mouseover", (event: MouseEvent, d: TrainrunSectionViewObject) => {
           this.onTrainrunSectionMouseoverPath(event, d.trainrunSection);
         })
-        .on("mouseout", (event: MouseEvent, d: TrainrunSectionViewObject) => {
-          this.onTrainrunSectionMouseoutPath(event, d.trainrunSection);
+        .on("mouseout", (_, d: TrainrunSectionViewObject) => {
+          this.onTrainrunSectionMouseoutPath(d.trainrunSection);
         });
     });
   }
@@ -1286,9 +1286,9 @@ export class TrainrunSectionsView {
             this.onTrainrunSectionMouseoverPath(event, d.trainrunSection);
           }
         })
-        .on("mouseout", (event: MouseEvent, d: TrainrunSectionViewObject) => {
+        .on("mouseout", (_, d: TrainrunSectionViewObject) => {
           if (enableEvents) {
-            this.onTrainrunSectionMouseoutPath(event, d.trainrunSection);
+            this.onTrainrunSectionMouseoutPath(d.trainrunSection);
           }
         });
     }
@@ -1553,14 +1553,14 @@ export class TrainrunSectionsView {
       .attr("style", (d: TrainrunSectionViewObject) =>
         TrainrunSectionsView.getTrainrunSectionValueHtmlStyle(d.trainrunSection, textElement),
       )
-      .on("mouseover", (event: MouseEvent, d: TrainrunSectionViewObject) => {
+      .on("mouseover", (event: MouseEvent) => {
         if (enableEvents) {
-          this.onTrainrunSectionTextMouseover(event, d.trainrunSection);
+          this.onTrainrunSectionTextMouseover(event);
         }
       })
-      .on("mouseout", (event: MouseEvent, d: TrainrunSectionViewObject) => {
+      .on("mouseout", (event: MouseEvent) => {
         if (enableEvents) {
-          this.onTrainrunSectionTextMouseout(event, d.trainrunSection);
+          this.onTrainrunSectionTextMouseout(event);
         }
       })
       .on("mouseup", (event: MouseEvent, d: TrainrunSectionViewObject) => {
@@ -1870,19 +1870,14 @@ export class TrainrunSectionsView {
     D3Utils.bringTrainrunSectionToFront();
   }
 
-  onTrainrunSectionTextMouseover(event: MouseEvent, trainrunSection: TrainrunSection) {
+  onTrainrunSectionTextMouseover(event: MouseEvent) {
     if (this.editorView.trainrunSectionPreviewLineView.getMode() === PreviewLineMode.NotDragging) {
       const domObj = D3Utils.getMouseEventCurrentTarget(event);
       d3.select(domObj).classed(StaticDomTags.TAG_HOVER, true);
     }
   }
 
-  onIntermediateStopMouseOut(
-    event: MouseEvent,
-    trainrunSection: TrainrunSection,
-    stopIndex: number,
-    position: Vec2D,
-  ) {
+  onIntermediateStopMouseOut(event: MouseEvent) {
     event.stopPropagation();
     if (event.buttons === 0) {
       const domObj = D3Utils.getMouseEventCurrentTarget(event);
@@ -1890,12 +1885,7 @@ export class TrainrunSectionsView {
     }
   }
 
-  onIntermediateStopMouseOver(
-    event: MouseEvent,
-    trainrunSection: TrainrunSection,
-    stopIndex: number,
-    position: Vec2D,
-  ) {
+  onIntermediateStopMouseOver(event: MouseEvent) {
     event.stopPropagation();
     const domObj = D3Utils.getMouseEventCurrentTarget(event);
     d3.select(domObj).classed(StaticDomTags.TAG_HOVER, true);
@@ -1936,7 +1926,7 @@ export class TrainrunSectionsView {
     this.editorView.setTrainrunAsSelected(trainrunSection.getTrainrun());
   }
 
-  onTrainrunSectionTextMouseout(event: MouseEvent, trainrunSection: TrainrunSection) {
+  onTrainrunSectionTextMouseout(event: MouseEvent) {
     const domObj = D3Utils.getMouseEventCurrentTarget(event);
     d3.select(domObj).classed(StaticDomTags.TAG_HOVER, false);
   }
@@ -1958,7 +1948,7 @@ export class TrainrunSectionsView {
     const clickPosition = new Vec2D(rect.x + rect.width / 2, rect.y + rect.height / 2);
 
     if (this.editorView.editorMode === EditorMode.Analytics) {
-      this.onTrainrunSectionElementClickedAnalytics(trainrunSection, textElement, clickPosition);
+      this.onTrainrunSectionElementClickedAnalytics(trainrunSection, textElement);
       return;
     }
     this.onTrainrunSectionElementClickedNetzgrafikEditing(
@@ -2052,7 +2042,7 @@ export class TrainrunSectionsView {
     }
   }
 
-  onTrainrunSectionMouseoutPath(event: MouseEvent, trainrunSection: TrainrunSection) {
+  onTrainrunSectionMouseoutPath(trainrunSection: TrainrunSection) {
     D3Utils.unhoverTrainrunSection(trainrunSection);
   }
 
@@ -2136,18 +2126,14 @@ export class TrainrunSectionsView {
   private onTrainrunSectionElementClickedAnalytics(
     trainrunSection: TrainrunSection,
     textElement: TrainrunSectionText,
-    clickPos: Vec2D,
   ) {
     let node: Node;
-    let minute: number;
     switch (textElement) {
       case TrainrunSectionText.SourceDeparture:
         node = trainrunSection.getSourceNode();
-        minute = trainrunSection.getSourceDeparture();
         break;
       case TrainrunSectionText.TargetDeparture:
         node = trainrunSection.getTargetNode();
-        minute = trainrunSection.getTargetDeparture();
         break;
     }
     this.editorView.unselectAllNodes();
@@ -2323,7 +2309,6 @@ export class TrainrunSectionsView {
 
     if (!this.editorView.isTemporaryDisableFilteringOfItemsInViewEnabled()) {
       if (ts.getSourceNode().isNonStopNode()) {
-        const node = ts.getSourceNode().getOppositeNode(ts);
         retPath = this.transformPathIfSourceNodeFilteredDueNonStopNodesFiltering(ts, retPath);
       }
       if (ts.getTargetNode().isNonStopNode()) {
@@ -2356,13 +2341,7 @@ export class TrainrunSectionsView {
         !this.filterOutAllTrainrunSectionWithHiddenNodeConnection(d.trainrunSection),
     );
 
-    this.make4LayerTrainrunSectionLines(
-      groupLines,
-      selectedTrainrun,
-      connectedTrainIds,
-      inGroupLabels,
-      false,
-    );
+    this.make4LayerTrainrunSectionLines(groupLines, selectedTrainrun, connectedTrainIds, false);
 
     if (!this.editorView.isElementDragging()) {
       this.createDirectionArrows(groupLines, selectedTrainrun, connectedTrainIds, false);
@@ -2480,13 +2459,7 @@ export class TrainrunSectionsView {
       this.filterOutAllTrainrunSectionWithHiddenNodeConnection(d.trainrunSection),
     );
 
-    this.make4LayerTrainrunSectionLines(
-      groupLines,
-      selectedTrainrun,
-      connectedTrainIds,
-      inGroupLabels,
-      true,
-    );
+    this.make4LayerTrainrunSectionLines(groupLines, selectedTrainrun, connectedTrainIds, true);
 
     if (!this.editorView.isElementDragging()) {
       this.createDirectionArrows(groupLines, selectedTrainrun, connectedTrainIds, true);
@@ -2636,7 +2609,6 @@ export class TrainrunSectionsView {
     groupLines: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
-    inGroupLabels: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
     enableEvents: boolean,
   ) {
     this.createTrainrunSection(
@@ -2716,12 +2688,8 @@ export class TrainrunSectionsView {
         TrainrunSectionsView.isSectionSelected(t.trainrunSection),
       )
       .classed(StaticDomTags.EDGE_LINE_STOPS_FILL, () => !collapsedStops)
-      .on("mouseover", (event: MouseEvent, t: TrainrunSectionViewObject) =>
-        this.onIntermediateStopMouseOver(event, t.trainrunSection, stopIndex, position),
-      )
-      .on("mouseout", (event: MouseEvent, t: TrainrunSectionViewObject) =>
-        this.onIntermediateStopMouseOut(event, t.trainrunSection, stopIndex, position),
-      )
+      .on("mouseover", (event: MouseEvent) => this.onIntermediateStopMouseOver(event))
+      .on("mouseout", (event: MouseEvent) => this.onIntermediateStopMouseOut(event))
       .on("mousedown", (event: MouseEvent, t: TrainrunSectionViewObject) =>
         this.onIntermediateStopMouseDown(event, t.trainrunSection, stopIndex, position),
       )

--- a/src/app/view/editor-main-view/data-views/transitions.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/transitions.view.spec.ts
@@ -67,7 +67,7 @@ describe("Transitions-View", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,
@@ -191,13 +191,12 @@ describe("Transitions-View", () => {
 
   it("transitionsView constructor test", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
-    const transitionsView = new TransitionsView(editorView);
+    new TransitionsView(editorView);
   });
 
   it("TransitionsView.isMuted - 001", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
     const t = trainrunService.getTrainrunFromId(2);
-    const s = trainrunService.getTrainrunFromId(1);
     const v1 = TransitionsView.isMuted(t, null, undefined);
     expect(v1).toBe(false);
   });
@@ -229,7 +228,6 @@ describe("Transitions-View", () => {
   it("TransitionsView.createTrainrunClassAttribute - 001", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
     const t = trainrunService.getTrainrunFromId(2);
-    const s = trainrunService.getTrainrunFromId(1);
     const v1 = TransitionsView.createTrainrunClassAttribute(t, null, undefined);
     expect(v1).toBe("transition_line Freq_20 ColorRef_S LinePatternRef_7/24");
   });

--- a/src/app/view/editor-main-view/data-views/transitions.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/transitions.view.spec.ts
@@ -5,8 +5,6 @@ import {TrainrunService} from "../../../services/data/trainrun.service";
 import {TrainrunSectionService} from "../../../services/data/trainrunsection.service";
 import {BaseDataService} from "../../../services/data/basedata.service";
 import {NoteService} from "../../../services/data/note.service";
-import {Node} from "../../../models/node.model";
-import {TrainrunSection} from "../../../models/trainrunsection.model";
 import {LabelGroupService} from "../../../services/data/labelgroup.service";
 import {LabelService} from "../../../services/data/label.service";
 import {NetzgrafikColoringService} from "../../../services/data/netzgrafikColoring.service";
@@ -34,8 +32,6 @@ describe("Transitions-View", () => {
   let trainrunSectionService: TrainrunSectionService;
   let baseDataService: BaseDataService;
   let noteService: NoteService;
-  let nodes: Node[] = null;
-  let trainrunSections: TrainrunSection[] = null;
   let logService: LogService = null;
   let logPublishersService: LogPublishersService = null;
   let labelGroupService: LabelGroupService = null;
@@ -79,10 +75,6 @@ describe("Transitions-View", () => {
       labelGroupService,
       filterService,
       netzgrafikColoringService,
-    );
-    nodeService.nodes.subscribe((updatesNodes) => (nodes = updatesNodes));
-    trainrunSectionService.trainrunSections.subscribe(
-      (updatesTrainrunSections) => (trainrunSections = updatesTrainrunSections),
     );
 
     loadPerlenketteService = new LoadPerlenketteService(

--- a/src/app/view/editor-main-view/data-views/transitions.view.ts
+++ b/src/app/view/editor-main-view/data-views/transitions.view.ts
@@ -156,13 +156,13 @@ export class TransitionsView {
       )
       .on("mousemove", (event: MouseEvent) => event.preventDefault())
       .on("mouseover", (event: MouseEvent, t: TransitionViewObject) =>
-        this.onTransitionMouseover(event, t.transition.getTrainrun(), t.transition),
+        this.onTransitionMouseover(event, t.transition),
       )
       .on("mouseup", (event: MouseEvent, t: TransitionViewObject) =>
-        this.onTransitionMouseup(event, t.transition.getTrainrun(), t.transition),
+        this.onTransitionMouseup(event, t.transition),
       )
       .on("mouseout", (event: MouseEvent, t: TransitionViewObject) =>
-        this.onTransitionButtonOut(event, t.transition.getTrainrun(), t.transition),
+        this.onTransitionButtonOut(event, t.transition),
       );
   }
 
@@ -275,7 +275,7 @@ export class TransitionsView {
     transitionsGroup.exit().remove();
   }
 
-  onTransitionMouseup(event: MouseEvent, trainrun: Trainrun, transition: Transition) {
+  onTransitionMouseup(event: MouseEvent, transition: Transition) {
     event.stopPropagation();
     const node: Node = this.editorView.getNodeFromTransition(transition);
     if (this.editorView.trainrunSectionPreviewLineView.getMode() === PreviewLineMode.NotDragging) {
@@ -301,7 +301,7 @@ export class TransitionsView {
     this.editorView.trainrunSectionPreviewLineView.stopPreviewLine();
   }
 
-  onTransitionButtonOut(event: MouseEvent, trainrun: Trainrun, transition: Transition) {
+  onTransitionButtonOut(event: MouseEvent, transition: Transition) {
     const domObj = D3Utils.getMouseEventCurrentTarget(event);
     d3.select(domObj).classed(StaticDomTags.TAG_HOVER, false);
 
@@ -334,7 +334,7 @@ export class TransitionsView {
     this.editorView.trainrunSectionPreviewLineView.updatePreviewLine(event);
   }
 
-  onTransitionMouseover(event: MouseEvent, trainrun: Trainrun, transition: Transition) {
+  onTransitionMouseover(event: MouseEvent, transition: Transition) {
     const node: Node = this.editorView.getNodeFromTransition(transition);
     if (this.editorView.trainrunSectionPreviewLineView.getMode() === PreviewLineMode.NotDragging) {
       const port1 = node.getPort(transition.getPortId1());

--- a/src/app/view/editor-main-view/editor-main-view.component.ts
+++ b/src/app/view/editor-main-view/editor-main-view.component.ts
@@ -188,8 +188,8 @@ export class EditorMainViewComponent implements AfterViewInit, OnDestroy {
     );
 
     this.editorView.bindMoveSelectedNotes(
-      (deltaPositionX: number, deltaPositionY: number, round: number, dragEnd: boolean) =>
-        this.noteService.moveSelectedNotes(deltaPositionX, deltaPositionY, round, dragEnd),
+      (deltaPositionX: number, deltaPositionY: number, round: number) =>
+        this.noteService.moveSelectedNotes(deltaPositionX, deltaPositionY, round),
     );
 
     this.editorView.bindAddTrainrunSectionWithSourceTarget(

--- a/src/app/view/editor-properties-view-component/editor-properties-view.component.html
+++ b/src/app/view/editor-properties-view-component/editor-properties-view.component.html
@@ -31,7 +31,7 @@
         [name]="'app.view.editor-properties-view-component.background-color' | translate"
         style="width: 242px; min-height: 37px"
         [(ngModel)]="activeBackgroundColor"
-        (change)="colorPicked($event)"
+        (change)="colorPicked()"
       />
       &nbsp;
       <button
@@ -82,7 +82,7 @@
         [name]="'app.view.editor-properties-view-component.background-color' | translate"
         style="width: 242px; min-height: 37px; vertical-align: middle"
         [(ngModel)]="activeDarkBackgroundColor"
-        (change)="colorPicked($event)"
+        (change)="colorPicked()"
       />
       &nbsp;
       <button

--- a/src/app/view/editor-properties-view-component/editor-properties-view.component.ts
+++ b/src/app/view/editor-properties-view-component/editor-properties-view.component.ts
@@ -146,7 +146,7 @@ export class EditorPropertiesViewComponent {
     this.activeTrafficSideType = event.value;
   }
 
-  colorPicked(value: string) {
+  colorPicked() {
     this.onUpdateColorTheme(
       new SbbRadioChange(null, this.uiInteractionService.getActiveTheme().themeRegistration),
     );

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -16,7 +16,6 @@ import {
   NetzgrafikDto,
   NodeDto,
   TrainrunCategoryHaltezeit,
-  TrainrunSectionDto,
 } from "../../data-structures/business.data.structures";
 import {downloadBlob} from "../util/download-utils";
 import {map} from "rxjs/operators";

--- a/src/app/view/knoten-auslastung-view/knoten-auslastung-view.component.ts
+++ b/src/app/view/knoten-auslastung-view/knoten-auslastung-view.component.ts
@@ -1,5 +1,5 @@
 import * as d3 from "d3";
-import {AfterViewInit, Component, Input, OnDestroy} from "@angular/core";
+import {AfterViewInit, Component, OnDestroy} from "@angular/core";
 import {NodeService} from "../../services/data/node.service";
 import {TrainrunSectionService} from "../../services/data/trainrunsection.service";
 import {TrainrunService} from "../../services/data/trainrun.service";

--- a/src/app/view/knoten-auslastung-view/knoten-auslastung-view.component.ts
+++ b/src/app/view/knoten-auslastung-view/knoten-auslastung-view.component.ts
@@ -200,7 +200,7 @@ export class KnotenAuslastungViewComponent implements AfterViewInit, OnDestroy {
       .append("title")
       .html((d) => d.tooltip);
 
-    const groupText = rootDataGroup
+    rootDataGroup
       .enter()
       .append(StaticDomTags.GROUP_SVG)
       .attr("class", StaticDomTags.KNOTENAUSLASTUNG_DATA_GROUP)

--- a/src/app/view/knoten-auslastung-view/knoten.auslastung.data.preparation.ts
+++ b/src/app/view/knoten-auslastung-view/knoten.auslastung.data.preparation.ts
@@ -4,7 +4,6 @@ import {Node} from "../../models/node.model";
 import {ResourceService} from "../../services/data/resource.service";
 import {TrainrunSectionService} from "../../services/data/trainrunsection.service";
 import {TrainrunService} from "../../services/data/trainrun.service";
-import {Direction} from "src/app/data-structures/business.data.structures";
 
 export class KnotenAuslastungDataPreparation {
   static MAX_NR_MINUTES = 60;

--- a/src/app/view/navigation-bar/navigation-bar.component.ts
+++ b/src/app/view/navigation-bar/navigation-bar.component.ts
@@ -138,7 +138,7 @@ class BreadcrumbsDefinitionsHandler {
 
   getParams(urlHandler: UrlHandler): Param[] {
     return urlHandler.splittedUrl
-      .filter((value, index) => this.parameterPointers.find((pointer) => pointer === index))
+      .filter((_, index) => this.parameterPointers.find((pointer) => pointer === index))
       .map((value) => new Param(value));
   }
 }

--- a/src/app/view/themes/theme.spec.ts
+++ b/src/app/view/themes/theme.spec.ts
@@ -48,7 +48,6 @@ describe("Theme Tests", () => {
   });
 
   it("check...Colors_keys() ", () => {
-    const nbrColorEntries = 46;
     const keys: string[] = [];
     ThemeDefaultUx.getThemeDefaultUxColors().forEach((str: string) => keys.push(str.split(":")[0]));
 

--- a/src/app/view/util/origin-destination-graph.ts
+++ b/src/app/view/util/origin-destination-graph.ts
@@ -94,12 +94,12 @@ export const buildEdges = (
 
   // Sorting is useful to find relevant connections later.
   verticesDepartureByTrainrunByNode.forEach((verticesDepartureByTrainrun) => {
-    verticesDepartureByTrainrun.forEach((departures, trainrunId) => {
+    verticesDepartureByTrainrun.forEach((departures) => {
       departures.sort((a, b) => a.time - b.time);
     });
   });
   verticesArrivalByTrainrunByNode.forEach((verticesArrivalByTrainrun) => {
-    verticesArrivalByTrainrun.forEach((arrivals, trainrunId) => {
+    verticesArrivalByTrainrun.forEach((arrivals) => {
       arrivals.sort((a, b) => a.time - b.time);
     });
   });
@@ -402,7 +402,7 @@ const buildConvenienceEdges = (
     edges.push(edge);
     const departuresByTrainrun = verticesDepartureByTrainrunByNode.get(nodeId);
     if (departuresByTrainrun !== undefined) {
-      departuresByTrainrun.forEach((departures, trainrunId) => {
+      departuresByTrainrun.forEach((departures) => {
         departures.forEach((departure) => {
           const edge = new Edge(srcVertex, departure, 0);
           edges.push(edge);
@@ -411,7 +411,7 @@ const buildConvenienceEdges = (
     }
     const arrivalsByTrainrun = verticesArrivalByTrainrunByNode.get(nodeId);
     if (arrivalsByTrainrun !== undefined) {
-      arrivalsByTrainrun.forEach((arrivals, trainrunId) => {
+      arrivalsByTrainrun.forEach((arrivals) => {
         arrivals.forEach((arrival) => {
           const edge = new Edge(arrival, tgtVertex, 0);
           edges.push(edge);
@@ -484,7 +484,7 @@ const depthFirstSearch = (
   visited.add(key);
   const neighbors = graph.get(key);
   if (neighbors !== undefined) {
-    neighbors.forEach(([neighbor, weight]) => {
+    neighbors.forEach(([neighbor, _weight]) => {
       if (!visited.has(neighbor)) {
         depthFirstSearch(graph, neighbor, visited, res);
       }

--- a/src/app/view/util/svg.mouse.controller.spec.ts
+++ b/src/app/view/util/svg.mouse.controller.spec.ts
@@ -3,25 +3,25 @@ import {Vec2D} from "../../utils/vec2D";
 import {ViewboxProperties} from "../../services/ui/ui.interaction.service";
 
 class DummySVGMouseControllerObserver implements SVGMouseControllerObserver {
-  onEarlyReturnFromMousemove(event: MouseEvent): boolean {
+  onEarlyReturnFromMousemove(): boolean {
     return true;
   }
 
-  onGraphContainerMouseup(event: MouseEvent, mousePosition: Vec2D, onPaning: boolean) {}
+  onGraphContainerMouseup() {}
 
-  zoomFactorChanged(newZoomFactor: number) {}
+  zoomFactorChanged() {}
 
-  onViewboxChanged(viewboxProperties: ViewboxProperties) {}
+  onViewboxChanged() {}
 
   onStartMultiSelect() {}
 
-  updateMultiSelect(topLeft: Vec2D, bottomRight: Vec2D) {}
+  updateMultiSelect() {}
 
   onEndMultiSelect() {}
 
-  onScaleNetzgrafik(factor: number, scaleCenter: Vec2D) {}
+  onScaleNetzgrafik() {}
 
-  onCtrlKeyChanged(state: boolean) {}
+  onCtrlKeyChanged() {}
 }
 
 describe("general view functions", () => {

--- a/src/app/view/variant/variant-view/variant-history/variant-history.component.spec.ts
+++ b/src/app/view/variant/variant-view/variant-history/variant-history.component.spec.ts
@@ -6,7 +6,7 @@ import {of} from "rxjs";
 import {PreviewService} from "../../../../services/data/preview.service";
 import {SbbDialogModule} from "@sbb-esta/angular/dialog";
 import {NavigationService} from "../../../../services/ui/navigation.service";
-import {VariantControllerBackendService, VariantCreateDto} from "../../../../api/generated";
+import {VariantControllerBackendService} from "../../../../api/generated";
 import {VersionControllerBackendService} from "../../../../api/generated";
 
 describe("VariantHistoryComponent", () => {

--- a/src/app/view/variant/variant-view/variant-history/variant-history.component.ts
+++ b/src/app/view/variant/variant-view/variant-history/variant-history.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnChanges, OnDestroy, SimpleChanges} from "@angular/core";
+import {Component, Input, OnChanges, OnDestroy} from "@angular/core";
 import {DownloadVersionModel, VersionId} from "./model";
 import {VersionControlService} from "../../../../services/data/version-control.service";
 import {
@@ -55,7 +55,7 @@ export class VariantHistoryComponent implements OnChanges, OnDestroy {
     this.destroyed.complete();
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(): void {
     this.versionEntries = this.groupVersionsByReleaseNumber([...this.variant.versions].reverse());
   }
 

--- a/src/app/view/variant/variants-view/variants-view.component.spec.ts
+++ b/src/app/view/variant/variants-view/variants-view.component.spec.ts
@@ -8,7 +8,6 @@ import {
   ProjectControllerBackendService,
   ProjectDto,
   VariantControllerBackendService,
-  VariantCreateDto,
   VersionControllerBackendService,
 } from "../../../api/generated";
 import {of} from "rxjs";
@@ -32,7 +31,7 @@ describe("VariantsViewComponent", () => {
 
   beforeEach(async () => {
     projectControllerBackendService = {
-      getProject: (projectId: number) => {
+      getProject: () => {
         const project: ProjectDto = {
           id: 10,
           name: "",
@@ -57,7 +56,7 @@ describe("VariantsViewComponent", () => {
       }),
     };
     variantControllerBackendService = {
-      createVariant: (projectId: number, variantCreateDto: VariantCreateDto) => of(10 as any),
+      createVariant: () => of(10 as any),
     };
 
     await TestBed.configureTestingModule({

--- a/src/app/view/variant/variants-view/variants-view.component.ts
+++ b/src/app/view/variant/variants-view/variants-view.component.ts
@@ -5,7 +5,6 @@ import {debounceTime, filter, map, mergeMap, startWith, takeUntil} from "rxjs/op
 import {
   ProjectControllerBackendService,
   ProjectDto,
-  ProjectSummaryDto,
   VariantControllerBackendService,
   VariantSummaryDto,
   VersionControllerBackendService,

--- a/src/app/view/variant/variants-view/variants-view.component.ts
+++ b/src/app/view/variant/variants-view/variants-view.component.ts
@@ -214,7 +214,7 @@ export class VariantsViewComponent implements OnDestroy {
         filter((confirmed) => confirmed),
         takeUntil(this.destroyed),
       )
-      .subscribe((project) => {
+      .subscribe(() => {
         this.versionControlService.archiveVariantWithId(variantToEdit.id).subscribe(() => {
           this.projectService
             .getProject(variantToEdit.projectId)
@@ -235,7 +235,7 @@ export class VariantsViewComponent implements OnDestroy {
         filter((confirmed) => confirmed),
         takeUntil(this.destroyed),
       )
-      .subscribe((project) => {
+      .subscribe(() => {
         this.versionControlService.unarchiveVariantWithId(variantToEdit.id).subscribe(() => {
           this.projectService
             .getProject(variantToEdit.projectId)

--- a/src/integration-testing/basedata.service.test.spec.ts
+++ b/src/integration-testing/basedata.service.test.spec.ts
@@ -52,7 +52,7 @@ describe("NodeService Test", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,

--- a/src/integration-testing/label.service.test.spec.ts
+++ b/src/integration-testing/label.service.test.spec.ts
@@ -50,7 +50,7 @@ describe("LabelService Test", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,

--- a/src/integration-testing/labelgroup.service.test.spec.ts
+++ b/src/integration-testing/labelgroup.service.test.spec.ts
@@ -50,7 +50,7 @@ describe("LabelGroupService Test", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,

--- a/src/integration-testing/node.service.test.spec.ts
+++ b/src/integration-testing/node.service.test.spec.ts
@@ -56,7 +56,7 @@ describe("NodeService Test", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,
@@ -115,9 +115,6 @@ describe("NodeService Test", () => {
 
     const betriebspunktName = "TT";
     const fullName = "TTest";
-    const labelIds = labelService
-      .getLabelsFromLabelRef(LabelRef.Node)
-      .map((label) => label.getId());
 
     nodeService.addNodeWithPosition(0, 0, betriebspunktName, fullName);
     expect(nodes.length).toBe(6);
@@ -713,8 +710,6 @@ describe("NodeService Test", () => {
     nodeZUE.getConnections().forEach((connection) => {
       expect(connection.getPortId2()).toBe(9);
       connection.resetWarning();
-      const trainrunSection1 = nodeZUE.getPort(connection.getPortId1()).getTrainrunSection();
-      const trainrunSection2 = nodeZUE.getPort(connection.getPortId2()).getTrainrunSection();
 
       if (connection.getId() === 2) {
         const port = nodeZUE.getPort(connection.getPortId2());

--- a/src/integration-testing/note.service.test.spec.ts
+++ b/src/integration-testing/note.service.test.spec.ts
@@ -51,7 +51,7 @@ describe("NodeService Test", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,
@@ -179,7 +179,6 @@ describe("NodeService Test", () => {
     noteService.unselectAllNotes();
     const newNote = noteService.addNote(new Vec2D(100, 1000), "Fun", "nice");
     noteService.setLabels(newNote.getId(), ["Spass"]);
-    const noteLabels = labelService.getTextLabelsFromIds(newNote.getLabelIds());
     expect(noteService.getNoteFromId(3).getId()).toBe(3);
     filterService.setFilterNoteLabels([0]);
     noteService.deleteAllNonVisibleNotes();

--- a/src/integration-testing/origin.destination.csv.test.spec.ts
+++ b/src/integration-testing/origin.destination.csv.test.spec.ts
@@ -55,7 +55,7 @@ describe("Origin Destination CSV Test", () => {
     );
     baseDataService = new BaseDataService();
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,
@@ -301,10 +301,10 @@ describe("Origin Destination CSV Test", () => {
 
     expect(topoVertices).toHaveSize(4);
     edges.forEach((edge) => {
-      const v1Index = topoVertices.findIndex((value, index, obj) => {
+      const v1Index = topoVertices.findIndex((value) => {
         return value === edge.v1;
       });
-      const v2Index = topoVertices.findIndex((value, index, obj) => {
+      const v2Index = topoVertices.findIndex((value) => {
         return value === edge.v2;
       });
       expect(v1Index).toBeLessThan(v2Index);
@@ -361,10 +361,10 @@ describe("Origin Destination CSV Test", () => {
     const topoVertices = topoSort(neighbors);
     expect(topoVertices).toHaveSize(11);
     edges.forEach((edge) => {
-      const v1Index = topoVertices.findIndex((value, index, obj) => {
+      const v1Index = topoVertices.findIndex((value) => {
         return value === edge.v1;
       });
-      const v2Index = topoVertices.findIndex((value, index, obj) => {
+      const v2Index = topoVertices.findIndex((value) => {
         return value === edge.v2;
       });
       expect(v1Index).toBeLessThan(v2Index);

--- a/src/integration-testing/reconnect.trainrunsections.test.spec.ts
+++ b/src/integration-testing/reconnect.trainrunsections.test.spec.ts
@@ -47,7 +47,7 @@ describe("Reconnect TrainrunSection Test", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,

--- a/src/integration-testing/resource.service.test.spec.ts
+++ b/src/integration-testing/resource.service.test.spec.ts
@@ -50,7 +50,7 @@ describe("ResourceService Test", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,

--- a/src/integration-testing/trainIterator.test.spec.ts
+++ b/src/integration-testing/trainIterator.test.spec.ts
@@ -48,7 +48,7 @@ describe("TrainrunSection Service Test", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,

--- a/src/integration-testing/trainrunsection.service.test.spec.ts
+++ b/src/integration-testing/trainrunsection.service.test.spec.ts
@@ -54,7 +54,7 @@ describe("TrainrunSection Service Test", () => {
       filterService,
     );
     noteService = new NoteService(logService, labelService, filterService);
-    netzgrafikColoringService = new NetzgrafikColoringService(logService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
     dataService = new DataService(
       resourceService,
       nodeService,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "lib": ["es2023", "dom"],
     "resolveJsonModule": true,
     "useDefineForClassFields": false,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "noUnusedParameters": true
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,


### PR DESCRIPTION
Removes unused parameters and imports across the code base to activate `noUnusedParameters` in `tsconfig.json` and `@typescript-eslint/no-unused-vars` in `es-lint.config.js`.

Part of the cleanup was driven by running `noUnusedLocals` too but its final activation is left for a follow-up PR.