### PR TITLE
Aeg/follow up search features

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -39,6 +39,7 @@ import {TrainrunSectionTabComponent} from "./view/dialogs/trainrun-and-section-d
 import {TrainrunSectionCardComponent} from "./view/dialogs/trainrun-and-section-dialog/trainrunsection-card/trainrun-section-card.component";
 import {EditorNodeDetailViewComponent} from "./view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component";
 import {EditorFilterViewComponent} from "./view/editor-filter-view/editor-filter-view.component";
+import {EditorSearchViewComponent} from "./view/editor-search-view/editor-search-view-component";
 import {EditorMenuComponent} from "./view/editor-menu/editor-menu.component";
 import {EditorSideViewComponent} from "./view/editor-side-view/editor-side-view.component";
 import {BaseDataDialogComponent} from "./view/dialogs/basedata-dialog/basedata-dialog.component";
@@ -124,6 +125,7 @@ import {TimeStepperComponent} from "./view/dialogs/trainrun-and-section-dialog/t
     TrainrunSectionCardComponent,
     EditorNodeDetailViewComponent,
     EditorFilterViewComponent,
+    EditorSearchViewComponent,
     BaseDataDialogComponent,
     EditorMenuComponent,
     EditorSideViewComponent,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -22,6 +22,7 @@ import {SbbLoadingIndicatorModule} from "@sbb-esta/angular/loading-indicator";
 import {SbbMenuModule} from "@sbb-esta/angular/menu";
 import {SbbNotificationToastModule} from "@sbb-esta/angular/notification-toast";
 import {SbbRadioButtonModule} from "@sbb-esta/angular/radio-button";
+import {SbbSearchModule} from "@sbb-esta/angular/search";
 import {SbbSelectModule} from "@sbb-esta/angular/select";
 import {SbbSidebarModule} from "@sbb-esta/angular/sidebar";
 import {SbbTableModule} from "@sbb-esta/angular/table";
@@ -40,6 +41,7 @@ import {TrainrunSectionCardComponent} from "./view/dialogs/trainrun-and-section-
 import {EditorNodeDetailViewComponent} from "./view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component";
 import {EditorFilterViewComponent} from "./view/editor-filter-view/editor-filter-view.component";
 import {EditorSearchViewComponent} from "./view/editor-search-view/editor-search-view-component";
+import {EditorNodeSearchViewComponent} from "./view/editor-search-view/editor-node-search-view-component/editor-node-search-view-component";
 import {EditorMenuComponent} from "./view/editor-menu/editor-menu.component";
 import {EditorSideViewComponent} from "./view/editor-side-view/editor-side-view.component";
 import {BaseDataDialogComponent} from "./view/dialogs/basedata-dialog/basedata-dialog.component";
@@ -126,6 +128,7 @@ import {TimeStepperComponent} from "./view/dialogs/trainrun-and-section-dialog/t
     EditorNodeDetailViewComponent,
     EditorFilterViewComponent,
     EditorSearchViewComponent,
+    EditorNodeSearchViewComponent,
     BaseDataDialogComponent,
     EditorMenuComponent,
     EditorSideViewComponent,
@@ -237,6 +240,7 @@ import {TimeStepperComponent} from "./view/dialogs/trainrun-and-section-dialog/t
     SbbUsermenuModule,
     SbbButtonModule,
     SbbInputModule,
+    SbbSearchModule,
     SbbFileSelectorModule,
     SbbMenuModule,
     SbbSidebarModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -42,6 +42,7 @@ import {EditorNodeDetailViewComponent} from "./view/editor-side-view/editor-node
 import {EditorFilterViewComponent} from "./view/editor-filter-view/editor-filter-view.component";
 import {EditorSearchViewComponent} from "./view/editor-search-view/editor-search-view-component";
 import {EditorNodeSearchViewComponent} from "./view/editor-search-view/editor-node-search-view-component/editor-node-search-view-component";
+import {EditorTrainrunSearchViewComponent} from "./view/editor-search-view/editor-trainrun-search-view-component/editor-trainrun-search-view-component";
 import {EditorMenuComponent} from "./view/editor-menu/editor-menu.component";
 import {EditorSideViewComponent} from "./view/editor-side-view/editor-side-view.component";
 import {BaseDataDialogComponent} from "./view/dialogs/basedata-dialog/basedata-dialog.component";
@@ -129,6 +130,7 @@ import {TimeStepperComponent} from "./view/dialogs/trainrun-and-section-dialog/t
     EditorFilterViewComponent,
     EditorSearchViewComponent,
     EditorNodeSearchViewComponent,
+    EditorTrainrunSearchViewComponent,
     BaseDataDialogComponent,
     EditorMenuComponent,
     EditorSideViewComponent,

--- a/src/app/netzgrafik-application/netzgrafik-application.component.html
+++ b/src/app/netzgrafik-application/netzgrafik-application.component.html
@@ -24,6 +24,15 @@
     >
       <sbb-icon svgIcon="filter-small"></sbb-icon>
     </a>
+    <a
+      sbbIconSidebarItem
+      [label]="'app.netzgrafik-application.search' | translate"
+      [class]="getSearchActivatedTag()"
+      [style]="getSearchStyle()"
+      (click)="onSearchClicked()"
+    >
+      <sbb-icon svgIcon="magnifying-glass-small"></sbb-icon>
+    </a>
     <!--
     <a sbbIconSidebarItem [label]="'app.netzgrafik-application.analytics' | translate" (click)="onAnalyticsClicked()">
       <sbb-icon svgIcon="bulb-on-small"></sbb-icon>

--- a/src/app/netzgrafik-application/netzgrafik-application.component.ts
+++ b/src/app/netzgrafik-application/netzgrafik-application.component.ts
@@ -84,6 +84,10 @@ export class NetzgrafikApplicationComponent {
     this.uiInteractionService.showOrCloseFilter(FilterWindowType.EDITOR_FILTER);
   }
 
+  onSearchClicked() {
+    this.uiInteractionService.showOrCloseFilter(FilterWindowType.SEARCH);
+  }
+
   onEditToolClicked() {
     this.uiInteractionService.showOrCloseFilter(FilterWindowType.EDIT_TOOLS);
   }
@@ -107,6 +111,11 @@ export class NetzgrafikApplicationComponent {
     return this.sanitizer.bypassSecurityTrustStyle("");
   }
 
