### PR TITLE
fix(perlenkette): render and scroll correctly in Safari

### DIFF
--- a/src/app/perlenkette/perlenkette.component.html
+++ b/src/app/perlenkette/perlenkette.component.html
@@ -168,50 +168,42 @@
     <div class="sepdiv"></div>
   </div>
 
-  <div class="svg-container">
-    <svg
-      #svgPerlenkette
-      [attr.height]="contentHeight * 1.25"
-      [attr.width]="contentWidth"
-      (mousemove)="changeSvgMousePosition($event)"
-      [attr.viewBox]="getPerlenketteViewBox()"
+  <div
+    class="svg-container"
+    #svgPerlenkette
+    [style.height.px]="getViewportHeight()"
+    (mousemove)="changeSvgMousePosition($event)"
+  >
+    <div
+      class="drawing-container"
+      #drawingContainer
+      [style.transform]="getDrawingContainerTransform()"
     >
-      <foreignObject
-        #svgForeignObject
-        [attr.height]="renderedElementsHeight + 64"
-        [attr.width]="contentWidth"
-      >
-        <div class="drawing-container" #drawingContainer>
-          <ng-container *ngFor="let pathItem of perlenketteTrainrun.pathItems; index as idx">
-            <sbb-perlenkette-node
-              *ngIf="pathItem.isPerlenketteNode()"
-              [perlenketteTrainrun]="perlenketteTrainrun"
-              (signalIsBeingEdited)="signalIsBeingEdited($event)"
-              (signalHeightChanged)="signalHeightChanged($event, pathItem)"
-              [perlenketteNode]="pathItem.getPerlenketteNode()"
-              [isTopNode]="idx === 0"
-              [isBottomNode]="idx === perlenketteTrainrun.pathItems.length - 1"
-            >
-            </sbb-perlenkette-node>
-            <div
-              *ngIf="doSplitTrainrun(perlenketteTrainrun.pathItems, idx)"
-              style="height: 16px"
-            ></div>
-            <sbb-perlenkette-section
-              *ngIf="pathItem.isPerlenketteSection()"
-              [perlenketteSection]="pathItem.getPerlenketteSection()"
-              [perlenketteTrainrun]="perlenketteTrainrun"
-              (signalIsBeingEdited)="signalIsBeingEdited($event)"
-              (signalHeightChanged)="signalHeightChanged($event, pathItem)"
-              [showAllLockStates]="getShowAllLockStates()"
-              [notificationIsBeingEdited]="getSignalAllChildrenIsBeingEditedObservable()"
-              [isFirstSection]="isFirstSection(pathItem)"
-              [isLastSection]="isLastSection(pathItem)"
-            >
-            </sbb-perlenkette-section>
-          </ng-container>
-        </div>
-      </foreignObject>
-    </svg>
+      <ng-container *ngFor="let pathItem of perlenketteTrainrun.pathItems; index as idx">
+        <sbb-perlenkette-node
+          *ngIf="pathItem.isPerlenketteNode()"
+          [perlenketteTrainrun]="perlenketteTrainrun"
+          (signalIsBeingEdited)="signalIsBeingEdited($event)"
+          (signalHeightChanged)="signalHeightChanged($event, pathItem)"
+          [perlenketteNode]="pathItem.getPerlenketteNode()"
+          [isTopNode]="idx === 0"
+          [isBottomNode]="idx === perlenketteTrainrun.pathItems.length - 1"
+        >
+        </sbb-perlenkette-node>
+        <div *ngIf="doSplitTrainrun(perlenketteTrainrun.pathItems, idx)" style="height: 16px"></div>
+        <sbb-perlenkette-section
+          *ngIf="pathItem.isPerlenketteSection()"
+          [perlenketteSection]="pathItem.getPerlenketteSection()"
+          [perlenketteTrainrun]="perlenketteTrainrun"
+          (signalIsBeingEdited)="signalIsBeingEdited($event)"
+          (signalHeightChanged)="signalHeightChanged($event, pathItem)"
+          [showAllLockStates]="getShowAllLockStates()"
+          [notificationIsBeingEdited]="getSignalAllChildrenIsBeingEditedObservable()"
+          [isFirstSection]="isFirstSection(pathItem)"
+          [isLastSection]="isLastSection(pathItem)"
+        >
+        </sbb-perlenkette-section>
+      </ng-container>
+    </div>
   </div>
 </div>

