### PR TITLE
fix: emit updates when scaling nodes

### DIFF
--- a/src/app/services/util/position.transformation.service.spec.ts
+++ b/src/app/services/util/position.transformation.service.spec.ts
@@ -18,6 +18,7 @@ import {NetzgrafikUnitTesting} from "../../../integration-testing/netzgrafik.uni
 import {ViewportCullService} from "../../services/ui/viewport.cull.service";
 import {PositionTransformationService} from "./position.transformation.service";
 import {Vec2D} from "../../utils/vec2D";
+import {Operation} from "../../models/operation.model";
 
 describe("PositionTransformationService", () => {
   let dataService: DataService;
@@ -158,6 +159,8 @@ describe("PositionTransformationService", () => {
 
   it("PositionTransformationService test-003", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
+    const operations: Operation[] = [];
+    positionTransformationService.operation.subscribe((operation) => operations.push(operation));
     const pos: Vec2D[] = [];
     nodeService.getNodes().forEach((n) => {
       pos.push(new Vec2D(n.getPositionX(), n.getPositionY()));
@@ -167,6 +170,35 @@ describe("PositionTransformationService", () => {
     nodeService.getNodes().forEach((n: Node, index: number) => {
       expect(n.getPositionX()).toBe(pos[index].getX() * 2.0);
       expect(n.getPositionY()).toBe(pos[index].getY() * 2.0);
+    });
+    expect(operations.filter((operation) => operation.objectType === "node").length).toBe(
+      nodeService.getNodes().length,
+    );
+    expect(operations.filter((operation) => operation.objectType === "note").length).toBe(
+      noteService.getNotes().length,
+    );
+  });
+
+  it("emits updates for each node scaled in a multiple selection", () => {
+    dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
+    const selectedNodes = nodeService.getNodes().slice(0, 2);
+    const initialPositions = new Map(
+      selectedNodes.map((node) => [node.getId(), [node.getPositionX(), node.getPositionY()]]),
+    );
+    selectedNodes.forEach((node) => nodeService.selectNode(node.getId()));
+    const operations: Operation[] = [];
+    positionTransformationService.operation.subscribe((operation) => operations.push(operation));
+
+    positionTransformationService.scaleNetzgrafikArea(2.0, new Vec2D(0.0, 0.0), "graphContainer");
+
+    const nodeOperations = operations.filter((operation) => operation.objectType === "node");
+    expect(nodeOperations.map((operation) => operation.node.id)).toEqual(
+      selectedNodes.map((node) => node.getId()),
+    );
+    nodeOperations.forEach((operation) => {
+      expect([operation.node.positionX, operation.node.positionY]).not.toEqual(
+        initialPositions.get(operation.node.id),
+      );
     });
   });
 });

--- a/src/app/services/util/position.transformation.service.ts
+++ b/src/app/services/util/position.transformation.service.ts
@@ -6,7 +6,12 @@ import {NoteService} from "../data/note.service";
 import {Vec2D} from "../../utils/vec2D";
 import {Node} from "../../models/node.model";
 import {ViewportCullService} from "../ui/viewport.cull.service";
-import {NodeOperation, Operation, OperationType} from "src/app/models/operation.model";
+import {
+  NodeOperation,
+  NoteOperation,
+  Operation,
+  OperationType,
+} from "src/app/models/operation.model";
 import {Note} from "../../models/note.model";
 
 @Injectable({
@@ -174,11 +179,14 @@ export class PositionTransformationService {
   }
 
   scaleNetzgrafikArea(factor: number, zoomCenter: Vec2D, windowViewboxPropertiesMapKey: string) {
-    const nodes: Node[] = this.nodeService.getSelectedNodes();
+    let nodes: Node[] = this.nodeService.getSelectedNodes();
+    let notes: Note[];
     if (nodes.length < 2) {
+      nodes = this.nodeService.getNodes();
+      notes = this.noteService.getNotes();
       this.scaleFullNetzgrafikArea(factor, zoomCenter, windowViewboxPropertiesMapKey);
     } else {
-      let notes: Note[] = this.noteService.getSelectedNotes();
+      notes = this.noteService.getSelectedNotes();
       if (notes.length === 0) {
         notes = this.noteService.getNotes();
       }
@@ -191,6 +199,9 @@ export class PositionTransformationService {
         windowViewboxPropertiesMapKey,
       );
     }
+
+    nodes.forEach((node) => this.operation.emit(new NodeOperation(OperationType.update, node)));
+    notes.forEach((note) => this.operation.emit(new NoteOperation(OperationType.update, note)));
 
     this.updateRendering();
   }


### PR DESCRIPTION
# Description

Emit update operations for each node and note moved by `scaleNetzgrafikArea()`, after the scaling calculation completes.

The service previously changed positions only in memory. Standalone consumers such as OSRD persist changes from the operation stream, so positions changed with Ctrl + Mousewheel reverted after reloading the page.

This also adds unit coverage for both full-graph scaling and scaling a multiple selection.

# Issues

Closes OpenRailAssociation/osrd#18002.

# Checklist

- [x] This PR contains a description of the changes I'm making
- [x] I've read the Contribution Guidelines
- [x] I've added tests for changes or features I've introduced
- [x] No new high-level concepts require documentation
- [ ] CI is green and this is ready for review

# Local validation

- `npm test -- --include=src/app/services/util/position.transformation.service.spec.ts`
- `npm run lint`
- `npm run build:standalone`
- `git diff --check`
- OSRD frontend production build using a local package tarball
- OSRD's existing Netzgrafik Chromium end-to-end test
- Dedicated OSRD Chromium test: create three nodes, select them with a right-drag rectangle, scale with Ctrl + Mousewheel, verify three successful persistence updates, reload, and confirm the scaled spacing is retained
