### PR TITLE
fix: persist scaled graph positions

### DIFF
--- a/src/app/services/util/position.transformation.service.spec.ts
+++ b/src/app/services/util/position.transformation.service.spec.ts
@@ -17,7 +17,6 @@ import {LoadPerlenketteService} from "../../perlenkette/service/load-perlenkette
 import {NetzgrafikUnitTesting} from "../../../integration-testing/netzgrafik.unit.testing";
 import {ViewportCullService} from "../../services/ui/viewport.cull.service";
 import {PositionTransformationService} from "./position.transformation.service";
-import {Operation} from "../../models/operation.model";
 import {Vec2D} from "../../utils/vec2D";
 
 describe("PositionTransformationService", () => {
@@ -169,32 +168,5 @@ describe("PositionTransformationService", () => {
       expect(n.getPositionX()).toBe(pos[index].getX() * 2.0);
       expect(n.getPositionY()).toBe(pos[index].getY() * 2.0);
     });
-  });
-
-  it("emits update operations when scaling the full graph", () => {
-    dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
-    const operations: Operation[] = [];
-    positionTransformationService.operation.subscribe((operation) => operations.push(operation));
-
-    positionTransformationService.scaleNetzgrafikArea(2.0, new Vec2D(0.0, 0.0), "graphContainer");
-
-    const nodeUpdates = operations.filter(
-      (operation) => operation.objectType === "node" && operation.type === "update",
-    );
-    expect(nodeUpdates.length).toBe(nodeService.getNodes().length);
-  });
-
-  it("emits update operations for scaled selected nodes", () => {
-    dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
-    nodeService.getNodes().slice(0, 2).forEach((node) => nodeService.selectNode(node.getId()));
-    const operations: Operation[] = [];
-    positionTransformationService.operation.subscribe((operation) => operations.push(operation));
-
-    positionTransformationService.scaleNetzgrafikArea(2.0, new Vec2D(0.0, 0.0), "graphContainer");
-
-    const nodeUpdates = operations.filter(
-      (operation) => operation.objectType === "node" && operation.type === "update",
-    );
-    expect(nodeUpdates.length).toBe(2);
   });
 });

--- a/src/app/services/util/position.transformation.service.spec.ts
+++ b/src/app/services/util/position.transformation.service.spec.ts
@@ -17,6 +17,7 @@ import {LoadPerlenketteService} from "../../perlenkette/service/load-perlenkette
 import {NetzgrafikUnitTesting} from "../../../integration-testing/netzgrafik.unit.testing";
 import {ViewportCullService} from "../../services/ui/viewport.cull.service";
 import {PositionTransformationService} from "./position.transformation.service";
+import {Operation} from "../../models/operation.model";
 import {Vec2D} from "../../utils/vec2D";
 
 describe("PositionTransformationService", () => {
@@ -168,5 +169,32 @@ describe("PositionTransformationService", () => {
       expect(n.getPositionX()).toBe(pos[index].getX() * 2.0);
       expect(n.getPositionY()).toBe(pos[index].getY() * 2.0);
     });
+  });
+
+  it("emits update operations when scaling the full graph", () => {
+    dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
+    const operations: Operation[] = [];
+    positionTransformationService.operation.subscribe((operation) => operations.push(operation));
+
+    positionTransformationService.scaleNetzgrafikArea(2.0, new Vec2D(0.0, 0.0), "graphContainer");
+
+    const nodeUpdates = operations.filter(
+      (operation) => operation.objectType === "node" && operation.type === "update",
+    );
+    expect(nodeUpdates.length).toBe(nodeService.getNodes().length);
+  });
+
+  it("emits update operations for scaled selected nodes", () => {
+    dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
+    nodeService.getNodes().slice(0, 2).forEach((node) => nodeService.selectNode(node.getId()));
+    const operations: Operation[] = [];
+    positionTransformationService.operation.subscribe((operation) => operations.push(operation));
+
+    positionTransformationService.scaleNetzgrafikArea(2.0, new Vec2D(0.0, 0.0), "graphContainer");
+
+    const nodeUpdates = operations.filter(
+      (operation) => operation.objectType === "node" && operation.type === "update",
+    );
+    expect(nodeUpdates.length).toBe(2);
   });
 });

--- a/src/app/services/util/position.transformation.service.ts
+++ b/src/app/services/util/position.transformation.service.ts
@@ -6,7 +6,7 @@ import {NoteService} from "../data/note.service";
 import {Vec2D} from "../../utils/vec2D";
 import {Node} from "../../models/node.model";
 import {ViewportCullService} from "../ui/viewport.cull.service";
-import {NodeOperation, Operation, OperationType} from "src/app/models/operation.model";
+import {NodeOperation, NoteOperation, Operation, OperationType} from "src/app/models/operation.model";
 import {Note} from "../../models/note.model";
 
 @Injectable({
@@ -47,6 +47,7 @@ export class PositionTransformationService {
         newPos = Vec2D.sub(newPos, delta);
       }
       n.setPosition(newPos.getX(), newPos.getY());
+      this.operation.emit(new NodeOperation(OperationType.update, n));
     });
 
     this.noteService.getNotes().forEach((n) => {
@@ -63,6 +64,7 @@ export class PositionTransformationService {
         newPos = Vec2D.sub(newPos, delta);
       }
       n.setPosition(newPos.getX(), newPos.getY());
+      this.operation.emit(new NoteOperation(OperationType.update, n));
     });
   }
 
@@ -145,6 +147,7 @@ export class PositionTransformationService {
       }
 
       n.setPosition(newPos.getX(), newPos.getY());
+      this.operation.emit(new NodeOperation(OperationType.update, n));
     });
 
     notes.forEach((n) => {
@@ -157,6 +160,7 @@ export class PositionTransformationService {
           n.getHeight() / 2.0,
       );
       n.setPosition(newPos.getX(), newPos.getY());
+      this.operation.emit(new NoteOperation(OperationType.update, n));
     });
   }
 


### PR DESCRIPTION
## Summary

The Ctrl+mousewheel scaling path updates node and note models in memory, but it does not emit the update operations that the host uses to persist edits. After a refresh, scaled positions therefore return to their previous values.

This patch emits the same `update` operations used by the alignment actions for every node and note changed by both full-graph and selected-element scaling. The added specs cover full-graph and multi-selected-node scaling.

## Validation

- `npx ng test -c ci --watch=false --include='src/app/services/util/position.transformation.service.spec.ts'`
- `npx tsc --noEmit --project tsconfig.spec.json`
- `git diff --check`

The focused Angular run passed all 6 specs in ChromeHeadless.

Related to OpenRailAssociation/osrd#18002