### PR TITLE
fix: version mismatch - update ngssc binary from v17.0.2 to v19.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm run build
 
 FROM ghcr.io/nginxinc/nginx-unprivileged:1.27.4-alpine-slim
 
-ADD --chmod=755 https://github.com/kyubisation/angular-server-side-configuration/releases/download/v17.0.2/ngssc_64bit /usr/sbin/ngssc
+ADD --chmod=755 https://github.com/kyubisation/angular-server-side-configuration/releases/download/v19.0.1/ngssc_64bit /usr/sbin/ngssc
 
 # Add ngssc script
 ADD --chmod=755 docker/99-ngssc.sh /docker-entrypoint.d/


### PR DESCRIPTION
Closes #1252

The `ngssc` binary downloaded in the `Dockerfile` was pinned at v17.0.2,
while the npm package `angular-server-side-configuration` was already at
^19.0.1 (matching Angular 19). The outdated binary was compiled with a Go
runtime version containing known vulnerabilities flagged by Dependabot.

**Root cause:** The binary version was not bumped when the npm package was
upgraded from v17 to v19.

**Fix:** Align the `ngssc` binary version with the npm package:

| Component | Before | After |
|---|---|---|
| `angular-server-side-configuration` (npm) | ^19.0.1 | ^19.0.1 (unchanged) |
| `ngssc` binary (Dockerfile) | v17.0.2 | v19.0.1 |