### PR TITLE
feat: adds the orthogonal section shape

### DIFF
--- a/src/app/models/trainrunsection.model.ts
+++ b/src/app/models/trainrunsection.model.ts
@@ -4,6 +4,7 @@ import {Node} from "./node.model";
 import {Trainrun} from "./trainrun.model";
 import {Vec2D} from "../utils/vec2D";
 import {SimpleTrainrunSectionRouter} from "../services/util/trainrunsection.routing";
+import {getModelSectionPath} from "../services/util/section-shape";
 import {
   ColorRefType,
   PathDto,
@@ -751,12 +752,7 @@ export class TrainrunSection {
   }
 
   routeEdgeAndPlaceText() {
-    this.pathVec2D = SimpleTrainrunSectionRouter.routeTrainrunSection(
-      this.sourceNode,
-      this.sourceNode.getPort(this.sourcePortId),
-      this.targetNode,
-      this.targetNode.getPort(this.targetPortId),
-    );
+    this.pathVec2D = getModelSectionPath(this);
 
     this.path.textPositions = SimpleTrainrunSectionRouter.placeTextOnTrainrunSection(
       this.pathVec2D,

--- a/src/app/services/ui/ui.interaction.service.ts
+++ b/src/app/services/ui/ui.interaction.service.ts
@@ -31,6 +31,7 @@ import {LoadPerlenketteService} from "../../perlenkette/service/load-perlenkette
 import {TravelTimeCreationEstimatorType} from "../../view/themes/editor-trainrun-traveltime-creator-type";
 import {OrderingAlgorithm} from "../../data-structures/technical.data.structures";
 import {TrafficSide} from "src/app/data-structures/business.data.structures";
+import {DEFAULT_SECTION_SHAPE, SectionRenderingStyle} from "../util/section-shape";
 import {DataService} from "../data/data.service";
 import {Operation, MetadataOperation} from "../../models/operation.model";
 import {EditorView} from "src/app/view/editor-main-view/data-views/editor.view";
@@ -112,6 +113,7 @@ export class UiInteractionService implements OnDestroy {
   private activeTheme: ThemeBase = null;
   private activeStreckengrafikRenderingType: StreckengrafikRenderingType = null;
   private activeTravelTimeCreationEstimatorType: TravelTimeCreationEstimatorType = null;
+  private activeSectionRenderingStyle: SectionRenderingStyle = DEFAULT_SECTION_SHAPE;
   private editorMode: EditorMode = EditorMode.NetzgrafikEditing;
   private isMultiSelectedNodesCorridor = false;
 
@@ -299,6 +301,16 @@ export class UiInteractionService implements OnDestroy {
     }
     this.activeTravelTimeCreationEstimatorType = activeTravelTimeCreationEstimatorType;
     this.saveUserSettingToLocalStorage();
+  }
+
+  getActiveSectionRenderingStyle(): SectionRenderingStyle {
+    return this.activeSectionRenderingStyle;
+  }
+
+  setActiveSectionRenderingStyle(sectionRenderingStyle: SectionRenderingStyle) {
+    this.activeSectionRenderingStyle = sectionRenderingStyle;
+    this.saveUserSettingToLocalStorage();
+    this.trainrunSectionService.trainrunSectionsUpdated();
   }
 
   getActiveTrafficSideType(): TrafficSide {
@@ -533,6 +545,9 @@ export class UiInteractionService implements OnDestroy {
         return;
       }
       const localStoredInfo = JSON.parse(serializedState);
+      this.setActiveSectionRenderingStyle(
+        localStoredInfo.sectionRenderingStyle ?? DEFAULT_SECTION_SHAPE,
+      );
       const activeTheme = localStoredInfo.activeTheme;
       this.createTheme(
         activeTheme.themeRegistration,
@@ -556,6 +571,7 @@ export class UiInteractionService implements OnDestroy {
           activeTheme: this.getActiveTheme(),
           streckengrafikRenderingType: this.getActiveStreckengrafikRenderingType(),
           travelTimeCreationEstimatorType: this.getActiveTravelTimeCreationEstimatorType(),
+          sectionRenderingStyle: this.getActiveSectionRenderingStyle(),
         }),
       );
     } catch (err) {

--- a/src/app/services/util/orthogonal/corners.ts
+++ b/src/app/services/util/orthogonal/corners.ts
@@ -1,0 +1,171 @@
+import {Vec2D} from "../../../utils/vec2D";
+import {MathUtils} from "../../../utils/math";
+import {PortAlignment} from "../../../data-structures/technical.data.structures";
+import {TrainrunSection} from "../../../models/trainrunsection.model";
+import {Node} from "../../../models/node.model";
+import {Port} from "../../../models/port.model";
+import {
+  TRAINRUN_SECTION_PORT_SPAN_HORIZONTAL,
+  TRAINRUN_SECTION_PORT_SPAN_VERTICAL,
+} from "../../../view/rastering/definitions";
+
+const isHorizontal = (port: Port): boolean =>
+  port.getPositionAlignment() === PortAlignment.Left ||
+  port.getPositionAlignment() === PortAlignment.Right;
+
+interface CornerContext {
+  horizontal: boolean;
+  srcNode: Node;
+  srcPort: Port;
+  trgNode: Node;
+  trgPort: Port;
+  srcAlignment: PortAlignment;
+  outwardAlignment: PortAlignment;
+  sM: number;
+  sC: number;
+  tM: number;
+  tC: number;
+  vec: (m: number, c: number) => Vec2D;
+}
+
+/**
+ * Returns the ports on the same side of `node` as `port`, from sections
+ * between `node` and `sibling`, ordered by position.
+ */
+function getSiblingPorts(node: Node, port: Port, sibling: Node): Port[] {
+  return node
+    .getPorts()
+    .filter(
+      (p) =>
+        p.getPositionAlignment() === port.getPositionAlignment() &&
+        (p.getTrainrunSection().getSourceNodeId() === sibling.getId() ||
+          p.getTrainrunSection().getTargetNodeId() === sibling.getId()),
+    )
+    .sort((a, b) => a.getPositionIndex() - b.getPositionIndex());
+}
+
+/**
+ * Returns this section's offset among its siblings, centered around 0, so
+ * their middle segments do not overlap.
+ */
+function getCenteredSiblingOffset(node: Node, port: Port, sibling: Node, span: number): number {
+  const siblings = getSiblingPorts(node, port, sibling);
+  const index = siblings.indexOf(port);
+
+  return (index - (siblings.length - 1) / 2) * span;
+}
+
+/**
+ * Returns this section's offset among its siblings, counted from the first
+ * one, so each is pushed further out than the previous.
+ */
+function getSiblingOffsetFromStart(node: Node, port: Port, sibling: Node, span: number): number {
+  return getSiblingPorts(node, port, sibling).indexOf(port) * span;
+}
+
+/**
+ * Computes the two corners for facing ports (Z-shape), with a shifted middle
+ * segment.
+ */
+function getFacingCorners(ctx: CornerContext): Vec2D[] {
+  const {
+    horizontal,
+    srcNode,
+    srcPort,
+    trgNode,
+    trgPort,
+    srcAlignment,
+    outwardAlignment,
+    sM,
+    sC,
+    tM,
+    tC,
+    vec,
+  } = ctx;
+  const refIsSource = srcAlignment === outwardAlignment;
+  const span = horizontal
+    ? TRAINRUN_SECTION_PORT_SPAN_VERTICAL
+    : TRAINRUN_SECTION_PORT_SPAN_HORIZONTAL;
+  const offset = refIsSource
+    ? getCenteredSiblingOffset(srcNode, srcPort, trgNode, span)
+    : getCenteredSiblingOffset(trgNode, trgPort, srcNode, span);
+
+  // shift in the direction the sections spread, so their segments never cross
+  const nodeSC = horizontal ? srcNode.getPositionY() : srcNode.getPositionX();
+  const nodeTC = horizontal ? trgNode.getPositionY() : trgNode.getPositionX();
+  const sign = (refIsSource ? nodeTC - nodeSC : nodeSC - nodeTC) < 0 ? 1 : -1;
+
+  // keep the segment between the nodes, even when they are very close
+  const segmentM = MathUtils.clamp((sM + tM) / 2 + sign * offset, sM, tM);
+
+  return [vec(segmentM, sC), vec(segmentM, tC)];
+}
+
+/**
+ * Computes the two corners for same-side ports (U-shape), pushing each section
+ * further out so they do not overlap. Only happens when port sides come from
+ * imported data and were never recomputed.
+ */
+function getSameSideCorners(ctx: CornerContext, s1: Vec2D, t1: Vec2D): Vec2D[] {
+  const {horizontal, srcNode, srcPort, trgNode, srcAlignment, outwardAlignment, sC, tC, vec} = ctx;
+  const exitM = (p: Vec2D) => (horizontal ? p.getX() : p.getY());
+  const span = horizontal
+    ? TRAINRUN_SECTION_PORT_SPAN_VERTICAL
+    : TRAINRUN_SECTION_PORT_SPAN_HORIZONTAL;
+  const dir = srcAlignment === outwardAlignment ? 1 : -1;
+  const offset = getSiblingOffsetFromStart(srcNode, srcPort, trgNode, span);
+  const segmentM =
+    (srcAlignment === outwardAlignment
+      ? Math.max(exitM(s1), exitM(t1))
+      : Math.min(exitM(s1), exitM(t1))) +
+    dir * offset;
+
+  return [vec(segmentM, sC), vec(segmentM, tC)];
+}
+
+/**
+ * Returns the corners of the orthogonal path, or undefined when ports are
+ * missing.
+ */
+export function getOrthogonalCorners(ts: TrainrunSection, modelPath: Vec2D[]): Vec2D[] | undefined {
+  const srcNode = ts.getSourceNode();
+  const trgNode = ts.getTargetNode();
+  const srcPort = srcNode.getPortOfTrainrunSection(ts.getId());
+  const trgPort = trgNode.getPortOfTrainrunSection(ts.getId());
+
+  if (!srcPort || !trgPort || modelPath.length < 4) return undefined;
+
+  const [s, s1, t1, t] = modelPath;
+  const srcAlignment = srcPort.getPositionAlignment();
+  const trgAlignment = trgPort.getPositionAlignment();
+  const horizontal = isHorizontal(srcPort);
+
+  if (horizontal !== isHorizontal(trgPort)) {
+    // perpendicular ports: one corner (L-shape)
+    return [horizontal ? new Vec2D(t.getX(), s.getY()) : new Vec2D(s.getX(), t.getY())];
+  }
+
+  // m: coordinate along the ports axis, c: the other coordinate
+  const vec = (m: number, c: number) => (horizontal ? new Vec2D(m, c) : new Vec2D(c, m));
+  const [sM, sC] = horizontal ? [s.getX(), s.getY()] : [s.getY(), s.getX()];
+  const [tM, tC] = horizontal ? [t.getX(), t.getY()] : [t.getY(), t.getX()];
+
+  if (sC === tC) return [];
+
+  const ctx: CornerContext = {
+    horizontal,
+    srcNode,
+    srcPort,
+    trgNode,
+    trgPort,
+    srcAlignment,
+    outwardAlignment: horizontal ? PortAlignment.Right : PortAlignment.Bottom,
+    sM,
+    sC,
+    tM,
+    tC,
+    vec,
+  };
+
+  return srcAlignment !== trgAlignment ? getFacingCorners(ctx) : getSameSideCorners(ctx, s1, t1);
+}

--- a/src/app/services/util/orthogonal/points.ts
+++ b/src/app/services/util/orthogonal/points.ts
@@ -1,0 +1,216 @@
+import {Vec2D} from "../../../utils/vec2D";
+import {MathUtils} from "../../../utils/math";
+import {
+  TrainrunSectionText,
+  TrainrunSectionTextPositions,
+} from "../../../data-structures/technical.data.structures";
+import {SimpleTrainrunSectionRouter} from "../trainrunsection.routing";
+import {TrainrunSection} from "../../../models/trainrunsection.model";
+import {TRANSITION_LINE_AREA_SPAN} from "../../../view/rastering/definitions";
+import {ShapeLabel} from "../section-shape";
+import {getOrthogonalCorners} from "./corners";
+
+// minimum distance from a label to the nodes
+const LABEL_NODE_CLEARANCE = 96;
+// minimum distance from a label to the corners
+const LABEL_CORNER_CLEARANCE = TRANSITION_LINE_AREA_SPAN;
+// segments shorter than this cannot fit a label
+const LABEL_MIN_SEGMENT_LENGTH = 96;
+
+interface Segment {
+  a: Vec2D;
+  b: Vec2D;
+  length: number;
+  unit: Vec2D;
+  anchor?: Vec2D;
+}
+
+const anchorOf = (segment: Segment): Vec2D =>
+  segment.anchor !== undefined ? segment.anchor : Vec2D.scale(Vec2D.add(segment.a, segment.b), 0.5);
+
+/**
+ * Collapses the path corners into segments: removes consecutive duplicate
+ * points, then drops points where the path doesn't actually turn. Returns
+ * undefined when fewer than two points remain.
+ */
+function buildSegments(s: Vec2D, corners: Vec2D[], t: Vec2D): Segment[] | undefined {
+  const deduped = Vec2D.dedupe([s, ...corners, t]);
+  const points = deduped.filter(
+    (p, i) =>
+      i === 0 ||
+      i === deduped.length - 1 ||
+      !Vec2D.areOnSameAxis(deduped[i - 1], p, deduped[i + 1]),
+  );
+  if (points.length < 2) return undefined;
+
+  return points.slice(1).map((b, i) => {
+    const a = points[i];
+    return {a, b, length: Vec2D.norm(Vec2D.sub(b, a)), unit: Vec2D.normalize(Vec2D.sub(b, a))};
+  });
+}
+
+/**
+ * Finds a spot on the segment close to the section center but away from the
+ * nodes and corners. Returns undefined when the segment is too short, or has
+ * no free spot at all.
+ */
+function findSegmentAnchor(
+  segment: Segment,
+  isFirst: boolean,
+  isLast: boolean,
+  nodes: Vec2D[],
+  center: Vec2D,
+): Vec2D | undefined {
+  if (segment.length < LABEL_MIN_SEGMENT_LENGTH) return undefined;
+
+  let lo = isFirst ? 0 : LABEL_CORNER_CLEARANCE;
+  let hi = segment.length - (isLast ? 0 : LABEL_CORNER_CLEARANCE);
+
+  nodes.forEach((node) => {
+    const rel = Vec2D.sub(node, segment.a);
+    const along = Vec2D.dot(segment.unit, rel);
+    const clearanceSq =
+      LABEL_NODE_CLEARANCE * LABEL_NODE_CLEARANCE -
+      (Vec2D.norm(rel) * Vec2D.norm(rel) - along * along);
+    if (clearanceSq <= 0) {
+      return;
+    }
+    const clearance = Math.sqrt(clearanceSq);
+    if (along <= segment.length / 2) {
+      lo = Math.max(lo, along + clearance);
+    } else {
+      hi = Math.min(hi, along - clearance);
+    }
+  });
+  if (lo > hi) return undefined;
+
+  const toCenter = Vec2D.sub(center, segment.a);
+  const centerM = Vec2D.dot(segment.unit, toCenter);
+  return Vec2D.add(segment.a, Vec2D.scale(segment.unit, MathUtils.clamp(centerM, lo, hi)));
+}
+
+/**
+ * Picks which segments carry the name, the time(s), and the stop count.
+ * Prefers segments with a free anchor, closest to the center first.
+ * Falls back to the two longest segments when none are free.
+ * The name shows left of its anchor and the time(s) right of it.
+ */
+function selectLabelSegments(
+  segments: Segment[],
+  center: Vec2D,
+): {nameSeg: Segment; timeSeg: Segment; stopsSeg: Segment} {
+  const clearSegments = segments
+    .filter((segment): segment is Segment & {anchor: Vec2D} => segment.anchor !== undefined)
+    .sort(
+      (s1, s2) =>
+        Vec2D.norm(Vec2D.sub(s1.anchor, center)) - Vec2D.norm(Vec2D.sub(s2.anchor, center)),
+    );
+  const byLength = [...segments].sort((s1, s2) => s2.length - s1.length);
+
+  const order = (seg1: Segment, seg2: Segment): [Segment, Segment] => {
+    const p1 = anchorOf(seg1);
+    const p2 = anchorOf(seg2);
+    const seg1First = p1.getX() !== p2.getX() ? p1.getX() < p2.getX() : p1.getY() > p2.getY();
+    return seg1First ? [seg1, seg2] : [seg2, seg1];
+  };
+
+  let nameSeg: Segment;
+  let timeSeg: Segment;
+
+  if (clearSegments.length >= 2) {
+    [nameSeg, timeSeg] = order(clearSegments[0], clearSegments[1]);
+  } else if (clearSegments.length === 1) {
+    nameSeg = clearSegments[0];
+    timeSeg = nameSeg;
+  } else if (byLength.length >= 2) {
+    [nameSeg, timeSeg] = order(byLength[0], byLength[1]);
+  } else {
+    nameSeg = byLength[0];
+    timeSeg = nameSeg;
+  }
+
+  return {nameSeg, timeSeg, stopsSeg: byLength[0]};
+}
+
+/**
+ * Computes the positions of the middle labels and stops on the orthogonal
+ * path: the name goes on the first free spot, the times on the second one,
+ * and the stops on the longest segment. Returns undefined when ports are
+ * missing.
+ */
+export function getOrthogonalPoints(
+  ts: TrainrunSection,
+  modelPath: Vec2D[],
+):
+  | {
+      labels: Partial<Record<TrainrunSectionText, ShapeLabel>>;
+      stopsSegment: [Vec2D, Vec2D];
+    }
+  | undefined {
+  const corners = getOrthogonalCorners(ts, modelPath);
+  if (corners === undefined) return undefined;
+
+  const [s, , , t] = modelPath;
+  const segments = buildSegments(s, corners, t);
+  if (segments === undefined) return undefined;
+
+  const center = Vec2D.scale(Vec2D.add(s, t), 0.5);
+  segments.forEach((segment, i) => {
+    segment.anchor = findSegmentAnchor(segment, i === 0, i === segments.length - 1, [s, t], center);
+  });
+
+  const {nameSeg, timeSeg, stopsSeg} = selectLabelSegments(segments, center);
+  const srcPort = ts.getSourceNode().getPortOfTrainrunSection(ts.getId());
+
+  // small fake path around the anchor, so the text placement follows the segment
+  const placeAt = (seg: Segment, anchor: Vec2D): TrainrunSectionTextPositions =>
+    SimpleTrainrunSectionRouter.placeTextOnTrainrunSection(
+      [
+        Vec2D.sub(anchor, Vec2D.scale(seg.unit, 2)),
+        Vec2D.sub(anchor, seg.unit),
+        Vec2D.add(anchor, seg.unit),
+        Vec2D.add(anchor, Vec2D.scale(seg.unit, 2)),
+      ],
+      srcPort,
+      seg.a.getX() === seg.b.getX(),
+    );
+  const positionsName = placeAt(nameSeg, anchorOf(nameSeg));
+  const positionsTime = timeSeg === nameSeg ? positionsName : placeAt(timeSeg, anchorOf(timeSeg));
+  const positionsStops = placeAt(stopsSeg, Vec2D.scale(Vec2D.add(stopsSeg.a, stopsSeg.b), 0.5));
+
+  const label = (
+    positions: TrainrunSectionTextPositions,
+    text: TrainrunSectionText,
+    seg: Segment,
+  ): ShapeLabel => ({
+    x: positions[text].x,
+    y: positions[text].y,
+    segment: [seg.a, seg.b],
+  });
+
+  return {
+    labels: {
+      [TrainrunSectionText.TrainrunSectionName]: label(
+        positionsName,
+        TrainrunSectionText.TrainrunSectionName,
+        nameSeg,
+      ),
+      [TrainrunSectionText.TrainrunSectionTravelTime]: label(
+        positionsTime,
+        TrainrunSectionText.TrainrunSectionTravelTime,
+        timeSeg,
+      ),
+      [TrainrunSectionText.TrainrunSectionBackwardTravelTime]: label(
+        positionsTime,
+        TrainrunSectionText.TrainrunSectionBackwardTravelTime,
+        timeSeg,
+      ),
+      [TrainrunSectionText.TrainrunSectionNumberOfStops]: label(
+        positionsStops,
+        TrainrunSectionText.TrainrunSectionNumberOfStops,
+        stopsSeg,
+      ),
+    },
+    stopsSegment: [stopsSeg.a, stopsSeg.b],
+  };
+}

--- a/src/app/services/util/section-shape.oblique.ts
+++ b/src/app/services/util/section-shape.oblique.ts
@@ -1,0 +1,67 @@
+import {Vec2D} from "../../utils/vec2D";
+import {TrainrunSectionText} from "../../data-structures/technical.data.structures";
+import {TrainrunSection} from "../../models/trainrunsection.model";
+import {SimpleTrainrunSectionRouter} from "./trainrunsection.routing";
+import {SectionShape, ShapeLabel} from "./section-shape";
+import {buildPathString} from "./svg";
+
+/** The classic route between the two ports: [anchor, exit point, exit point, anchor]. */
+function getPath(ts: TrainrunSection): Vec2D[] {
+  const sourceNode = ts.getSourceNode();
+  const targetNode = ts.getTargetNode();
+  const sourcePort = sourceNode.getPort(ts.getSourcePortId());
+  const targetPort = targetNode.getPort(ts.getTargetPortId());
+  const s = SimpleTrainrunSectionRouter.getPortPositionForTrainrunSectionRouting(
+    sourceNode,
+    sourcePort,
+  );
+  const t = SimpleTrainrunSectionRouter.getPortPositionForTrainrunSectionRouting(
+    targetNode,
+    targetPort,
+  );
+  const s1 = SimpleTrainrunSectionRouter.getSimpleTrainrunSectionFirstPoint(s, sourcePort);
+  const t1 = SimpleTrainrunSectionRouter.getSimpleTrainrunSectionFirstPoint(t, targetPort);
+  return [s, s1, t1, t];
+}
+
+/**
+ * Anchors of all texts and stops on the oblique path: the model's own
+ * cached text positions, rotated along the exit-to-exit segment.
+ */
+function getPoints(ts: TrainrunSection): {
+  labels: Record<TrainrunSectionText, ShapeLabel>;
+  stopsSegment: [Vec2D, Vec2D];
+} {
+  const [, s1, t1] = getPath(ts);
+  const segment: [Vec2D, Vec2D] = [s1, t1];
+  const label = (text: TrainrunSectionText): ShapeLabel => ({
+    x: ts.getTextPositionX(text),
+    y: ts.getTextPositionY(text),
+    segment,
+  });
+  return {
+    labels: {
+      [TrainrunSectionText.SourceArrival]: label(TrainrunSectionText.SourceArrival),
+      [TrainrunSectionText.SourceDeparture]: label(TrainrunSectionText.SourceDeparture),
+      [TrainrunSectionText.TargetArrival]: label(TrainrunSectionText.TargetArrival),
+      [TrainrunSectionText.TargetDeparture]: label(TrainrunSectionText.TargetDeparture),
+      [TrainrunSectionText.TrainrunSectionName]: label(TrainrunSectionText.TrainrunSectionName),
+      [TrainrunSectionText.TrainrunSectionTravelTime]: label(
+        TrainrunSectionText.TrainrunSectionTravelTime,
+      ),
+      [TrainrunSectionText.TrainrunSectionBackwardTravelTime]: label(
+        TrainrunSectionText.TrainrunSectionBackwardTravelTime,
+      ),
+      [TrainrunSectionText.TrainrunSectionNumberOfStops]: label(
+        TrainrunSectionText.TrainrunSectionNumberOfStops,
+      ),
+    },
+    stopsSegment: segment,
+  };
+}
+
+export const ObliqueSectionShape: SectionShape = {
+  getPath,
+  getPoints,
+  getPathAsSVGString: (path: Vec2D[]): string => buildPathString(path, 0),
+};

--- a/src/app/services/util/section-shape.orthogonal.ts
+++ b/src/app/services/util/section-shape.orthogonal.ts
@@ -1,0 +1,43 @@
+import {Vec2D} from "../../utils/vec2D";
+import {TrainrunSectionText} from "../../data-structures/technical.data.structures";
+import {TrainrunSection} from "../../models/trainrunsection.model";
+import {TRANSITION_LINE_AREA_SPAN} from "../../view/rastering/definitions";
+import {SectionShape, ShapeLabel} from "./section-shape";
+import {buildPathString} from "./svg";
+import {ObliqueSectionShape} from "./section-shape.oblique";
+import {getOrthogonalCorners} from "./orthogonal/corners";
+import {getOrthogonalPoints} from "./orthogonal/points";
+
+/**
+ * Falls back to the oblique shape wherever the orthogonal geometry can't be
+ * computed (e.g. missing ports) or doesn't reposition a given text.
+ */
+export const OrthogonalSectionShape: SectionShape = {
+  getPath(ts: TrainrunSection): Vec2D[] {
+    const obliquePath = ObliqueSectionShape.getPath(ts);
+    const corners = getOrthogonalCorners(ts, obliquePath);
+    if (!corners) {
+      return obliquePath;
+    }
+    return [obliquePath[0], ...corners, obliquePath[3]];
+  },
+
+  getPoints(ts: TrainrunSection): {
+    labels: Record<TrainrunSectionText, ShapeLabel>;
+    stopsSegment: [Vec2D, Vec2D];
+  } {
+    const oblique = ObliqueSectionShape.getPoints(ts);
+    const points = getOrthogonalPoints(ts, ObliqueSectionShape.getPath(ts));
+    if (!points) {
+      return oblique;
+    }
+    return {
+      labels: {...oblique.labels, ...points.labels},
+      stopsSegment: points.stopsSegment,
+    };
+  },
+
+  getPathAsSVGString(path: Vec2D[]): string {
+    return buildPathString(path, TRANSITION_LINE_AREA_SPAN);
+  },
+};

--- a/src/app/services/util/section-shape.ts
+++ b/src/app/services/util/section-shape.ts
@@ -1,0 +1,86 @@
+import {Vec2D} from "../../utils/vec2D";
+import {TrainrunSectionText} from "../../data-structures/technical.data.structures";
+import {TrainrunSection} from "../../models/trainrunsection.model";
+import {ObliqueSectionShape} from "./section-shape.oblique";
+
+const SECTION_SHAPES_REGISTRY = {
+  oblique: ObliqueSectionShape,
+} as const;
+
+export type SectionRenderingStyle = keyof typeof SECTION_SHAPES_REGISTRY;
+export const SECTION_SHAPES = Object.keys(SECTION_SHAPES_REGISTRY) as SectionRenderingStyle[];
+export const DEFAULT_SECTION_SHAPE: SectionRenderingStyle = "oblique";
+
+export interface ShapeLabel {
+  x: number;
+  y: number;
+  segment: [Vec2D, Vec2D];
+}
+
+/**
+ * How a section connects its two nodes: its path, texts and stops. Everything
+ * is computed from the current nodes and ports.
+ *
+ *   node A
+ *     o     <- port anchor, getPath(ts)[0]
+ *     │
+ *     │     getPath(ts): Returns the full path drawn from port to port.
+ *     │     getPathAsSVGString(path): Turns it later into the "d" attribute of
+ *     │     the SVG <path> element.
+ *     │
+ *     x---- TrainrunSectionName        <- one entry of getPoints(ts).labels,
+ *     │                                   keyed by TrainrunSectionText,
+ *     x---- TrainrunSectionTravelTime     each a { x, y, segment } anchor
+ *     │
+ *     x---- stopsSegment               <- getPoints(ts).stopsSegment, where
+ *     │                                   the intermediate stops sit
+ *     │
+ *     o     <- port anchor, last point of getPath(ts)
+ *   node B
+ */
+export interface SectionShape {
+  getPath(ts: TrainrunSection): Vec2D[];
+  getPoints(ts: TrainrunSection): {
+    labels: Record<TrainrunSectionText, ShapeLabel>;
+    stopsSegment: [Vec2D, Vec2D];
+  };
+  getPathAsSVGString(path: Vec2D[]): string;
+}
+
+export function getSectionShape(style: SectionRenderingStyle): SectionShape {
+  return SECTION_SHAPES_REGISTRY[style];
+}
+
+/**
+ * The path TrainrunSection.routeEdgeAndPlaceText caches on the model:
+ * always [anchor, exit point, exit point, anchor], whatever the active shape.
+ */
+export function getModelSectionPath(ts: TrainrunSection): Vec2D[] {
+  return ObliqueSectionShape.getPath(ts);
+}
+
+/**
+ * The section path to render. With both nodes visible, this is the full path
+ * of the given shape. When a node is filtered out, only a short piece is drawn
+ * on each visible side: from the port to the exit point of the model path,
+ * whatever the shape.
+ */
+export function getSectionPath(
+  ts: TrainrunSection,
+  shape: SectionShape,
+  sourceVisible: boolean,
+  targetVisible: boolean,
+): Vec2D[] {
+  if (sourceVisible && targetVisible) {
+    return shape.getPath(ts);
+  }
+  const [s, s1, t1, t] = getModelSectionPath(ts);
+  const retPath: Vec2D[] = [];
+  if (sourceVisible) {
+    retPath.push(s, s1);
+  }
+  if (targetVisible) {
+    retPath.push(t1, t);
+  }
+  return retPath;
+}

--- a/src/app/services/util/section-shape.ts
+++ b/src/app/services/util/section-shape.ts
@@ -2,9 +2,11 @@ import {Vec2D} from "../../utils/vec2D";
 import {TrainrunSectionText} from "../../data-structures/technical.data.structures";
 import {TrainrunSection} from "../../models/trainrunsection.model";
 import {ObliqueSectionShape} from "./section-shape.oblique";
+import {OrthogonalSectionShape} from "./section-shape.orthogonal";
 
 const SECTION_SHAPES_REGISTRY = {
   oblique: ObliqueSectionShape,
+  orthogonal: OrthogonalSectionShape,
 } as const;
 
 export type SectionRenderingStyle = keyof typeof SECTION_SHAPES_REGISTRY;

--- a/src/app/services/util/svg.ts
+++ b/src/app/services/util/svg.ts
@@ -1,0 +1,28 @@
+import {Vec2D} from "../../utils/vec2D";
+
+/**
+ * SVG path string through the given points. Corners are cut by a diagonal of
+ * length `cut` (0 for a plain polyline), like transitions within nodes.
+ */
+export function buildPathString(path: Vec2D[], cut: number): string {
+  const points = Vec2D.dedupe(path);
+  if (points.length === 0) {
+    return "";
+  }
+  const coords = (p: Vec2D) => p.getX() + "," + p.getY();
+  let svg = "M" + coords(points[0]);
+  for (let i = 1; i < points.length; i++) {
+    if (cut === 0 || i === points.length - 1) {
+      svg += "L" + coords(points[i]);
+      continue;
+    }
+    const corner = points[i];
+    const inVec = Vec2D.sub(corner, points[i - 1]);
+    const outVec = Vec2D.sub(points[i + 1], corner);
+    const r = Math.min(cut, Vec2D.norm(inVec) / 2, Vec2D.norm(outVec) / 2);
+    const cutStart = Vec2D.sub(corner, Vec2D.scale(Vec2D.normalize(inVec), r));
+    const cutEnd = Vec2D.add(corner, Vec2D.scale(Vec2D.normalize(outVec), r));
+    svg += "L" + coords(cutStart) + "L" + coords(cutEnd);
+  }
+  return svg;
+}

--- a/src/app/services/util/trainrunsection.routing.ts
+++ b/src/app/services/util/trainrunsection.routing.ts
@@ -195,25 +195,6 @@ export class SimpleTrainrunSectionRouter {
     return diff !== 0 ? diff : BEZIER_CONTROL_SAME_ALIGNMENT_DIFFERENCE;
   }
 
-  static routeTrainrunSection(
-    sourceNode: Node,
-    sourcePort: Port,
-    targetNode: Node,
-    targetPort: Port,
-  ): Vec2D[] {
-    const s = SimpleTrainrunSectionRouter.getPortPositionForTrainrunSectionRouting(
-      sourceNode,
-      sourcePort,
-    );
-    const t = SimpleTrainrunSectionRouter.getPortPositionForTrainrunSectionRouting(
-      targetNode,
-      targetPort,
-    );
-    const s1 = SimpleTrainrunSectionRouter.getSimpleTrainrunSectionFirstPoint(s, sourcePort);
-    const t1 = SimpleTrainrunSectionRouter.getSimpleTrainrunSectionFirstPoint(t, targetPort);
-    return [s, s1, t1, t];
-  }
-
   static routeTransition(node: Node, port1: Port, port2: Port): Vec2D[] {
     const s = SimpleTrainrunSectionRouter.getPortPositionForTransitionAndConnectionRouting(
       node,

--- a/src/app/services/util/trainrunsection.routing.ts
+++ b/src/app/services/util/trainrunsection.routing.ts
@@ -286,6 +286,7 @@ export class SimpleTrainrunSectionRouter {
   static placeTextOnTrainrunSection(
     lineWayPoints: Vec2D[],
     sourcePort: Port,
+    verticalOverride?: boolean,
   ): TrainrunSectionTextPositions {
     const s = lineWayPoints[0];
     const s1 = lineWayPoints[1];
@@ -308,7 +309,12 @@ export class SimpleTrainrunSectionRouter {
 
     const invertTrafficSide = SimpleTrainrunSectionRouter.trafficSideType === "leftHand" ? 1 : -1;
 
-    if (SimpleTrainrunSectionRouter.isLineVertical(sourcePort)) {
+    const isVertical =
+      verticalOverride !== undefined
+        ? verticalOverride
+        : SimpleTrainrunSectionRouter.isLineVertical(sourcePort);
+
+    if (isVertical) {
       if (t1.getY() < s1.getY()) {
         deltaSt = Vec2D.normalize(Vec2D.sub(t1, s1));
       }

--- a/src/app/utils/math.ts
+++ b/src/app/utils/math.ts
@@ -12,4 +12,8 @@ export class MathUtils {
   static mod60(value: number): number {
     return ((value % 60) + 60) % 60;
   }
+
+  static clamp(value: number, a: number, b: number): number {
+    return Math.min(Math.max(value, Math.min(a, b)), Math.max(a, b));
+  }
 }

--- a/src/app/utils/vec2D.ts
+++ b/src/app/utils/vec2D.ts
@@ -47,6 +47,10 @@ export class Vec2D {
     return new Vec2D().setData(s * a.getX(), s * a.getY());
   }
 
+  static dot(a: Vec2D, b: Vec2D): number {
+    return a.getX() * b.getX() + a.getY() * b.getY();
+  }
+
   static norm(a: Vec2D): number {
     return Math.sqrt(a.getX() * a.getX() + a.getY() * a.getY());
   }
@@ -67,6 +71,14 @@ export class Vec2D {
       y += p.getY() / points.length;
     });
     return new Vec2D(x, y);
+  }
+
+  /** Returns true when all three points share the same X or the same Y */
+  static areOnSameAxis(a: Vec2D, b: Vec2D, c: Vec2D): boolean {
+    return (
+      (a.getX() === b.getX() && b.getX() === c.getX()) ||
+      (a.getY() === b.getY() && b.getY() === c.getY())
+    );
   }
 
   /** Removes consecutive duplicate points */

--- a/src/app/utils/vec2D.ts
+++ b/src/app/utils/vec2D.ts
@@ -69,6 +69,11 @@ export class Vec2D {
     return new Vec2D(x, y);
   }
 
+  /** Removes consecutive duplicate points */
+  static dedupe(points: Vec2D[]): Vec2D[] {
+    return points.filter((p, i) => i === 0 || !Vec2D.equal(p, points[i - 1]));
+  }
+
   public toString(): string {
     return "(" + this.getX() + "," + this.getY() + ")";
   }

--- a/src/app/view/editor-main-view/data-views/d3.utils.spec.ts
+++ b/src/app/view/editor-main-view/data-views/d3.utils.spec.ts
@@ -18,6 +18,7 @@ import {LoadPerlenketteService} from "../../../perlenkette/service/load-perlenke
 import {EditorMainViewComponent} from "../editor-main-view.component";
 import {EditorView} from "./editor.view";
 import {D3Utils} from "./d3.utils";
+import {buildPathString} from "../../../services/util/svg";
 import {NetzgrafikUnitTesting} from "../../../../integration-testing/netzgrafik.unit.testing";
 import {Vec2D} from "../../../utils/vec2D";
 import {LevelOfDetailService} from "../../../services/ui/level.of.detail.service";
@@ -178,11 +179,9 @@ describe("3d.Utils.tests", () => {
     controller.bindViewToServices();
   });
 
-  it("NotesView.convertText", () => {
+  it("buildPathString", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
-    const txt0 = D3Utils.getPathAsSVGString(
-      trainrunSectionService.getTrainrunSectionFromId(1).getPath(),
-    );
+    const txt0 = buildPathString(trainrunSectionService.getTrainrunSectionFromId(1).getPath(), 0);
     expect(txt0).toBe("M418,48L482,48L670,80L734,80");
   });
 

--- a/src/app/view/editor-main-view/data-views/d3.utils.ts
+++ b/src/app/view/editor-main-view/data-views/d3.utils.ts
@@ -260,16 +260,6 @@ export class D3Utils {
       .classed(StaticDomTags.NODE_HIGHLIGHT, false);
   }
 
-  static getPathAsSVGString(pathVec2D: Vec2D[]) {
-    let sep = "M";
-    let svgPathString = "";
-    pathVec2D.forEach((p) => {
-      svgPathString += sep + p.getX() + "," + p.getY();
-      sep = "L";
-    });
-    return svgPathString;
-  }
-
   static getBezierCurveAsSVGString(pathVec2D: Vec2D[]) {
     const start: Vec2D = pathVec2D[0];
     const controlPointStart: Vec2D = pathVec2D[1];

--- a/src/app/view/editor-main-view/data-views/data.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/data.view.spec.ts
@@ -222,7 +222,7 @@ describe("Editor-DataView", () => {
     const ts = trainrunSectionService.getTrainrunSectionFromId(3);
     const cvo1 = new TrainrunSectionViewObject(editorView, ts);
     expect(cvo1.key).toBe(
-      "#3@1234_false_false_0_39_49_39_49_1_21_39_0_0_141_39_0_180_0_S_20_7/24_4_1_0_S_20_7/24_20_0_round_trip_false_true_false_false_false_false_true_false_false_false_leftHand_false_true_true_true_false_false_true_true_true_false_0_false_2_true_true_true_1_false_true_true_0_false_true_true(130,80)(194,80)(254,80)(318,80)",
+      "#3@1234_false_false_0_39_49_39_49_1_21_39_0_0_141_39_0_180_0_S_20_7/24_4_1_0_S_20_7/24_20_0_round_trip_false_true_false_false_false_false_true_false_false_false_leftHand_oblique_2_5_false_true_true_true_false_false_true_true_true_false_0_false_2_true_true_true_1_false_true_true_0_false_true_true(130,80)(194,80)(254,80)(318,80)",
     );
   });
 

--- a/src/app/view/editor-main-view/data-views/editor.view.ts
+++ b/src/app/view/editor-main-view/data-views/editor.view.ts
@@ -45,6 +45,7 @@ import {
 } from "../../../data-structures/business.data.structures";
 import {TrainrunSectionText} from "../../../data-structures/technical.data.structures";
 import {AutoLayoutService} from "../../../services/util/auto-layout.service";
+import {SectionRenderingStyle} from "../../../services/util/section-shape";
 
 export class EditorView implements SVGMouseControllerObserver {
   static svgName = "graphContainer";
@@ -324,6 +325,10 @@ export class EditorView implements SVGMouseControllerObserver {
 
   getActiveTrafficSideType(): TrafficSide {
     return this.uiInteractionService.getActiveTrafficSideType();
+  }
+
+  getSectionRenderingStyle(): SectionRenderingStyle {
+    return this.uiInteractionService.getActiveSectionRenderingStyle();
   }
 
   bindShowTrainrunOneWayInformation(

--- a/src/app/view/editor-main-view/data-views/trainrunSectionViewObject.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunSectionViewObject.ts
@@ -147,6 +147,12 @@ export class TrainrunSectionViewObject {
       "_" +
       activeTrafficSideType +
       "_" +
+      editorView.getSectionRenderingStyle() +
+      "_" +
+      d.getSourceNode().getPorts().length +
+      "_" +
+      d.getTargetNode().getPorts().length +
+      "_" +
       editorView.isTemporaryDisableFilteringOfItemsInViewEnabled() +
       "_" +
       editorView.isFilterShowNonStopTimeEnabled() +

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -31,6 +31,12 @@ import {InformSelectedTrainrunClick} from "../../../services/data/trainrunsectio
 import {LevelOfDetail} from "../../../services/ui/level.of.detail.service";
 import {LinePatternRefs} from "../../../data-structures/business.data.structures";
 import {TrainrunsectionHelper} from "src/app/services/util/trainrunsection.helper";
+import {
+  DEFAULT_SECTION_SHAPE,
+  getSectionPath,
+  getSectionShape,
+  SectionRenderingStyle,
+} from "../../../services/util/section-shape";
 
 export class TrainrunSectionsView {
   trainrunSectionGroup: d3.Selection<SVGElement, undefined, Element, undefined>;
@@ -40,13 +46,12 @@ export class TrainrunSectionsView {
   static translateAndRotateText(
     trainrunSection: TrainrunSection,
     trainrunSectionText: TrainrunSectionText,
+    style: SectionRenderingStyle = DEFAULT_SECTION_SHAPE,
   ) {
-    const x = trainrunSection.getTextPositionX(trainrunSectionText);
-    const y = trainrunSection.getTextPositionY(trainrunSectionText);
-
-    const pathVec2D: Vec2D[] = trainrunSection.getPath();
-    const s1: Vec2D = pathVec2D[1];
-    const t1: Vec2D = pathVec2D[2];
+    const {labels} = getSectionShape(style).getPoints(trainrunSection);
+    const label = labels[trainrunSectionText];
+    const [s1, t1] = label.segment;
+    const {x, y} = label;
     const diff: Vec2D = Vec2D.sub(t1, s1);
     let a: number = (Math.atan2(diff.getY(), diff.getX()) / Math.PI) * 180.0;
     if (Math.abs(a) > 90) {
@@ -353,6 +358,7 @@ export class TrainrunSectionsView {
   static getAdditionPositioningValue(
     trainrunSection: TrainrunSection,
     textElement: TrainrunSectionText,
+    style: SectionRenderingStyle = DEFAULT_SECTION_SHAPE,
   ) {
     switch (textElement) {
       case TrainrunSectionText.SourceDeparture:
@@ -363,7 +369,7 @@ export class TrainrunSectionsView {
       case TrainrunSectionText.TrainrunSectionTravelTime:
       case TrainrunSectionText.TrainrunSectionBackwardTravelTime:
       case TrainrunSectionText.TrainrunSectionName:
-        return TrainrunSectionsView.translateAndRotateText(trainrunSection, textElement);
+        return TrainrunSectionsView.translateAndRotateText(trainrunSection, textElement, style);
       default:
         return 0;
     }
@@ -1246,6 +1252,7 @@ export class TrainrunSectionsView {
     connectedTrainIds: number[],
     enableEvents = true,
   ) {
+    const shape = getSectionShape(this.editorView.getSectionRenderingStyle());
     const trainrunSectionElements = groupEnter
       .filter((d: TrainrunSectionViewObject) => {
         return !levelFreqFilter.includes(d.trainrunSection.getFrequencyLinePatternRef());
@@ -1266,7 +1273,7 @@ export class TrainrunSectionsView {
         d.trainrunSection.getTrainrun().getId(),
       )
       .attr("d", (d: TrainrunSectionViewObject) =>
-        D3Utils.getPathAsSVGString(this.transformPath(d.trainrunSection)),
+        shape.getPathAsSVGString(this.transformPath(d.trainrunSection)),
       )
       .classed(StaticDomTags.TAG_SELECTED, (d: TrainrunSectionViewObject) =>
         TrainrunSectionsView.isSectionSelected(d.trainrunSection),
@@ -1477,6 +1484,7 @@ export class TrainrunSectionsView {
     enableEvents = true,
     hasWarning = true,
   ) {
+    const style = this.editorView.getSectionRenderingStyle();
     const isDefaultText =
       textElement === TrainrunSectionText.TrainrunSectionName ||
       textElement === TrainrunSectionText.TrainrunSectionTravelTime ||
@@ -1528,7 +1536,7 @@ export class TrainrunSectionsView {
       .attr(
         TrainrunSectionsView.getAdditionPositioningAttr(textElement),
         (d: TrainrunSectionViewObject) =>
-          TrainrunSectionsView.getAdditionPositioningValue(d.trainrunSection, textElement),
+          TrainrunSectionsView.getAdditionPositioningValue(d.trainrunSection, textElement, style),
       )
       .classed(StaticDomTags.TAG_SELECTED, (d: TrainrunSectionViewObject) =>
         TrainrunSectionsView.isSectionSelected(d.trainrunSection),
@@ -1670,6 +1678,7 @@ export class TrainrunSectionsView {
     connectedTrainIds: number[],
     numberOfStops: number,
   ) {
+    const style = this.editorView.getSectionRenderingStyle();
     groupEnter
       .append(StaticDomTags.EDGE_LINE_TEXT_SVG)
       .attr(
@@ -1694,6 +1703,7 @@ export class TrainrunSectionsView {
         TrainrunSectionsView.translateAndRotateText(
           trainrunSection,
           TrainrunSectionText.TrainrunSectionNumberOfStops,
+          style,
         ),
       )
       .text(numberOfStops)
@@ -1715,9 +1725,10 @@ export class TrainrunSectionsView {
     connectedTrainIds: number[],
   ) {
     const numberOfStops = trainrunSection.getNumberOfStops();
-    const path = trainrunSection.getPath();
-    let startPosition = path[1];
-    let lineOrientationVector = Vec2D.sub(path[2], startPosition);
+    const shape = getSectionShape(this.editorView.getSectionRenderingStyle());
+    const {stopsSegment} = shape.getPoints(trainrunSection);
+    let startPosition = stopsSegment[0];
+    let lineOrientationVector = Vec2D.sub(stopsSegment[1], startPosition);
     const maxNumberOfStops = Math.min(
       SHOW_MAX_SINGLE_TRAINRUN_SECTIONS_STOPS,
       Vec2D.norm(lineOrientationVector) / 20,
@@ -2296,16 +2307,8 @@ export class TrainrunSectionsView {
       notFilteringTargetNode = true;
     }
 
-    const path = ts.getPath();
-    let retPath: Vec2D[] = [];
-    if (notFilteringSourceNode) {
-      retPath.push(path[0].copy());
-      retPath.push(path[1].copy());
-    }
-    if (notFilteringTargetNode) {
-      retPath.push(path[2].copy());
-      retPath.push(path[3].copy());
-    }
+    const shape = getSectionShape(this.editorView.getSectionRenderingStyle());
+    let retPath = getSectionPath(ts, shape, notFilteringSourceNode, notFilteringTargetNode);
 
     if (!this.editorView.isTemporaryDisableFilteringOfItemsInViewEnabled()) {
       if (ts.getSourceNode().isNonStopNode()) {

--- a/src/app/view/editor-main-view/data-views/transitions.view.ts
+++ b/src/app/view/editor-main-view/data-views/transitions.view.ts
@@ -9,6 +9,7 @@ import {DragTransitionInfo, PreviewLineMode} from "./trainrunsection.previewline
 import {Vec2D} from "../../../utils/vec2D";
 import {TransitionViewObject} from "./transitionViewObject";
 import {LinePatternRefs} from "../../../data-structures/business.data.structures";
+import {buildPathString} from "../../../services/util/svg";
 
 export class TransitionsView {
   transitionsGroup: d3.Selection<SVGElement, undefined, Element, undefined>;
@@ -118,7 +119,7 @@ export class TransitionsView {
       .classed(StaticDomTags.TAG_SELECTED, (t: TransitionViewObject) =>
         t.transition.getTrainrun().selected(),
       )
-      .attr("d", (t: TransitionViewObject) => D3Utils.getPathAsSVGString(t.transition.getPath()));
+      .attr("d", (t: TransitionViewObject) => buildPathString(t.transition.getPath(), 0));
   }
 
   createNonStopToggle(

--- a/src/app/view/editor-properties-view-component/editor-properties-view.component.html
+++ b/src/app/view/editor-properties-view-component/editor-properties-view.component.html
@@ -155,6 +155,28 @@
 
   <sbb-expansion-panel [expanded]="true">
     <sbb-expansion-panel-header>{{
+      "app.view.editor-properties-view-component.sectionRendering" | translate
+    }}</sbb-expansion-panel-header>
+    <sbb-label>{{
+      "app.view.editor-properties-view-component.sectionRendering" | translate
+    }}</sbb-label>
+    <br />
+    <sbb-radio-group [(ngModel)]="activeSectionRenderingStyle" class="sbb-radio-group-vertical">
+      <sbb-radio-button
+        *ngFor="let style of sectionRenderingStyles"
+        [value]="style"
+        [title]="
+          'app.view.editor-properties-view-component.' + style + 'SectionsTooltip' | translate
+        "
+        (change)="onUpdateSectionRenderingStyle($event)"
+      >
+        {{ "app.view.editor-properties-view-component." + style + "Sections" | translate }}
+      </sbb-radio-button>
+    </sbb-radio-group>
+  </sbb-expansion-panel>
+
+  <sbb-expansion-panel [expanded]="true">
+    <sbb-expansion-panel-header>{{
       "app.view.editor-properties-view-component.graphicTimetable" | translate
     }}</sbb-expansion-panel-header>
     <sbb-label>{{

--- a/src/app/view/editor-properties-view-component/editor-properties-view.component.ts
+++ b/src/app/view/editor-properties-view-component/editor-properties-view.component.ts
@@ -7,6 +7,7 @@ import {ThemeRegistration} from "../themes/theme-registration";
 import {StreckengrafikRenderingType} from "../themes/streckengrafik-rendering-type";
 import {TravelTimeCreationEstimatorType} from "../themes/editor-trainrun-traveltime-creator-type";
 import {TrafficSide} from "src/app/data-structures/business.data.structures";
+import {SECTION_SHAPES, SectionRenderingStyle} from "../../services/util/section-shape";
 
 @Component({
   selector: "sbb-editor-properties-view-component",
@@ -100,6 +101,9 @@ export class EditorPropertiesViewComponent {
   ];
   activeTrafficSideType: TrafficSide = null;
 
+  sectionRenderingStyles = SECTION_SHAPES;
+  activeSectionRenderingStyle: SectionRenderingStyle = null;
+
   activeDarkBackgroundColor = EditorPropertiesViewComponent.DEFAULT_DARK_BACKGROUNDCOLOR;
   activeBackgroundColor = EditorPropertiesViewComponent.DEFAULT_BACKGROUNDCOLOR;
 
@@ -114,6 +118,7 @@ export class EditorPropertiesViewComponent {
     this.activeTravelTimeCreationEstimatorType =
       this.uiInteractionService.getActiveTravelTimeCreationEstimatorType();
     this.activeTrafficSideType = this.uiInteractionService.getActiveTrafficSideType();
+    this.activeSectionRenderingStyle = this.uiInteractionService.getActiveSectionRenderingStyle();
     if (activeTheme.isDark) {
       this.activeDarkBackgroundColor = this.getHexColor(activeTheme.backgroundColor);
     } else {
@@ -144,6 +149,11 @@ export class EditorPropertiesViewComponent {
   onUpdateTrafficSideType(event: SbbRadioChange) {
     this.uiInteractionService.setActiveTrafficSideType(event.value);
     this.activeTrafficSideType = event.value;
+  }
+
+  onUpdateSectionRenderingStyle(event: SbbRadioChange) {
+    this.uiInteractionService.setActiveSectionRenderingStyle(event.value);
+    this.activeSectionRenderingStyle = event.value;
   }
 
   colorPicked() {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -479,7 +479,12 @@
         "retrieveFromEdgeTooltip": "Takes over the max. travel time on the same section of all trains of the same category, otherwise max. travel time of all trains, otherwise 1 min.",
         "trafficSide": "Traffic side",
         "leftTrafficSideTooltip": "Trains are operated according to left-hand running conventions.",
-        "rightTrafficSideTooltip": "Trains are operated according to right-hand running conventions."
+        "rightTrafficSideTooltip": "Trains are operated according to right-hand running conventions.",
+        "sectionRendering": "Section rendering",
+        "obliqueSections": "Oblique",
+        "obliqueSectionsTooltip": "Sections are drawn as straight lines between nodes (default).",
+        "orthogonalSections": "Right angles",
+        "orthogonalSectionsTooltip": "Sections are drawn with horizontal and vertical segments only."
       },
       "editor-side-view": {
         "editor-node-detail-view": {

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -479,7 +479,12 @@
         "retrieveFromEdgeTooltip": "Reprend le temps de parcours maximal sur le même tronçon de tous les trains de la même catégorie, sinon le temps de parcours maximal de tous les trains, sinon 1 min.",
         "trafficSide": "Sens de circulation",
         "leftTrafficSideTooltip": "Les trains sont affichés selon les conventions de circulation à gauche.",
-        "rightTrafficSideTooltip": "Les trains sont affichés selon les conventions de circulation à droite."
+        "rightTrafficSideTooltip": "Les trains sont affichés selon les conventions de circulation à droite.",
+        "sectionRendering": "Tracé des sections",
+        "obliqueSections": "Oblique",
+        "obliqueSectionsTooltip": "Les sections sont tracées en lignes droites entre les nœuds (par défaut).",
+        "orthogonalSections": "Angles droits",
+        "orthogonalSectionsTooltip": "Les sections sont tracées uniquement avec des segments horizontaux et verticaux."
       },
       "editor-side-view": {
         "editor-node-detail-view": {


### PR DESCRIPTION
This PR lets users draw the trainrun sections with right angles instead of the classic oblique lines.

Until now, the oblique rendering was the only one, with its logic spread across the views and the router, so there was no clean place to plug an alternative rendering in.

This PR is split in three commits:

1. A new `SectionShape` abstraction now describes how a section is drawn between its two nodes: its path (`getPath`), where its labels and stops go (`getPoints`), and how the path becomes an SVG string (`getPathAsSVGString`). The existing rendering becomes `ObliqueSectionShape`, and every section path (including the one cached on the model) is now built through this API.
2. A new `OrthogonalSectionShape` draws sections with horizontal and vertical segments only, with corners cut like the transitions inside nodes. Parallel sections between the same two nodes are shifted so they do not overlap, and the name, times and stops are placed on free segments of the path. It falls back to the oblique shape when ports are missing.
3. A new "Section rendering" panel in the properties view lets users switch between the two shapes, persisted to local storage.

<img width="1244" height="798" alt="image" src="https://github.com/user-attachments/assets/e1649460-2d4b-4fc6-ba91-71b223e54b1b" />