+  getSearchStyle() {
+    // TODO: Implement logic to determine if search is active and return appropriate style
+    return this.sanitizer.bypassSecurityTrustStyle("");
+  }
+
   getEditStyle() {
     if (this.uiInteractionService.getEditorMode() === EditorMode.MultiNodeMoving) {
       if (this.nodeService.getSelectedNodes().length > 0) {
@@ -118,6 +127,10 @@ export class NetzgrafikApplicationComponent {
 
   getFilterActivatedTag() {
     return this.getActivatedTag(FilterWindowType.EDITOR_FILTER);
+  }
+
+  getSearchActivatedTag() {
+    return this.getActivatedTag(FilterWindowType.SEARCH);
   }
 
   getPropertiesActivatedTag() {

--- a/src/app/perlenkette/service/load-perlenkette.service.spec.ts
+++ b/src/app/perlenkette/service/load-perlenkette.service.spec.ts
@@ -1,0 +1,112 @@
+import {DataService} from "../../services/data/data.service";
+import {NodeService} from "../../services/data/node.service";
+import {ResourceService} from "../../services/data/resource.service";
+import {TrainrunService} from "../../services/data/trainrun.service";
+import {TrainrunSectionService} from "../../services/data/trainrunsection.service";
+import {BaseDataService} from "../../services/data/basedata.service";
+import {NoteService} from "../../services/data/note.service";
+import {LogService} from "../../logger/log.service";
+import {LogPublishersService} from "../../logger/log.publishers.service";
+import {LabelGroupService} from "../../services/data/labelgroup.service";
+import {LabelService} from "../../services/data/label.service";
+import {NetzgrafikUnitTesting} from "../../../integration-testing/netzgrafik.unit.testing";
+import {FilterService} from "../../services/ui/filter.service";
+import {NetzgrafikColoringService} from "../../services/data/netzgrafikColoring.service";
+import {LoadPerlenketteService} from "./load-perlenkette.service";
+
+describe("LoadPerlenketteService", () => {
+  let dataService: DataService;
+  let nodeService: NodeService;
+  let resourceService: ResourceService;
+  let trainrunService: TrainrunService;
+  let trainrunSectionService: TrainrunSectionService;
+  let baseDataService: BaseDataService;
+  let noteService: NoteService;
+  let logService: LogService = null;
+  let logPublishersService: LogPublishersService = null;
+  let labelGroupService: LabelGroupService = null;
+  let labelService: LabelService = null;
+  let filterService: FilterService = null;
+  let netzgrafikColoringService: NetzgrafikColoringService = null;
+  let perlenketteService: LoadPerlenketteService = null;
+
+  beforeEach(() => {
+    baseDataService = new BaseDataService();
+    resourceService = new ResourceService();
+    logPublishersService = new LogPublishersService();
+    logService = new LogService(logPublishersService);
+    labelGroupService = new LabelGroupService(logService);
+    labelService = new LabelService(logService, labelGroupService);
+    filterService = new FilterService(labelService, labelGroupService);
+    trainrunService = new TrainrunService(logService, labelService, filterService);
+    trainrunSectionService = new TrainrunSectionService(logService, trainrunService, filterService);
+    nodeService = new NodeService(
+      logService,
+      resourceService,
+      trainrunService,
+      trainrunSectionService,
+      labelService,
+      filterService,
+    );
+    noteService = new NoteService(logService, labelService, filterService);
+    netzgrafikColoringService = new NetzgrafikColoringService();
+    dataService = new DataService(
+      resourceService,
+      nodeService,
+      trainrunSectionService,
+      trainrunService,
+      baseDataService,
+      noteService,
+      labelService,
+      labelGroupService,
+      filterService,
+      netzgrafikColoringService,
+    );
+    perlenketteService = new LoadPerlenketteService(
+      trainrunService,
+      trainrunSectionService,
+      nodeService,
+      filterService,
+    );
+  });
+
+  it("check getOrderedNodeEntriesForTrainrun - 001", () => {
+    dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
+    const t = trainrunService.getTrainrunFromId(0);
+    trainrunService.setTrainrunAsSelected(t.getId());
+    const entries = perlenketteService.getOrderedNodeEntriesForTrainrun(t);
+    console.log("A", entries, t.getId());
+    expect(entries.length).toBe(3);
+    expect(entries[0].nodeId).toBe(0);
+    expect(entries[0].trainrunSectionId).toBe(0);
+    expect(entries[0].hasGapAfter).toBe(false);
+    expect(entries[1].nodeId).toBe(1);
+    expect(entries[1].trainrunSectionId).toBe(0);
+    expect(entries[1].hasGapAfter).toBe(false);
+    expect(entries[2].nodeId).toBe(2);
+    expect(entries[2].trainrunSectionId).toBe(1);
+    expect(entries[2].hasGapAfter).toBe(false);
+  });
+
+  it("check getOrderedNodeEntriesForTrainrun - 002", () => {
+    dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
+    const t = trainrunService.getTrainrunFromId(1);
+    trainrunService.setTrainrunAsSelected(t.getId());
+    const newSection = trainrunSectionService.createTrainrunSection(3, 4, false);
+    const entries = perlenketteService.getOrderedNodeEntriesForTrainrun(t);
+    console.log("B", entries, t.getId());
+    expect(entries.length).toBe(4);
+    expect(entries[0].nodeId).toBe(1);
+    expect(entries[0].trainrunSectionId).toBe(2);
+    expect(entries[0].hasGapAfter).toBe(false);
+    expect(entries[1].nodeId).toBe(2);
+    expect(entries[1].trainrunSectionId).toBe(2);
+    expect(entries[1].hasGapAfter).toBe(true);
+    expect(entries[2].nodeId).toBe(3);
+    expect(entries[2].trainrunSectionId).toBe(newSection.getId());
+    expect(entries[2].hasGapAfter).toBe(false);
+    expect(entries[3].nodeId).toBe(4);
+    expect(entries[3].trainrunSectionId).toBe(newSection.getId());
+    expect(entries[3].hasGapAfter).toBe(false);
+  });
+});

--- a/src/app/perlenkette/service/load-perlenkette.service.ts
+++ b/src/app/perlenkette/service/load-perlenkette.service.ts
@@ -17,7 +17,8 @@ import {NodeService} from "../../services/data/node.service";
 import {FilterService} from "../../services/ui/filter.service";
 
 export interface OrderedTrainrunNodeEntry {
-  node: Node;
+  nodeId: number;
+  trainrunSectionId?: number;
   hasGapAfter: boolean;
 }
 
@@ -80,27 +81,35 @@ export class LoadPerlenketteService implements OnDestroy {
     return this.perlenketteTrainrun$;
   }
 
-  public getOrderedNodesForTrainrun(trainrun: Trainrun): Node[] {
-    return this.getPerlenketteItem(trainrun)
-      .filter((item) => item.isPerlenketteNode())
-      .map((item) => this.nodeService.getNodeFromId(item.getPerlenketteNode().nodeId))
-      .filter((node): node is Node => node !== undefined);
-  }
-
   public getOrderedNodeEntriesForTrainrun(trainrun: Trainrun): OrderedTrainrunNodeEntry[] {
-    const nodeItems = this.getPerlenketteItem(trainrun).filter((item) => item.isPerlenketteNode());
+    const allItems = this.getPerlenketteItem(trainrun);
+    const entries: OrderedTrainrunNodeEntry[] = [];
 
-    return nodeItems
-      .map((item, index) => {
+    allItems.forEach((item, index) => {
+      if (item.isPerlenketteNode()) {
         const perlenketteNode = item.getPerlenketteNode();
         const node = this.nodeService.getNodeFromId(perlenketteNode.nodeId);
+        const incomingSectionId =
+          index > 0 && allItems[index - 1].isPerlenketteSection()
+            ? allItems[index - 1].getPerlenketteSection().trainrunSectionId
+            : undefined;
+        const outgoingSectionId =
+          index < allItems.length - 1 && allItems[index + 1].isPerlenketteSection()
+            ? allItems[index + 1].getPerlenketteSection().trainrunSectionId
+            : undefined;
+        const hasMoreNodesAfter =
+          index < allItems.length - 1 ? allItems[index + 1].isPerlenketteNode() : false;
 
-        return {
-          node,
-          hasGapAfter: perlenketteNode.isLastTrainrunPartNode() && index < nodeItems.length - 1,
-        };
-      })
-      .filter((entry): entry is OrderedTrainrunNodeEntry => entry.node !== undefined);
+        entries.push({
+          nodeId: node.getId(),
+          // First node in a part has no incoming section, so use outgoing section.
+          trainrunSectionId: incomingSectionId ?? outgoingSectionId,
+          // if two nodes are next to eaach other make a gap after or as well if last node
+          hasGapAfter: perlenketteNode.isLastTrainrunPartNode() && hasMoreNodesAfter,
+        });
+      }
+    });
+    return entries;
   }
 
   getSelectedTrainrun(): Trainrun {

--- a/src/app/perlenkette/service/load-perlenkette.service.ts
+++ b/src/app/perlenkette/service/load-perlenkette.service.ts
@@ -16,6 +16,11 @@ import {TrainrunSectionService} from "../../services/data/trainrunsection.servic
 import {NodeService} from "../../services/data/node.service";
 import {FilterService} from "../../services/ui/filter.service";
 
+export interface OrderedTrainrunNodeEntry {
+  node: Node;
+  hasGapAfter: boolean;
+}
+
 @Injectable({
   providedIn: "root",
 })
@@ -73,6 +78,29 @@ export class LoadPerlenketteService implements OnDestroy {
 
   getPerlenketteData(): Observable<PerlenketteTrainrun> {
     return this.perlenketteTrainrun$;
+  }
+
+  public getOrderedNodesForTrainrun(trainrun: Trainrun): Node[] {
+    return this.getPerlenketteItem(trainrun)
+      .filter((item) => item.isPerlenketteNode())
+      .map((item) => this.nodeService.getNodeFromId(item.getPerlenketteNode().nodeId))
+      .filter((node): node is Node => node !== undefined);
+  }
+
+  public getOrderedNodeEntriesForTrainrun(trainrun: Trainrun): OrderedTrainrunNodeEntry[] {
+    const nodeItems = this.getPerlenketteItem(trainrun).filter((item) => item.isPerlenketteNode());
+
+    return nodeItems
+      .map((item, index) => {
+        const perlenketteNode = item.getPerlenketteNode();
+        const node = this.nodeService.getNodeFromId(perlenketteNode.nodeId);
+
+        return {
+          node,
+          hasGapAfter: perlenketteNode.isLastTrainrunPartNode() && index < nodeItems.length - 1,
+        };
+      })
+      .filter((entry): entry is OrderedTrainrunNodeEntry => entry.node !== undefined);
   }
 
   getSelectedTrainrun(): Trainrun {

--- a/src/app/services/ui/ui.interaction.service.ts
+++ b/src/app/services/ui/ui.interaction.service.ts
@@ -412,6 +412,20 @@ export class UiInteractionService implements OnDestroy {
     this.moveNetzgrafikEditorFocalViewPoint(new Vec2D(x, y));
   }
 
+  getNetzgrafikOffsetFromScreenPx(offsetXPx: number, offsetYPx: number = 0): Vec2D {
+    const viewboxProperties = this.getViewboxProperties(EditorView.svgName);
+    const xScale =
+      viewboxProperties.origWidth > 0
+        ? viewboxProperties.panZoomWidth / viewboxProperties.origWidth
+        : 100 / Math.max(viewboxProperties.zoomFactor, 1);
+    const yScale =
+      viewboxProperties.origHeight > 0
+        ? viewboxProperties.panZoomHeight / viewboxProperties.origHeight
+        : 100 / Math.max(viewboxProperties.zoomFactor, 1);
+
+    return new Vec2D(offsetXPx * xScale, offsetYPx * yScale);
+  }
+
   showOrCloseFilter(type: FilterWindowType) {
     if (this.isFilterWindowType(type)) {
       this.closeFilter();

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -466,10 +466,9 @@ export class TrainrunSectionsView {
   }
 
   static extractTrainrunName(trainrunSection: TrainrunSection): string {
-    return (
-      trainrunSection.getTrainrun().getCategoryShortName() +
-      trainrunSection.getTrainrun().getTitle()
-    );
+    return `${trainrunSection.getTrainrun().getCategoryShortName()}${trainrunSection
+      .getTrainrun()
+      .getTitle()}`;
   }
 
   static extractTravelTime(

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -466,9 +466,10 @@ export class TrainrunSectionsView {
   }
 
   static extractTrainrunName(trainrunSection: TrainrunSection): string {
-    return `${trainrunSection.getTrainrun().getCategoryShortName()}${trainrunSection
-      .getTrainrun()
-      .getTitle()}`;
+    return (
+      trainrunSection.getTrainrun().getCategoryShortName() +
+      trainrunSection.getTrainrun().getTitle()
+    );
   }
 
   static extractTravelTime(

--- a/src/app/view/editor-search-view/editor-node-search-view-component/editor-node-search-view-component.html
+++ b/src/app/view/editor-search-view/editor-node-search-view-component/editor-node-search-view-component.html
@@ -1,6 +1,6 @@
 <sbb-search
   (search)="search()"
-  aria-label="{{ 'app.view.editor-search-view-component.search-node' | translate }}"
+  aria-label="{{ 'app.view.editor-search-view-component.select-node' | translate }}"
 >
   <input
     sbbInput
@@ -17,14 +17,14 @@
 
 @if (searchResults.length > 1) {
 <div
+  #nodeResultsList
   class="search-results-list"
   [class.search-results-overflow]="searchResults.length > 8"
-  [class.search-results-dragging]="isSearchResultsDragging"
-  (mousedown)="onSearchResultsMouseDown($event)"
+  [class.dragging]="isDraggingResults"
+  (mousedown)="onResultListMouseDown($event, nodeResultsList)"
 >
   @for (node of searchResults; track node) {
-  <br />
-  <p class="alignleft" style="line-height: 10px">
+  <div class="search-result-item">
     <span
       class="smallstation"
       [title]="transformNodeName(node)"
@@ -32,7 +32,7 @@
     >
       {{ getNodeSearchValue(node) }}
     </span>
-  </p>
+  </div>
   }
 </div>
 }

--- a/src/app/view/editor-search-view/editor-node-search-view-component/editor-node-search-view-component.html
+++ b/src/app/view/editor-search-view/editor-node-search-view-component/editor-node-search-view-component.html
@@ -1,0 +1,33 @@
+<sbb-search
+  (search)="search()"
+  aria-label="{{ 'app.view.editor-search-view-component.search-node' | translate }}"
+>
+  <input
+    sbbInput
+    [placeholder]="'app.view.editor-search-view-component.search-node' | translate"
+    [formControl]="searchControl"
+    [sbbAutocomplete]="auto"
+  />
+</sbb-search>
+<sbb-autocomplete #auto="sbbAutocomplete" [displayWith]="displayNode">
+  @for (option of filteredNodes; track option) {
+  <sbb-option [value]="option">{{ transformNodeName(option) }}</sbb-option>
+  }
+</sbb-autocomplete>
+
+@if (searchResults.length > 1) {
+<div class="search-results-list">
+  @for (node of searchResults; track node) {
+  <br />
+  <p class="alignleft" style="line-height: 10px">
+    <span
+      class="smallstation"
+      [title]="transformNodeName(node)"
+      (click)="onSearchResultClick(node)"
+    >
+      {{ getNodeSearchValue(node) }}
+    </span>
+  </p>
+  }
+</div>
+}

--- a/src/app/view/editor-search-view/editor-node-search-view-component/editor-node-search-view-component.html
+++ b/src/app/view/editor-search-view/editor-node-search-view-component/editor-node-search-view-component.html
@@ -10,13 +10,18 @@
   />
 </sbb-search>
 <sbb-autocomplete #auto="sbbAutocomplete" [displayWith]="displayNode">
-  @for (option of filteredNodes; track option) {
-  <sbb-option [value]="option">{{ transformNodeName(option) }}</sbb-option>
-  }
+  <sbb-option *ngFor="let option of filteredNodes" [value]="option">
+    {{ transformNodeName(option) }}
+  </sbb-option>
 </sbb-autocomplete>
 
 @if (searchResults.length > 1) {
-<div class="search-results-list">
+<div
+  class="search-results-list"
+  [class.search-results-overflow]="searchResults.length > 8"
+  [class.search-results-dragging]="isSearchResultsDragging"
+  (mousedown)="onSearchResultsMouseDown($event)"
+>
   @for (node of searchResults; track node) {
   <br />
   <p class="alignleft" style="line-height: 10px">

--- a/src/app/view/editor-search-view/editor-node-search-view-component/editor-node-search-view-component.scss
+++ b/src/app/view/editor-search-view/editor-node-search-view-component/editor-node-search-view-component.scss
@@ -15,26 +15,22 @@
   overflow-y: auto;
 }
 
-.search-results-list:not(.search-results-dragging) {
-  cursor: cursor;
-}
-
-.search-results-list.search-results-dragging {
-  cursor: cursor;
+.search-results-list.dragging {
   user-select: none;
 }
 
-.alignleft {
-  float: left;
-  width: 100%;
-  margin: 0;
+.search-result-item {
+  line-height: 1.15;
+  margin: 2px 0;
 }
 
 span.smallstation {
   cursor: pointer;
-  font-size: 12px;
-  border: 3px solid var(--sbb-color-background);
-  font-weight: lighter;
+  color: var(--sbb-form-input-color);
+  font-size: var(--sbb-font-size);
+  border: 5px solid none;
+  margin-left: 4px;
+  font-weight: light;
   user-select: none;
 }
 

--- a/src/app/view/editor-search-view/editor-node-search-view-component/editor-node-search-view-component.scss
+++ b/src/app/view/editor-search-view/editor-node-search-view-component/editor-node-search-view-component.scss
@@ -3,10 +3,25 @@
 @use "../../rastering/definitions" as *;
 
 .search-results-list {
+  display: flow-root;
   margin-top: 0.5rem;
+  height: auto;
   max-height: 200px;
-  overflow-y: auto;
+  overflow-y: hidden;
   overflow-x: hidden;
+}
+
+.search-results-list.search-results-overflow {
+  overflow-y: auto;
+}
+
+.search-results-list:not(.search-results-dragging) {
+  cursor: cursor;
+}
+
+.search-results-list.search-results-dragging {
+  cursor: cursor;
+  user-select: none;
 }
 
 .alignleft {

--- a/src/app/view/editor-search-view/editor-node-search-view-component/editor-node-search-view-component.scss
+++ b/src/app/view/editor-search-view/editor-node-search-view-component/editor-node-search-view-component.scss
@@ -1,0 +1,29 @@
+@use "../../../../variables" as *;
+@use "./../../../view/editor-filter-view/editor-filter-view.component.scss";
+@use "../../rastering/definitions" as *;
+
+.search-results-list {
+  margin-top: 0.5rem;
+  max-height: 200px;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.alignleft {
+  float: left;
+  width: 100%;
+  margin: 0;
+}
+
+span.smallstation {
+  cursor: pointer;
+  font-size: 12px;
+  border: 3px solid var(--sbb-color-background);
+  font-weight: lighter;
+  user-select: none;
+}
+
+span.smallstation:hover {
+  font-weight: bolder;
+  color: var(--COLOR_Edit);
+}

--- a/src/app/view/editor-search-view/editor-node-search-view-component/editor-node-search-view-component.ts
+++ b/src/app/view/editor-search-view/editor-node-search-view-component/editor-node-search-view-component.ts
@@ -1,4 +1,15 @@
-import {Component, HostListener, inject} from "@angular/core";
+import {
+  Component,
+  EventEmitter,
+  HostListener,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  Output,
+  SimpleChanges,
+} from "@angular/core";
+import {FilterService} from "../../../services/ui/filter.service";
 import {UiInteractionService} from "../../../services/ui/ui.interaction.service";
 import {takeUntil} from "rxjs/operators";
 import {Subject} from "rxjs";
@@ -14,8 +25,11 @@ import {Vec2D} from "../../../utils/vec2D";
   styleUrls: ["./editor-node-search-view-component.scss"],
   standalone: false,
 })
-export class EditorNodeSearchViewComponent {
+export class EditorNodeSearchViewComponent implements OnInit, OnDestroy, OnChanges {
   private static readonly FILTER_PANEL_ID = "cd-layout-filter";
+
+  @Input() resetSignal = 0;
+  @Output() isEmptyChange = new EventEmitter<boolean>();
 
   searchControl = new FormControl<string | Node | null>("");
   searchResults: Node[] = [];
@@ -25,21 +39,32 @@ export class EditorNodeSearchViewComponent {
   private destroyed = new Subject<void>();
   allSearchableNodes: Node[] = [];
   filteredNodes: Node[] = [];
-  isSearchResultsDragging = false;
-  private searchResultsElement: HTMLElement | null = null;
-  private searchResultsDragStartY = 0;
-  private searchResultsDragStartScrollTop = 0;
+  isDraggingResults = false;
+
+  private dragStartY = 0;
+  private dragStartScrollTop = 0;
+  private activeResultsList: HTMLElement | null = null;
 
   constructor(
     private uiInteractionService: UiInteractionService,
     private nodeService: NodeService,
+    private filterService: FilterService,
   ) {
     this.nodeService.nodes.pipe(takeUntil(this.destroyed)).subscribe((nodes: Node[]) => {
-      this.allSearchableNodes = nodes;
+      this.allSearchableNodes = nodes.filter((node) => this.filterService.filterNode(node));
       this.updateFilteredNodes(this.searchControl.value);
     });
 
-    this.allSearchableNodes = this.nodeService.getNodes();
+    this.filterService.filter.pipe(takeUntil(this.destroyed)).subscribe(() => {
+      this.allSearchableNodes = this.nodeService
+        .getNodes()
+        .filter((node) => this.filterService.filterNode(node));
+      this.updateFilteredNodes(this.searchControl.value);
+    });
+
+    this.allSearchableNodes = this.nodeService
+      .getNodes()
+      .filter((node) => this.filterService.filterNode(node));
     this.updateFilteredNodes(this.searchControl.value);
   }
 
@@ -57,15 +82,58 @@ export class EditorNodeSearchViewComponent {
 
     this.searchControl.valueChanges.pipe(takeUntil(this.destroyed)).subscribe((value) => {
       this.updateFilteredNodes(value);
+      this.emitIsEmptyState();
     });
+
+    this.emitIsEmptyState();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes["resetSignal"] && !changes["resetSignal"].firstChange) {
+      this.clearSearch();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.stopDragScroll();
+    this.destroyed.next();
+    this.destroyed.complete();
+  }
+
+  onResultListMouseDown(event: MouseEvent, listElement: HTMLElement): void {
+    if (event.button !== 0) {
+      return;
+    }
+
+    // Dragging is enabled only if the list can actually scroll.
+    if (listElement.scrollHeight <= listElement.clientHeight) {
+      return;
+    }
+
+    this.isDraggingResults = true;
+    this.activeResultsList = listElement;
+    this.dragStartY = event.clientY;
+    this.dragStartScrollTop = listElement.scrollTop;
+    event.preventDefault();
+  }
+
+  @HostListener("document:mousemove", ["$event"])
+  onDocumentMouseMove(event: MouseEvent): void {
+    if (!this.isDraggingResults || !this.activeResultsList) {
+      return;
+    }
+
+    const deltaY = event.clientY - this.dragStartY;
+    this.activeResultsList.scrollTop = this.dragStartScrollTop + deltaY;
+  }
+
+  @HostListener("document:mouseup")
+  onDocumentMouseUp(): void {
+    this.stopDragScroll();
   }
 
   get isNetzgrafikMode(): boolean {
     return this.mainViewMode === MainViewMode.Netzgrafik;
-  }
-  ngOnDestroy(): void {
-    this.destroyed.next();
-    this.destroyed.complete();
   }
 
   search() {
@@ -87,45 +155,6 @@ export class EditorNodeSearchViewComponent {
       EditorNodeSearchViewComponent.FILTER_PANEL_ID,
     );
     this.uiInteractionService.gotoNode(node, offset);
-  }
-
-  canResetSearch(): boolean {
-    return this.searchResults.length > 0 || this.getSearchTerm(this.searchControl.value) !== "";
-  }
-
-  resetSearch(): void {
-    this.searchResults = [];
-    this.onSearchResultsMouseUp();
-    this.searchControl.setValue("");
-  }
-
-  onSearchResultsMouseDown(event: MouseEvent): void {
-    if (event.button !== 0 || (event.target as HTMLElement).closest(".smallstation") !== null) {
-      return;
-    }
-
-    this.searchResultsElement = event.currentTarget as HTMLElement;
-    this.searchResultsDragStartY = event.clientY;
-    this.searchResultsDragStartScrollTop = this.searchResultsElement.scrollTop;
-    this.isSearchResultsDragging = true;
-    event.preventDefault();
-  }
-
-  @HostListener("document:mousemove", ["$event"])
-  onSearchResultsMouseMove(event: MouseEvent): void {
-    if (!this.isSearchResultsDragging || this.searchResultsElement === null) {
-      return;
-    }
-
-    this.searchResultsElement.scrollTop =
-      this.searchResultsDragStartScrollTop + (event.clientY - this.searchResultsDragStartY);
-    event.preventDefault();
-  }
-
-  @HostListener("document:mouseup")
-  onSearchResultsMouseUp(): void {
-    this.isSearchResultsDragging = false;
-    this.searchResultsElement = null;
   }
 
   getNodeSearchValue(node: Node): string {
@@ -204,5 +233,24 @@ export class EditorNodeSearchViewComponent {
     const element = document.getElementById(elementId);
     const offsetXPx = element?.getBoundingClientRect().right ?? 0;
     return this.uiInteractionService.getNetzgrafikOffsetFromScreenPx(offsetXPx, 0);
+  }
+
+  private clearSearch(): void {
+    this.stopDragScroll();
+    this.searchControl.setValue("");
+    this.searchResults = [];
+    this.updateFilteredNodes(this.searchControl.value);
+    this.emitIsEmptyState();
+  }
+
+  private emitIsEmptyState(): void {
+    const value = this.searchControl.value;
+    const isEmpty = value === null || (typeof value === "string" && value.trim() === "");
+    this.isEmptyChange.emit(isEmpty);
+  }
+
+  private stopDragScroll(): void {
+    this.isDraggingResults = false;
+    this.activeResultsList = null;
   }
 }

--- a/src/app/view/editor-search-view/editor-node-search-view-component/editor-node-search-view-component.ts
+++ b/src/app/view/editor-search-view/editor-node-search-view-component/editor-node-search-view-component.ts
@@ -1,0 +1,167 @@
+import {Component, inject} from "@angular/core";
+import {UiInteractionService} from "../../../services/ui/ui.interaction.service";
+import {takeUntil} from "rxjs/operators";
+import {Subject} from "rxjs";
+import {MainViewMode} from "../../filter-main-side-view/main-view-mode";
+import {Node} from "../../../models/node.model";
+import {NodeService} from "../../../services/data/node.service";
+import {FormControl} from "@angular/forms";
+import {Vec2D} from "../../../utils/vec2D";
+
+@Component({
+  selector: "sbb-editor-node-search-view-component",
+  templateUrl: "./editor-node-search-view-component.html",
+  styleUrls: ["./editor-node-search-view-component.scss"],
+  standalone: false,
+})
+export class EditorNodeSearchViewComponent {
+  private static readonly FILTER_PANEL_ID = "cd-layout-filter";
+
+  searchControl = new FormControl<string | Node | null>("");
+  searchResults: Node[] = [];
+  readonly displayNode = (value: string | Node | null): string => this.getDisplayValue(value);
+
+  mainViewMode: MainViewMode = MainViewMode.Netzgrafik;
+  private destroyed = new Subject<void>();
+  allSearchableNodes: Node[] = [];
+  filteredNodes: Node[] = [];
+
+  constructor(
+    private uiInteractionService: UiInteractionService,
+    private nodeService: NodeService,
+  ) {
+    this.nodeService.nodes.pipe(takeUntil(this.destroyed)).subscribe((nodes: Node[]) => {
+      this.allSearchableNodes = nodes;
+      this.filteredNodes = this.filterNodes(this.searchControl.value).sort((a, b) =>
+        this.getNodeSearchValue(a).localeCompare(this.getNodeSearchValue(b)),
+      );
+    });
+
+    this.allSearchableNodes = this.nodeService.getNodes();
+    this.filteredNodes = this.filterNodes(this.searchControl.value).sort((a, b) =>
+      this.getNodeSearchValue(a).localeCompare(this.getNodeSearchValue(b)),
+    );
+  }
+
+  ngOnInit(): void {
+    this.uiInteractionService.streckengrafikWindow
+      .pipe(takeUntil(this.destroyed))
+      .subscribe((mainViewMode: MainViewMode) => {
+        this.mainViewMode = mainViewMode;
+      });
+    this.uiInteractionService.originDestinationWindow
+      .pipe(takeUntil(this.destroyed))
+      .subscribe((mainViewMode: MainViewMode) => {
+        this.mainViewMode = mainViewMode;
+      });
+
+    this.searchControl.valueChanges.pipe(takeUntil(this.destroyed)).subscribe((value) => {
+      this.filteredNodes = this.filterNodes(value).sort((a, b) =>
+        this.getNodeSearchValue(a).localeCompare(this.getNodeSearchValue(b)),
+      );
+    });
+  }
+
+  get isNetzgrafikMode(): boolean {
+    return this.mainViewMode === MainViewMode.Netzgrafik;
+  }
+  ngOnDestroy(): void {
+    this.destroyed.next();
+    this.destroyed.complete();
+  }
+
+  search() {
+    if (this.searchControl.value instanceof Node) {
+      this.searchResults = [this.searchControl.value];
+      this.onSearchResultClick(this.searchControl.value);
+      return;
+    }
+
+    this.searchResults = this.filterNodes(this.searchControl.value).sort((a, b) =>
+      this.getNodeSearchValue(a).localeCompare(this.getNodeSearchValue(b)),
+    );
+
+    if (this.searchResults.length === 1) {
+      this.onSearchResultClick(this.searchResults[0]);
+    }
+  }
+
+  onSearchResultClick(node: Node): void {
+    const offset = this.getNetzgrafikOffsetForElementRightEdge(
+      EditorNodeSearchViewComponent.FILTER_PANEL_ID,
+    );
+    this.uiInteractionService.gotoNode(node, offset);
+  }
+
+  getNodeSearchValue(node: Node): string {
+    if (node) {
+      const betriebspunktName = node.getBetriebspunktName() ?? "";
+      const fullName = node.getFullName() ?? "";
+
+      return `${betriebspunktName} (${fullName})`;
+    }
+
+    return "";
+  }
+
+  transformNodeName(node: Node): string {
+    if (node) {
+      const betriebspunktName = node.getBetriebspunktName() ?? "";
+      const fullName = node.getFullName() ?? "";
+      const formattedBetriebspunktName =
+        betriebspunktName.length > 8
+          ? `${betriebspunktName.slice(0, 5)}...`
+          : betriebspunktName.padEnd(8, " ");
+
+      return `${formattedBetriebspunktName} ${fullName}`;
+    }
+    return "";
+  }
+
+  private filterNodes(value: string | Node | null): Node[] {
+    const searchTerm = this.getSearchTerm(value);
+    if (!searchTerm) {
+      return this.allSearchableNodes;
+    }
+
+    return this.allSearchableNodes.filter((node) => this.matchesNode(node, searchTerm));
+  }
+
+  private getSearchTerm(value: string | Node | null): string {
+    if (typeof value === "string") {
+      return value.trim().toLocaleUpperCase();
+    }
+
+    if (value instanceof Node) {
+      return this.getNodeSearchValue(value).toLocaleUpperCase();
+    }
+
+    return "";
+  }
+
+  private getDisplayValue(value: string | Node | null): string {
+    if (value instanceof Node) {
+      return this.getNodeSearchValue(value);
+    }
+
+    return value ?? "";
+  }
+
+  private matchesNode(node: Node, searchTerm: string): boolean {
+    const betriebspunktName = (node.getBetriebspunktName() ?? "").toLocaleUpperCase();
+    const fullName = (node.getFullName() ?? "").toLocaleUpperCase();
+    const compactLabel = this.getNodeSearchValue(node).toLocaleUpperCase();
+
+    return (
+      betriebspunktName.includes(searchTerm) ||
+      fullName.includes(searchTerm) ||
+      compactLabel.includes(searchTerm)
+    );
+  }
+
+  private getNetzgrafikOffsetForElementRightEdge(elementId: string): Vec2D {
+    const element = document.getElementById(elementId);
+    const offsetXPx = element?.getBoundingClientRect().right ?? 0;
+    return this.uiInteractionService.getNetzgrafikOffsetFromScreenPx(offsetXPx, 0);
+  }
+}

--- a/src/app/view/editor-search-view/editor-node-search-view-component/editor-node-search-view-component.ts
+++ b/src/app/view/editor-search-view/editor-node-search-view-component/editor-node-search-view-component.ts
@@ -1,4 +1,4 @@
-import {Component, inject} from "@angular/core";
+import {Component, HostListener, inject} from "@angular/core";
 import {UiInteractionService} from "../../../services/ui/ui.interaction.service";
 import {takeUntil} from "rxjs/operators";
 import {Subject} from "rxjs";
@@ -25,6 +25,10 @@ export class EditorNodeSearchViewComponent {
   private destroyed = new Subject<void>();
   allSearchableNodes: Node[] = [];
   filteredNodes: Node[] = [];
+  isSearchResultsDragging = false;
+  private searchResultsElement: HTMLElement | null = null;
+  private searchResultsDragStartY = 0;
+  private searchResultsDragStartScrollTop = 0;
 
   constructor(
     private uiInteractionService: UiInteractionService,
@@ -32,15 +36,11 @@ export class EditorNodeSearchViewComponent {
   ) {
     this.nodeService.nodes.pipe(takeUntil(this.destroyed)).subscribe((nodes: Node[]) => {
       this.allSearchableNodes = nodes;
-      this.filteredNodes = this.filterNodes(this.searchControl.value).sort((a, b) =>
-        this.getNodeSearchValue(a).localeCompare(this.getNodeSearchValue(b)),
-      );
+      this.updateFilteredNodes(this.searchControl.value);
     });
 
     this.allSearchableNodes = this.nodeService.getNodes();
-    this.filteredNodes = this.filterNodes(this.searchControl.value).sort((a, b) =>
-      this.getNodeSearchValue(a).localeCompare(this.getNodeSearchValue(b)),
-    );
+    this.updateFilteredNodes(this.searchControl.value);
   }
 
   ngOnInit(): void {
@@ -56,9 +56,7 @@ export class EditorNodeSearchViewComponent {
       });
 
     this.searchControl.valueChanges.pipe(takeUntil(this.destroyed)).subscribe((value) => {
-      this.filteredNodes = this.filterNodes(value).sort((a, b) =>
-        this.getNodeSearchValue(a).localeCompare(this.getNodeSearchValue(b)),
-      );
+      this.updateFilteredNodes(value);
     });
   }
 
@@ -77,9 +75,7 @@ export class EditorNodeSearchViewComponent {
       return;
     }
 
-    this.searchResults = this.filterNodes(this.searchControl.value).sort((a, b) =>
-      this.getNodeSearchValue(a).localeCompare(this.getNodeSearchValue(b)),
-    );
+    this.searchResults = this.filterNodes(this.searchControl.value);
 
     if (this.searchResults.length === 1) {
       this.onSearchResultClick(this.searchResults[0]);
@@ -91,6 +87,45 @@ export class EditorNodeSearchViewComponent {
       EditorNodeSearchViewComponent.FILTER_PANEL_ID,
     );
     this.uiInteractionService.gotoNode(node, offset);
+  }
+
+  canResetSearch(): boolean {
+    return this.searchResults.length > 0 || this.getSearchTerm(this.searchControl.value) !== "";
+  }
+
+  resetSearch(): void {
+    this.searchResults = [];
+    this.onSearchResultsMouseUp();
+    this.searchControl.setValue("");
+  }
+
+  onSearchResultsMouseDown(event: MouseEvent): void {
+    if (event.button !== 0 || (event.target as HTMLElement).closest(".smallstation") !== null) {
+      return;
+    }
+
+    this.searchResultsElement = event.currentTarget as HTMLElement;
+    this.searchResultsDragStartY = event.clientY;
+    this.searchResultsDragStartScrollTop = this.searchResultsElement.scrollTop;
+    this.isSearchResultsDragging = true;
+    event.preventDefault();
+  }
+
+  @HostListener("document:mousemove", ["$event"])
+  onSearchResultsMouseMove(event: MouseEvent): void {
+    if (!this.isSearchResultsDragging || this.searchResultsElement === null) {
+      return;
+    }
+
+    this.searchResultsElement.scrollTop =
+      this.searchResultsDragStartScrollTop + (event.clientY - this.searchResultsDragStartY);
+    event.preventDefault();
+  }
+
+  @HostListener("document:mouseup")
+  onSearchResultsMouseUp(): void {
+    this.isSearchResultsDragging = false;
+    this.searchResultsElement = null;
   }
 
   getNodeSearchValue(node: Node): string {
@@ -120,11 +155,17 @@ export class EditorNodeSearchViewComponent {
 
   private filterNodes(value: string | Node | null): Node[] {
     const searchTerm = this.getSearchTerm(value);
-    if (!searchTerm) {
-      return this.allSearchableNodes;
-    }
+    const nodes = searchTerm
+      ? this.allSearchableNodes.filter((node) => this.matchesNode(node, searchTerm))
+      : [...this.allSearchableNodes];
 
-    return this.allSearchableNodes.filter((node) => this.matchesNode(node, searchTerm));
+    return nodes.sort((a, b) =>
+      this.getNodeSearchValue(a).localeCompare(this.getNodeSearchValue(b)),
+    );
+  }
+
+  private updateFilteredNodes(value: string | Node | null): void {
+    this.filteredNodes = this.filterNodes(value).slice(0, 10);
   }
 
   private getSearchTerm(value: string | Node | null): string {

--- a/src/app/view/editor-search-view/editor-search-view-component.html
+++ b/src/app/view/editor-search-view/editor-search-view-component.html
@@ -6,17 +6,35 @@
       >{{ "app.view.editor-search-view-component.goto" | translate }}</sbb-expansion-panel-header
     >
 
-    <sbb-editor-node-search-view-component #nodeSearch></sbb-editor-node-search-view-component>
+    <sbb-label>{{ "app.view.editor-search-view-component.select-node" | translate }}</sbb-label>
+    <sbb-editor-node-search-view-component
+      [resetSignal]="resetSignal"
+      (isEmptyChange)="onNodeSearchEmptyChange($event)"
+    ></sbb-editor-node-search-view-component>
+  </sbb-expansion-panel>
 
-    <button
-      sbb-secondary-button
-      class="sbb-mt-m"
-      type="button"
-      [disabled]="!nodeSearch.canResetSearch()"
-      [title]="'app.view.editor-search-view-component.reset' | translate"
-      (click)="nodeSearch.resetSearch()"
+  <sbb-expansion-panel [expanded]="true">
+    <sbb-expansion-panel-header
+      >{{ "app.view.editor-search-view-component.navigate" | translate
+      }}</sbb-expansion-panel-header
     >
-      {{ "app.view.editor-search-view-component.reset" | translate }}
-    </button>
+
+    <sbb-label>{{ "app.view.editor-search-view-component.select-trainrun" | translate }}</sbb-label>
+    <sbb-editor-trainrun-search-view-component
+      [resetSignal]="resetSignal"
+      (isEmptyChange)="onTrainrunSearchEmptyChange($event)"
+    ></sbb-editor-trainrun-search-view-component>
   </sbb-expansion-panel>
 </sbb-accordion>
+
+<div style="transform: translate(24px, 10px)">
+  <button
+    sbb-secondary-button
+    class="sbb-mt-m"
+    [disabled]="allSearchFieldsEmpty()"
+    [title]="'app.view.editor-search-view-component.clear-all-search-fields' | translate"
+    (click)="onResetAllSearchFields()"
+  >
+    {{ "app.view.editor-search-view-component.clear-all-search-fields" | translate }}
+  </button>
+</div>

--- a/src/app/view/editor-search-view/editor-search-view-component.html
+++ b/src/app/view/editor-search-view/editor-search-view-component.html
@@ -1,0 +1,11 @@
+<h2 class="SummaryTitle">{{ "app.view.editor-search-view-component.search" | translate }}</h2>
+
+<sbb-accordion [multi]="true">
+  <sbb-expansion-panel [expanded]="true">
+    <sbb-expansion-panel-header
+      >{{ "app.view.editor-search-view-component.goto" | translate }}</sbb-expansion-panel-header
+    >
+    <sbb-label>{{ "app.view.editor-search-view-component.node" | translate }}</sbb-label>
+    <br />
+  </sbb-expansion-panel>
+</sbb-accordion>

--- a/src/app/view/editor-search-view/editor-search-view-component.html
+++ b/src/app/view/editor-search-view/editor-search-view-component.html
@@ -5,7 +5,7 @@
     <sbb-expansion-panel-header
       >{{ "app.view.editor-search-view-component.goto" | translate }}</sbb-expansion-panel-header
     >
-    <sbb-label>{{ "app.view.editor-search-view-component.node" | translate }}</sbb-label>
-    <br />
+
+    <sbb-editor-node-search-view-component></sbb-editor-node-search-view-component>
   </sbb-expansion-panel>
 </sbb-accordion>

--- a/src/app/view/editor-search-view/editor-search-view-component.html
+++ b/src/app/view/editor-search-view/editor-search-view-component.html
@@ -6,6 +6,17 @@
       >{{ "app.view.editor-search-view-component.goto" | translate }}</sbb-expansion-panel-header
     >
 
-    <sbb-editor-node-search-view-component></sbb-editor-node-search-view-component>
+    <sbb-editor-node-search-view-component #nodeSearch></sbb-editor-node-search-view-component>
+
+    <button
+      sbb-secondary-button
+      class="sbb-mt-m"
+      type="button"
+      [disabled]="!nodeSearch.canResetSearch()"
+      [title]="'app.view.editor-search-view-component.reset' | translate"
+      (click)="nodeSearch.resetSearch()"
+    >
+      {{ "app.view.editor-search-view-component.reset" | translate }}
+    </button>
   </sbb-expansion-panel>
 </sbb-accordion>

--- a/src/app/view/editor-search-view/editor-search-view-component.scss
+++ b/src/app/view/editor-search-view/editor-search-view-component.scss
@@ -1,0 +1,3 @@
+@use "../../../variables" as *;
+@use "./../../view/editor-filter-view/editor-filter-view.component.scss";
+@use "../rastering/definitions" as *;

--- a/src/app/view/editor-search-view/editor-search-view-component.scss
+++ b/src/app/view/editor-search-view/editor-search-view-component.scss
@@ -1,3 +1,8 @@
 @use "../../../variables" as *;
 @use "./../../view/editor-filter-view/editor-filter-view.component.scss";
 @use "../rastering/definitions" as *;
+
+:host {
+  overflow-x: hidden;
+  overflow-y: hidden;
+}

--- a/src/app/view/editor-search-view/editor-search-view-component.ts
+++ b/src/app/view/editor-search-view/editor-search-view-component.ts
@@ -1,0 +1,12 @@
+import {Component} from "@angular/core";
+import {UiInteractionService} from "../../services/ui/ui.interaction.service";
+
+@Component({
+  selector: "sbb-editor-search-view-component",
+  templateUrl: "./editor-search-view-component.html",
+  styleUrls: ["./editor-search-view-component.scss"],
+  standalone: false,
+})
+export class EditorSearchViewComponent {
+  constructor(private uiInteractionService: UiInteractionService) {}
+}

--- a/src/app/view/editor-search-view/editor-search-view-component.ts
+++ b/src/app/view/editor-search-view/editor-search-view-component.ts
@@ -1,4 +1,4 @@
-import {Component, inject} from "@angular/core";
+import {Component} from "@angular/core";
 
 @Component({
   selector: "sbb-editor-search-view-component",
@@ -7,5 +7,25 @@ import {Component, inject} from "@angular/core";
   standalone: false,
 })
 export class EditorSearchViewComponent {
+  resetSignal = 0;
+  nodeSearchEmpty = true;
+  trainrunSearchEmpty = true;
+
   constructor() {}
+
+  allSearchFieldsEmpty(): boolean {
+    return this.nodeSearchEmpty && this.trainrunSearchEmpty;
+  }
+
+  onResetAllSearchFields(): void {
+    this.resetSignal += 1;
+  }
+
+  onNodeSearchEmptyChange(isEmpty: boolean): void {
+    this.nodeSearchEmpty = isEmpty;
+  }
+
+  onTrainrunSearchEmptyChange(isEmpty: boolean): void {
+    this.trainrunSearchEmpty = isEmpty;
+  }
 }

--- a/src/app/view/editor-search-view/editor-search-view-component.ts
+++ b/src/app/view/editor-search-view/editor-search-view-component.ts
@@ -1,5 +1,4 @@
-import {Component} from "@angular/core";
-import {UiInteractionService} from "../../services/ui/ui.interaction.service";
+import {Component, inject} from "@angular/core";
 
 @Component({
   selector: "sbb-editor-search-view-component",
@@ -8,5 +7,5 @@ import {UiInteractionService} from "../../services/ui/ui.interaction.service";
   standalone: false,
 })
 export class EditorSearchViewComponent {
-  constructor(private uiInteractionService: UiInteractionService) {}
+  constructor() {}
 }

--- a/src/app/view/editor-search-view/editor-trainrun-search-view-component/editor-trainrun-search-view-component.html
+++ b/src/app/view/editor-search-view/editor-trainrun-search-view-component/editor-trainrun-search-view-component.html
@@ -1,0 +1,47 @@
+<sbb-search
+  (search)="onSearch()"
+  aria-label="{{ 'app.view.editor-search-view-component.select-trainrun' | translate }}"
+>
+  <input
+    sbbInput
+    [placeholder]="'app.view.editor-search-view-component.search-trainrun' | translate"
+    [formControl]="searchControl"
+    [sbbAutocomplete]="auto"
+  />
+</sbb-search>
+<sbb-autocomplete #auto="sbbAutocomplete" [displayWith]="displayTrainrun">
+  @for (option of filteredTrainruns; track option) {
+  <sbb-option [value]="option">{{ transformTrainrunName(option) }}</sbb-option>
+  }
+</sbb-autocomplete>
+
+@if (searchResults.length === 1 && orderedNodeEntries.length > 0) {
+<div
+  #trainrunResultsList
+  class="search-results-list"
+  [class.dragging]="isDraggingResults"
+  (mousedown)="onResultListMouseDown($event, trainrunResultsList)"
+>
+  @for (entry of orderedNodeEntries; track entry.node.getId(); let last = $last) {
+  <div class="timeline-row">
+    <div class="timeline-marker-column">
+      <span class="pearl"></span>
+    </div>
+    <span
+      class="smallstation"
+      [title]="transformNodeName(entry.node)"
+      (click)="onOrderedNodeClick(entry.node)"
+    >
+      {{ transformNodeName(entry.node) }}
+    </span>
+  </div>
+
+  @if (!last && !entry.hasGapAfter) {
+  <div class="connector-row">
+    <span class="connector"></span>
+  </div>
+  } @else if (entry.hasGapAfter) {
+  <div class="timeline-gap"></div>
+  } }
+</div>
+}

--- a/src/app/view/editor-search-view/editor-trainrun-search-view-component/editor-trainrun-search-view-component.html
+++ b/src/app/view/editor-search-view/editor-trainrun-search-view-component/editor-trainrun-search-view-component.html
@@ -22,17 +22,17 @@
   [class.dragging]="isDraggingResults"
   (mousedown)="onResultListMouseDown($event, trainrunResultsList)"
 >
-  @for (entry of orderedNodeEntries; track entry.node.getId(); let last = $last) {
+  @for (entry of orderedNodeEntries; track $index; let last = $last) {
   <div class="timeline-row">
     <div class="timeline-marker-column">
       <span class="pearl"></span>
     </div>
     <span
       class="smallstation"
-      [title]="transformNodeName(entry.node)"
-      (click)="onOrderedNodeClick(entry.node)"
+      [title]="transformNodeEntryName(entry)"
+      (click)="onOrderedNodeClick(entry)"
     >
-      {{ transformNodeName(entry.node) }}
+      {{ transformNodeEntryName(entry) }}
     </span>
   </div>
 

--- a/src/app/view/editor-search-view/editor-trainrun-search-view-component/editor-trainrun-search-view-component.scss
+++ b/src/app/view/editor-search-view/editor-trainrun-search-view-component/editor-trainrun-search-view-component.scss
@@ -1,0 +1,76 @@
+@use "../../../../variables" as *;
+@use "./../../../view/editor-filter-view/editor-filter-view.component.scss";
+@use "../../rastering/definitions" as *;
+
+.search-results-list {
+  margin-top: 0.5rem;
+  max-height: 405px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-top: 4px;
+}
+
+.search-results-list.dragging {
+  user-select: none;
+}
+
+.timeline-row {
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+  min-height: 18px;
+}
+
+.timeline-marker-column {
+  width: 9px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 9px;
+}
+
+.connector-row {
+  width: 9px;
+  display: flex;
+  justify-content: center;
+  margin-left: 0;
+  height: 4px;
+  transform: translateY(-5px);
+}
+
+span.smallstation {
+  cursor: pointer;
+  color: var(--sbb-form-input-color);
+  font-size: var(--sbb-font-size);
+  border: 5px solid none;
+  margin-left: 4px;
+  font-weight: light;
+  user-select: none;
+}
+
+span.smallstation:hover {
+  font-weight: bolder;
+  color: var(--COLOR_Edit);
+}
+
+.pearl {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--sbb-color-granite);
+}
+
+.connector {
+  display: inline-block;
+  width: 2px;
+  height: 32px;
+  background: var(--sbb-color-granite);
+  transform: translateY(-8px);
+}
+
+.timeline-gap {
+  height: 6px;
+}

--- a/src/app/view/editor-search-view/editor-trainrun-search-view-component/editor-trainrun-search-view-component.ts
+++ b/src/app/view/editor-search-view/editor-trainrun-search-view-component/editor-trainrun-search-view-component.ts
@@ -1,0 +1,315 @@
+import {
+  Component,
+  EventEmitter,
+  HostListener,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  Output,
+  SimpleChanges,
+} from "@angular/core";
+import {FilterService} from "../../../services/ui/filter.service";
+import {takeUntil} from "rxjs/operators";
+import {Subject} from "rxjs";
+import {Trainrun} from "../../../models/trainrun.model";
+import {TrainrunService} from "../../../services/data/trainrun.service";
+import {TrainrunSectionService} from "../../../services/data/trainrunsection.service";
+import {UiInteractionService} from "../../../services/ui/ui.interaction.service";
+import {FormControl} from "@angular/forms";
+import {
+  LoadPerlenketteService,
+  OrderedTrainrunNodeEntry,
+} from "../../../perlenkette/service/load-perlenkette.service";
+import {Node} from "../../../models/node.model";
+import {Vec2D} from "../../../utils/vec2D";
+
+@Component({
+  selector: "sbb-editor-trainrun-search-view-component",
+  templateUrl: "./editor-trainrun-search-view-component.html",
+  styleUrls: ["./editor-trainrun-search-view-component.scss"],
+  standalone: false,
+})
+export class EditorTrainrunSearchViewComponent implements OnInit, OnDestroy, OnChanges {
+  private static readonly FILTER_PANEL_ID = "cd-layout-filter";
+
+  @Input() resetSignal = 0;
+  @Output() isEmptyChange = new EventEmitter<boolean>();
+
+  searchControl = new FormControl<string | Trainrun | null>("");
+  searchResults: Trainrun[] = [];
+  orderedNodeEntries: OrderedTrainrunNodeEntry[] = [];
+  readonly displayTrainrun = (value: string | Trainrun | null): string =>
+    this.getDisplayValue(value);
+
+  private destroyed = new Subject<void>();
+  allSearchableTrainruns: Trainrun[] = [];
+  filteredTrainruns: Trainrun[] = [];
+  isDraggingResults = false;
+
+  private dragStartY = 0;
+  private dragStartScrollTop = 0;
+  private activeResultsList: HTMLElement | null = null;
+
+  constructor(
+    private trainrunService: TrainrunService,
+    private trainrunSectionService: TrainrunSectionService,
+    private uiInteractionService: UiInteractionService,
+    private loadPerlenketteService: LoadPerlenketteService,
+    private filterService: FilterService,
+  ) {
+    this.allSearchableTrainruns = this.trainrunService
+      .getTrainruns()
+      .filter((trainrun) => this.filterService.filterTrainrun(trainrun));
+    this.filteredTrainruns = this.filterTrainruns(this.searchControl.value).sort((a, b) =>
+      this.getTrainrunSearchValue(a).localeCompare(this.getTrainrunSearchValue(b)),
+    );
+  }
+
+  ngOnInit(): void {
+    this.trainrunService.trainruns
+      .pipe(takeUntil(this.destroyed))
+      .subscribe((trainruns: Trainrun[]) => {
+        this.allSearchableTrainruns = trainruns.filter((trainrun) =>
+          this.filterService.filterTrainrun(trainrun),
+        );
+        this.filteredTrainruns = this.filterTrainruns(this.searchControl.value).sort((a, b) =>
+          this.getTrainrunSearchValue(a).localeCompare(this.getTrainrunSearchValue(b)),
+        );
+        this.orderedNodeEntries = this.updateOrderedNodeEntries();
+        if (!this.trainrunService.getSelectedTrainrun()) {
+          this.searchControl.setValue(null);
+        } else {
+          const currentValue = this.searchControl.value;
+          if (currentValue instanceof Trainrun) {
+            if (this.trainrunService.getSelectedTrainrun().getId() !== currentValue.getId()) {
+              this.searchControl.setValue(this.trainrunService.getSelectedTrainrun());
+              this.search();
+            }
+          } else {
+            this.searchControl.setValue(this.trainrunService.getSelectedTrainrun());
+            this.search();
+          }
+        }
+      });
+
+    this.trainrunSectionService.trainrunSections.pipe(takeUntil(this.destroyed)).subscribe(() => {
+      this.allSearchableTrainruns = this.trainrunService
+        .getTrainruns()
+        .filter((trainrun) => this.filterService.filterTrainrun(trainrun));
+      this.filteredTrainruns = this.filterTrainruns(this.searchControl.value).sort((a, b) =>
+        this.getTrainrunSearchValue(a).localeCompare(this.getTrainrunSearchValue(b)),
+      );
+      this.orderedNodeEntries = this.updateOrderedNodeEntries();
+    });
+
+    this.filterService.filter.pipe(takeUntil(this.destroyed)).subscribe(() => {
+      this.allSearchableTrainruns = this.trainrunService
+        .getTrainruns()
+        .filter((trainrun) => this.filterService.filterTrainrun(trainrun));
+      this.filteredTrainruns = this.filterTrainruns(this.searchControl.value).sort((a, b) =>
+        this.getTrainrunSearchValue(a).localeCompare(this.getTrainrunSearchValue(b)),
+      );
+      this.orderedNodeEntries = this.updateOrderedNodeEntries();
+    });
+
+    this.searchControl.valueChanges.pipe(takeUntil(this.destroyed)).subscribe((value) => {
+      this.filteredTrainruns = this.filterTrainruns(value).sort((a, b) =>
+        this.getTrainrunSearchValue(a).localeCompare(this.getTrainrunSearchValue(b)),
+      );
+      this.emitIsEmptyState();
+    });
+
+    this.emitIsEmptyState();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes["resetSignal"] && !changes["resetSignal"].firstChange) {
+      this.clearSearch();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.stopDragScroll();
+    this.destroyed.next();
+    this.destroyed.complete();
+  }
+
+  onResultListMouseDown(event: MouseEvent, listElement: HTMLElement): void {
+    if (event.button !== 0) {
+      return;
+    }
+
+    // Dragging is enabled only if the list can actually scroll.
+    if (listElement.scrollHeight <= listElement.clientHeight) {
+      return;
+    }
+
+    this.isDraggingResults = true;
+    this.activeResultsList = listElement;
+    this.dragStartY = event.clientY;
+    this.dragStartScrollTop = listElement.scrollTop;
+    event.preventDefault();
+  }
+
+  @HostListener("document:mousemove", ["$event"])
+  onDocumentMouseMove(event: MouseEvent): void {
+    if (!this.isDraggingResults || !this.activeResultsList) {
+      return;
+    }
+
+    const deltaY = event.clientY - this.dragStartY;
+    this.activeResultsList.scrollTop = this.dragStartScrollTop + deltaY;
+  }
+
+  @HostListener("document:mouseup")
+  onDocumentMouseUp(): void {
+    this.stopDragScroll();
+  }
+
+  onSearch() {
+    this.search();
+    if (this.searchResults.length === 1) {
+      this.onSearchResultClick(this.searchControl.value as Trainrun);
+    }
+  }
+
+  onSearchResultClick(trainrun: Trainrun): void {
+    this.trainrunService.setTrainrunAsSelected(trainrun.getId());
+    this.orderedNodeEntries = this.updateOrderedNodeEntries();
+    const firstNode = this.orderedNodeEntries.at(0)?.node;
+    if (firstNode) {
+      const offset = this.getNetzgrafikOffsetForElementRightEdge(
+        EditorTrainrunSearchViewComponent.FILTER_PANEL_ID,
+      );
+      this.uiInteractionService.gotoNode(firstNode, offset);
+    }
+  }
+
+  updateOrderedNodeEntries() {
+    if (this.trainrunService.getSelectedTrainrun()) {
+      return this.loadPerlenketteService.getOrderedNodeEntriesForTrainrun(
+        this.trainrunService.getSelectedTrainrun(),
+      );
+    }
+    return [];
+  }
+
+  onOrderedNodeClick(node: Node): void {
+    const offset = this.getNetzgrafikOffsetForElementRightEdge(
+      EditorTrainrunSearchViewComponent.FILTER_PANEL_ID,
+    );
+    this.uiInteractionService.gotoNode(node, offset);
+  }
+
+  getTrainrunSearchValue(trainrun: Trainrun): string {
+    if (trainrun) {
+      const category = trainrun.getCategoryShortName() ?? "";
+      const title = trainrun.getTitle() ?? "";
+
+      return `${category}${title}`.trim();
+    }
+
+    return "";
+  }
+
+  transformTrainrunName(trainrun: Trainrun): string {
+    return this.getTrainrunSearchValue(trainrun);
+  }
+
+  transformNodeName(node: Node): string {
+    const betriebspunktName = node.getBetriebspunktName() ?? "";
+    const fullName = node.getFullName() ?? "";
+    return `${betriebspunktName} (${fullName})`;
+  }
+
+  private search() {
+    if (this.searchControl.value instanceof Trainrun) {
+      this.searchResults = [this.searchControl.value];
+      this.trainrunService.setTrainrunAsSelected(this.searchResults[0].getId());
+      this.orderedNodeEntries = this.updateOrderedNodeEntries();
+      return;
+    }
+
+    this.searchResults = this.filterTrainruns(this.searchControl.value).sort((a, b) =>
+      this.getTrainrunSearchValue(a).localeCompare(this.getTrainrunSearchValue(b)),
+    );
+
+    if (this.searchResults.length === 1) {
+      const trainrun = this.searchResults[0];
+      this.trainrunService.setTrainrunAsSelected(trainrun.getId());
+      this.orderedNodeEntries = this.updateOrderedNodeEntries();
+    }
+  }
+
+  private filterTrainruns(value: string | Trainrun | null): Trainrun[] {
+    const searchTerm = this.getSearchTerm(value);
+    if (!searchTerm) {
+      return this.allSearchableTrainruns.slice(0, 10);
+    }
+
+    return this.allSearchableTrainruns.filter((trainrun) =>
+      this.matchesTrainrun(trainrun, searchTerm),
+    );
+  }
+
+  private getSearchTerm(value: string | Trainrun | null): string {
+    if (typeof value === "string") {
+      return value.trim().toLocaleUpperCase();
+    }
+
+    if (value instanceof Trainrun) {
+      return this.getTrainrunSearchValue(value).toLocaleUpperCase();
+    }
+
+    return "";
+  }
+
+  private getDisplayValue(value: string | Trainrun | null): string {
+    if (value instanceof Trainrun) {
+      return this.getTrainrunSearchValue(value);
+    }
+
+    return value ?? "";
+  }
+
+  private matchesTrainrun(trainrun: Trainrun, searchTerm: string): boolean {
+    const category = (trainrun.getCategoryShortName() ?? "").toLocaleUpperCase();
+    const title = (trainrun.getTitle() ?? "").toLocaleUpperCase();
+    const compactLabel = this.getTrainrunSearchValue(trainrun).toLocaleUpperCase();
+
+    return (
+      category.includes(searchTerm) ||
+      title.includes(searchTerm) ||
+      compactLabel.includes(searchTerm)
+    );
+  }
+
+  private getNetzgrafikOffsetForElementRightEdge(elementId: string): Vec2D {
+    const element = document.getElementById(elementId);
+    const offsetXPx = element?.getBoundingClientRect().right ?? 0;
+    return this.uiInteractionService.getNetzgrafikOffsetFromScreenPx(offsetXPx, 0);
+  }
+
+  private clearSearch(): void {
+    this.searchControl.setValue("");
+    this.searchResults = [];
+    this.orderedNodeEntries = [];
+    this.trainrunService.unselectAllTrainruns();
+    this.filteredTrainruns = this.filterTrainruns(this.searchControl.value).sort((a, b) =>
+      this.getTrainrunSearchValue(a).localeCompare(this.getTrainrunSearchValue(b)),
+    );
+    this.emitIsEmptyState();
+  }
+
+  private emitIsEmptyState(): void {
+    const value = this.searchControl.value;
+    const isEmpty = value === null || (typeof value === "string" && value.trim() === "");
+    this.isEmptyChange.emit(isEmpty);
+  }
+
+  private stopDragScroll(): void {
+    this.isDraggingResults = false;
+    this.activeResultsList = null;
+  }
+}

--- a/src/app/view/editor-search-view/editor-trainrun-search-view-component/editor-trainrun-search-view-component.ts
+++ b/src/app/view/editor-search-view/editor-trainrun-search-view-component/editor-trainrun-search-view-component.ts
@@ -14,7 +14,10 @@ import {takeUntil} from "rxjs/operators";
 import {Subject} from "rxjs";
 import {Trainrun} from "../../../models/trainrun.model";
 import {TrainrunService} from "../../../services/data/trainrun.service";
-import {TrainrunSectionService} from "../../../services/data/trainrunsection.service";
+import {
+  InformSelectedTrainrunClick,
+  TrainrunSectionService,
+} from "../../../services/data/trainrunsection.service";
 import {UiInteractionService} from "../../../services/ui/ui.interaction.service";
 import {FormControl} from "@angular/forms";
 import {
@@ -22,6 +25,7 @@ import {
   OrderedTrainrunNodeEntry,
 } from "../../../perlenkette/service/load-perlenkette.service";
 import {Node} from "../../../models/node.model";
+import {NodeService} from "../../../services/data/node.service";
 import {Vec2D} from "../../../utils/vec2D";
 
 @Component({
@@ -57,6 +61,7 @@ export class EditorTrainrunSearchViewComponent implements OnInit, OnDestroy, OnC
     private uiInteractionService: UiInteractionService,
     private loadPerlenketteService: LoadPerlenketteService,
     private filterService: FilterService,
+    private nodeService: NodeService,
   ) {
     this.allSearchableTrainruns = this.trainrunService
       .getTrainruns()
@@ -177,25 +182,53 @@ export class EditorTrainrunSearchViewComponent implements OnInit, OnDestroy, OnC
   onSearchResultClick(trainrun: Trainrun): void {
     this.trainrunService.setTrainrunAsSelected(trainrun.getId());
     this.orderedNodeEntries = this.updateOrderedNodeEntries();
-    const firstNode = this.orderedNodeEntries.at(0)?.node;
-    if (firstNode) {
-      const offset = this.getNetzgrafikOffsetForElementRightEdge(
-        EditorTrainrunSearchViewComponent.FILTER_PANEL_ID,
-      );
-      this.uiInteractionService.gotoNode(firstNode, offset);
+    if (this.orderedNodeEntries.length === 0) {
+      return;
+    }
+    const firstEntry = this.orderedNodeEntries.at(0);
+    if (firstEntry) {
+      this.onOrderedNodeClick(firstEntry);
     }
   }
 
   updateOrderedNodeEntries() {
     if (this.trainrunService.getSelectedTrainrun()) {
-      return this.loadPerlenketteService.getOrderedNodeEntriesForTrainrun(
+      const data = this.loadPerlenketteService.getOrderedNodeEntriesForTrainrun(
         this.trainrunService.getSelectedTrainrun(),
       );
+      console.log("Ordered Node Entries for Trainrun:", data);
+      return data;
     }
     return [];
   }
 
-  onOrderedNodeClick(node: Node): void {
+  private gotoTrainrunSection(sectionId: number): void {
+    const ts = this.trainrunService.getSelectedTrainrun();
+    const trainrunSection = this.trainrunSectionService.getTrainrunSectionFromId(sectionId);
+    if (!trainrunSection) {
+      return;
+    }
+
+    if (ts.getId() !== trainrunSection.getTrainrunId()) {
+      this.trainrunService.setTrainrunAsSelected(trainrunSection.getTrainrunId());
+    }
+    const param: InformSelectedTrainrunClick = {
+      trainrunSectionId: trainrunSection.getId(),
+      open: false,
+    };
+    this.trainrunSectionService.clickSelectedTrainrunSection(param);
+  }
+
+  onOrderedNodeClick(entry: OrderedTrainrunNodeEntry): void {
+    const node = this.nodeService.getNodeFromId(entry.nodeId);
+    if (!node) {
+      return;
+    }
+
+    if (entry.trainrunSectionId !== undefined) {
+      this.gotoTrainrunSection(entry.trainrunSectionId);
+    }
+
     const offset = this.getNetzgrafikOffsetForElementRightEdge(
       EditorTrainrunSearchViewComponent.FILTER_PANEL_ID,
     );
@@ -221,6 +254,14 @@ export class EditorTrainrunSearchViewComponent implements OnInit, OnDestroy, OnC
     const betriebspunktName = node.getBetriebspunktName() ?? "";
     const fullName = node.getFullName() ?? "";
     return `${betriebspunktName} (${fullName})`;
+  }
+
+  transformNodeEntryName(entry: OrderedTrainrunNodeEntry): string {
+    const node = this.nodeService.getNodeFromId(entry.nodeId);
+    if (!node) {
+      return `${entry.nodeId}`;
+    }
+    return this.transformNodeName(node);
   }
 
   private search() {

--- a/src/app/view/filter-main-side-view/filter-main-side-view.component.html
+++ b/src/app/view/filter-main-side-view/filter-main-side-view.component.html
@@ -8,6 +8,7 @@
   <div filter class="col-padding">
     <sbb-variant-view *ngIf="showVariantInfo"></sbb-variant-view>
     <sbb-editor-filter-view *ngIf="showEditorFilter"></sbb-editor-filter-view>
+    <sbb-editor-search-view-component *ngIf="showEditorSearch"></sbb-editor-search-view-component>
     <sbb-editor-edit-tools-view-component
       *ngIf="showEditorEditTools"
     ></sbb-editor-edit-tools-view-component>

--- a/src/app/view/filter-main-side-view/filter-main-side-view.component.ts
+++ b/src/app/view/filter-main-side-view/filter-main-side-view.component.ts
@@ -11,6 +11,7 @@ import {NodeService} from "../../services/data/node.service";
 export enum FilterWindowType {
   VARIANT_INFO = "variant-info",
   EDITOR_FILTER = "editor-filter",
+  SEARCH = "search",
   PROPERTIES = "properties",
   EDIT_TOOLS = "edit-tools",
   TOOLS = "tools",
@@ -47,6 +48,10 @@ export class FilterMainSideViewComponent implements OnInit, OnDestroy {
 
   get showEditorFilter(): boolean {
     return this.type === FilterWindowType.EDITOR_FILTER;
+  }
+
+  get showEditorSearch(): boolean {
+    return this.type === FilterWindowType.SEARCH;
   }
 
   get showEditorEditTools(): boolean {

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -428,6 +428,11 @@
         "search": "Suchen",
         "goto": "Gehe zu",
         "search-node": "Suche nach Knoten",
+        "navigate": "Navigieren",
+        "select-node": "Knoten auswählen",
+        "search-trainrun": "Suche nach Zugfahrten",
+        "select-trainrun": "Zugfahrt auswählen",
+        "clear-all-search-fields": "Alle Suchfelder zurücksetzen",
         "reset": "Suche zurücksetzen"
       },
       "editor-menu": {

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -427,7 +427,7 @@
       "editor-search-view-component": {
         "search": "Suchen",
         "goto": "Gehe zu",
-        "node": "Knoten"
+        "search-node": "Suche nach Knoten"
       },
       "editor-menu": {
         "save-changes": "Speichere Änderungen",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -424,6 +424,11 @@
           "hide": "ausblenden"
         }
       },
+      "editor-search-view-component": {
+        "search": "Suchen",
+        "goto": "Gehe zu",
+        "node": "Knoten"
+      },
       "editor-menu": {
         "save-changes": "Speichere Änderungen",
         "changes-saved": "Änderungen gespeichert",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -427,7 +427,8 @@
       "editor-search-view-component": {
         "search": "Suchen",
         "goto": "Gehe zu",
-        "search-node": "Suche nach Knoten"
+        "search-node": "Suche nach Knoten",
+        "reset": "Suche zurücksetzen"
       },
       "editor-menu": {
         "save-changes": "Speichere Änderungen",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -424,6 +424,11 @@
           "hide": "hide"
         }
       },
+      "editor-search-view-component": {
+        "search": "Search",
+        "goto": "Goto",
+        "node": "Node"
+      },
       "editor-menu": {
         "save-changes": "Save changes",
         "changes-saved": "Changes saved",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -427,7 +427,7 @@
       "editor-search-view-component": {
         "search": "Search",
         "goto": "Goto",
-        "node": "Node"
+        "search-node": "Search node"
       },
       "editor-menu": {
         "save-changes": "Save changes",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -428,6 +428,11 @@
         "search": "Search",
         "goto": "Goto",
         "search-node": "Search node",
+        "navigate": "Navigate",
+        "select-node": "Select node",
+        "search-trainrun": "Search trainrun",
+        "select-trainrun": "Select trainrun",
+        "clear-all-search-fields": "Reset all search fields",
         "reset": "Reset search"
       },
       "editor-menu": {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -427,7 +427,8 @@
       "editor-search-view-component": {
         "search": "Search",
         "goto": "Goto",
-        "search-node": "Search node"
+        "search-node": "Search node",
+        "reset": "Reset search"
       },
       "editor-menu": {
         "save-changes": "Save changes",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -424,6 +424,11 @@
           "hide": "masquer"
         }
       },
+      "editor-search-view-component": {
+        "search": "Rechercher",
+        "goto": "Aller à",
+        "node": "Noeud"
+      },
       "editor-menu": {
         "save-changes": "Enregistrer les modifications",
         "changes-saved": "Modifications enregistrées",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -427,7 +427,8 @@
       "editor-search-view-component": {
         "search": "Rechercher",
         "goto": "Aller à",
-        "search-node": "Rechercher un noeud"
+        "search-node": "Rechercher un noeud",
+        "reset": "Réinitialiser la recherche"
       },
       "editor-menu": {
         "save-changes": "Enregistrer les modifications",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -427,7 +427,7 @@
       "editor-search-view-component": {
         "search": "Rechercher",
         "goto": "Aller à",
-        "node": "Noeud"
+        "search-node": "Rechercher un noeud"
       },
       "editor-menu": {
         "save-changes": "Enregistrer les modifications",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -428,6 +428,11 @@
         "search": "Rechercher",
         "goto": "Aller à",
         "search-node": "Rechercher un noeud",
+        "navigate": "Naviguer",
+        "select-node": "Sélectionner un noeud",
+        "search-trainrun": "Rechercher un trajet de train",
+        "select-trainrun": "Sélectionner un trajet de train",
+        "clear-all-search-fields": "Effacer tous les champs de recherche",
         "reset": "Réinitialiser la recherche"
       },
       "editor-menu": {


### PR DESCRIPTION
This new feature allows user to navigate very quickly throught the Netzgrafik-Editor. The user can either search for  a trainrun.

Adds a new trainrun search-component to the left-side search panel  

This PR replaces https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/pull/1264 and extends https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/pull/1287. 