### PR TITLE
chore(docker): bump ngssc to v22.0.2 to address CVE-2026-27143

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm run build
 
 FROM ghcr.io/nginxinc/nginx-unprivileged:1.27.4-alpine-slim
 
-ADD --chmod=755 https://github.com/kyubisation/angular-server-side-configuration/releases/download/v17.0.2/ngssc_64bit /usr/sbin/ngssc
+ADD --chmod=755 https://github.com/kyubisation/angular-server-side-configuration/releases/download/v22.0.2/ngssc_64bit /usr/sbin/ngssc
 
 # Add ngssc script
 ADD --chmod=755 docker/99-ngssc.sh /docker-entrypoint.d/


### PR DESCRIPTION
## Summary

Bumps the `ngssc_64bit` binary downloaded in the `Dockerfile` from `v17.0.2` to `v22.0.2` to address **CVE-2026-27143** (Go compiler induction integer overflow leading to omitted bounds checks in `cmd/compile`).

## Why

The container image is flagged by an internal vulnerability scan because the embedded `ngssc` binary (built at `v17.0.2`) was compiled with Golang `1.17.13`, which is affected by CVE-2026-27143 (fixed in Go 1.25.9 / 1.26.2).

Upstream `angular-server-side-configuration` [v21.0.4 release notes](https://github.com/kyubisation/angular-server-side-configuration/releases/tag/v21.0.4) confirm the rebuild specifically to satisfy security scanners for this CVE. `v22.0.2` is the current latest release.

## Notes

- The `ngssc` runtime binary only injects environment variables into `index.html` at container start-up, so it is decoupled from the Angular / npm package version used at build time. No app-code changes required.
- Runtime nginx image (`nginx-unprivileged:1.27.4-alpine-slim`) untouched.

## References

- CVE: https://nvd.nist.gov/vuln/detail/CVE-2026-27143
- Upstream fix: https://github.com/kyubisation/angular-server-side-configuration/releases/tag/v21.0.4
- Go patch: https://go-review.googlesource.com/c/go/+/763546