### PR TITLE
fix(view): fix selection.on()

### DIFF
--- a/src/app/view/knoten-auslastung-view/knoten-auslastung-view.component.ts
+++ b/src/app/view/knoten-auslastung-view/knoten-auslastung-view.component.ts
@@ -194,7 +194,7 @@ export class KnotenAuslastungViewComponent implements AfterViewInit, OnDestroy {
           ),
       )
       .attr("d", arc)
-      .on("mousedown", (d) =>
+      .on("mousedown", (_, d) =>
         this.trainrunService.setTrainrunAsSelected(d.trainrunSection.getTrainrunId()),
       )
       .append("title")
@@ -242,7 +242,7 @@ export class KnotenAuslastungViewComponent implements AfterViewInit, OnDestroy {
       .attr("x", 0)
       .attr("y", 0)
       .attr("text-anchor", "middle")
-      .on("mousedown", (d) =>
+      .on("mousedown", (_, d) =>
         this.trainrunService.setTrainrunAsSelected(d.trainrunSection.getTrainrunId()),
       )
       .append("title")


### PR DESCRIPTION
Fixes event handlers in the `KnotenAuslastungViewComponent` to match the expected parameters for d3 event callbacks : d3 `selection.on()` calls its listener as `(event, d)`. 