--- a/src/app/perlenkette/perlenkette.component.scss
+++ b/src/app/perlenkette/perlenkette.component.scss
@@ -22,7 +22,11 @@
 .svg-container {
   display: flex;
   justify-content: center;
+  align-items: flex-start;
   width: 100%;
+  // The vertical scrolling is done by translating the .drawing-container,
+  // therefore the overflowing content has to be clipped here.
+  overflow: hidden;
 
   .drawing-container {
     display: flex;
@@ -30,6 +34,8 @@
     flex-direction: column;
     align-items: center;
     padding: 24px 0;
+    flex-shrink: 0;
+    will-change: transform;
   }
 }
 

--- a/src/app/perlenkette/perlenkette.component.ts
+++ b/src/app/perlenkette/perlenkette.component.ts
@@ -39,7 +39,7 @@ enum ShowTrainrunEditTab {
 })
 export class PerlenketteComponent implements AfterContentChecked, OnDestroy {
   perlenketteTrainrun: PerlenketteTrainrun;
-  @ViewChild("svgPerlenkette") svgPerlenkette: ElementRef<SVGSVGElement>;
+  @ViewChild("svgPerlenkette") svgPerlenkette: ElementRef<HTMLDivElement>;
   @ViewChild("drawingContainer") drawingContainer: ElementRef;
   @Input() sidebarElementHeight: number;
 
@@ -57,6 +57,8 @@ export class PerlenketteComponent implements AfterContentChecked, OnDestroy {
   private selectedPerlenketteConnection: PerlenketteConnection = undefined;
 
   private showAllLockStates = false;
+
+  private lastMouseClientY: number | undefined = undefined;
 
   public showTrainrunEditTab: ShowTrainrunEditTab = ShowTrainrunEditTab.sbb_trainrun_tab;
 
@@ -211,8 +213,18 @@ export class PerlenketteComponent implements AfterContentChecked, OnDestroy {
     this.destroyed$.complete();
   }
 
-  getPerlenketteViewBox(): string {
-    return "0 " + this.svgPoint.getY() + " " + this.contentWidth + " " + this.contentHeight;
+  getViewportHeight(): number {
+    return this.contentHeight * 1.25;
+  }
+
+  getDrawingContainerTransform(): string {
+    // Scrolling used to be done by moving the viewBox of a <svg> wrapping the content inside a
+    // <foreignObject>. Safari (WebKit) does not apply that viewBox transformation reliably to
+    // (positioned) html content inside a <foreignObject> - parts of the perlenkette stayed in
+    // place while the rest scrolled. Therefore the content is now plain html, scrolled with a
+    // css transform. The additional contentHeight * 0.125 keeps the former vertical centering
+    // (viewport height is 1.25 * contentHeight, viewBox height was contentHeight).
+    return "translateY(" + (this.contentHeight * 0.125 - this.svgPoint.getY()) + "px)";
   }
 
   showTrainrunName(): boolean {
@@ -250,9 +262,16 @@ export class PerlenketteComponent implements AfterContentChecked, OnDestroy {
 
   changeSvgMousePosition(event: MouseEvent) {
     if (event.buttons > 0) {
-      let currentY = this.svgPoint.getY();
-      currentY -= event.movementY;
-      this.updateSvgPointY(currentY);
+      // MouseEvent.movementY is not reported in the same unit by all browsers (physical,
+      // logical or css pixel). WebKit reports screen pixels, so dragging scrolls twice as
+      // fast on a retina display. Calculating the delta from clientY gives css pixels
+      // everywhere - this is also what the specification recommends.
+      const movementY =
+        this.lastMouseClientY === undefined ? 0 : event.clientY - this.lastMouseClientY;
+      this.lastMouseClientY = event.clientY;
+      this.updateSvgPointY(this.svgPoint.getY() - movementY);
+    } else {
+      this.lastMouseClientY = undefined;
     }
     event.stopPropagation();
   }


### PR DESCRIPTION
Fixes #1026

## Problem

When a trainrun is selected, the perlenkette is rendered torn apart in Safari and the nodes
(Betriebspunkte) are not aligned with the line and do not scroll along, while everything looks fine
in Chrome.

## Cause

The content was rendered inside a `<foreignObject>` and scrolled by moving the `viewBox` of the
wrapping `<svg>`. WebKit does not apply that viewBox transformation reliably to positioned html
content inside a `foreignObject`. The nodes use `position: relative` and therefore stayed in place
while the sections scrolled.

## Solution

- Removed the `<svg>` / `<foreignObject>` wrapper, the content is now plain html inside a viewport
  with `overflow: hidden`
- Scrolling is done with a css `transform`; the former vertical centering is kept, so the rendering
  in Chrome is unchanged
- The drag delta is derived from `clientY` instead of `MouseEvent.movementY`, because WebKit reports
  screen pixels there, which made dragging scroll twice as fast on retina displays

## Test

Manually verified in Safari and Chrome: select a trainrun, scroll with the mouse wheel and by
dragging.
