### PR TITLE
ci: add Docker build check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,16 @@ jobs:
           name: build-standalone-demo
           path: dist/
 
+  build-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Build
+        uses: docker/build-push-action@v7
+        with:
+          push: false
+
   deploy-github-pages:
     if: github.event_name == 'push'
     needs: build-standalonedemo


### PR DESCRIPTION
Check that the Docker image builds correctly when merging a pull request.

Previously, the Dockerfile was only checked when publishing a release. This patch ensures that we don't hit a build failure when performing a release.