### PR TITLE
Move Connection.path to ConnectionsViewObject

### DIFF
--- a/src/app/models/connection.model.ts
+++ b/src/app/models/connection.model.ts
@@ -1,5 +1,4 @@
 import {ConnectionDto, WarningDto} from "../data-structures/technical.data.structures";
-import {Vec2D} from "../utils/vec2D";
 
 export class Connection {
   private static currentId = 0;
@@ -8,7 +7,6 @@ export class Connection {
   private port1Id: number;
   private port2Id: number;
 
-  private path: Vec2D[];
   private warning: WarningDto = null;
 
   private isSelected = false;
@@ -52,14 +50,6 @@ export class Connection {
 
   getPortId2(): number {
     return this.port2Id;
-  }
-
-  setPath(path: Vec2D[]) {
-    this.path = path;
-  }
-
-  getPath(): Vec2D[] {
-    return this.path;
   }
 
   setWarning(warningTitle: string, warningDescription = "") {

--- a/src/app/models/node.model.ts
+++ b/src/app/models/node.model.ts
@@ -328,12 +328,6 @@ export class Node {
     transition.setPath(SimpleTrainrunSectionRouter.routeTransition(this, port1, port2));
   }
 
-  computeConnectionRouting(connection: Connection) {
-    const port1 = this.getPort(connection.getPortId1());
-    const port2 = this.getPort(connection.getPortId2());
-    connection.setPath(SimpleTrainrunSectionRouter.routeConnection(this, port1, port2));
-  }
-
   addPort(alignment: PortAlignment, trainrunSection: TrainrunSection): number {
     const port = new Port();
     port.setPositionAlignment(alignment);
@@ -582,7 +576,6 @@ export class Node {
     const connection: Connection = new Connection();
     connection.setPort1Id(port1.getId());
     connection.setPort2Id(port2.getId());
-    this.computeConnectionRouting(connection);
     ConnectionValidator.validateConnection(connection, this);
     this.connections.push(connection);
   }
@@ -603,7 +596,6 @@ export class Node {
 
   updateConnectionsRouting() {
     this.connections.forEach((connection) => {
-      this.computeConnectionRouting(connection);
       ConnectionValidator.validateConnection(connection, this);
     });
   }

--- a/src/app/view/editor-main-view/data-views/connectionViewObject.ts
+++ b/src/app/view/editor-main-view/data-views/connectionViewObject.ts
@@ -1,9 +1,12 @@
 import {Connection} from "../../../models/connection.model";
 import {Node} from "../../../models/node.model";
+import {SimpleTrainrunSectionRouter} from "../../../services/util/trainrunsection.routing";
+import {Vec2D} from "../../../utils/vec2D";
 import {EditorView} from "./editor.view";
 
 export class ConnectionsViewObject {
   key: string;
+  readonly path: Vec2D[];
 
   constructor(
     private editorView: EditorView,
@@ -12,51 +15,44 @@ export class ConnectionsViewObject {
     displayConnectionPin1: boolean,
     displayConnectionPin2: boolean,
   ) {
-    this.key = ConnectionsViewObject.generateKey(
-      editorView,
-      connection,
-      displayConnectionPin1,
-      displayConnectionPin2,
-    );
+    const port1 = node.getPort(connection.getPortId1());
+    const port2 = node.getPort(connection.getPortId2());
+    this.path = SimpleTrainrunSectionRouter.routeConnection(node, port1, port2);
+    this.key = this.generateKey(displayConnectionPin1, displayConnectionPin2);
   }
 
-  static generateKey(
-    editorView: EditorView,
-    connection: Connection,
-    displayConnectionPin1: boolean,
-    displayConnectionPin2: boolean,
-  ): string {
+  private generateKey(displayConnectionPin1: boolean, displayConnectionPin2: boolean): string {
     let key =
       "#" +
-      connection.getId() +
+      this.connection.getId() +
       "@" +
-      connection.hasWarning() +
+      this.connection.hasWarning() +
       "_" +
-      connection.getPortId1() +
+      this.connection.getPortId1() +
       "_" +
-      connection.getPortId2() +
+      this.connection.getPortId2() +
       "_" +
-      connection.selected() +
+      this.connection.selected() +
       "_" +
-      connection.getPath()[0] +
+      this.path[0] +
       "_" +
-      connection.getPath()[1] +
+      this.path[1] +
       "_" +
-      connection.getPath()[2] +
+      this.path[2] +
       "_" +
-      connection.getPath()[3] +
+      this.path[3] +
       "_" +
       displayConnectionPin1 +
       "_" +
       displayConnectionPin2 +
       "_" +
-      editorView.isTemporaryDisableFilteringOfItemsInViewEnabled() +
+      this.editorView.isTemporaryDisableFilteringOfItemsInViewEnabled() +
       "_" +
-      editorView.getLevelOfDetail() +
+      this.editorView.getLevelOfDetail() +
       "_" +
-      editorView.trainrunSectionPreviewLineView.getVariantIsWritable();
+      this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable();
 
-    connection.getPath().forEach((p) => {
+    this.path.forEach((p) => {
       key += p.toString();
     });
     return key;

--- a/src/app/view/editor-main-view/data-views/connections.view.ts
+++ b/src/app/view/editor-main-view/data-views/connections.view.ts
@@ -132,9 +132,7 @@ export class ConnectionsView {
     drawingGroup
       .append(StaticDomTags.CONNECTION_LINE_SVG)
       .attr("class", StaticDomTags.CONNECTION_LINE_CLASS)
-      .attr("d", (c: ConnectionsViewObject) =>
-        D3Utils.getBezierCurveAsSVGString(c.connection.getPath()),
-      )
+      .attr("d", (c: ConnectionsViewObject) => D3Utils.getBezierCurveAsSVGString(c.path))
       .attr(StaticDomTags.CONNECTION_ID, (c: ConnectionsViewObject) => c.connection.getId())
       .classed(StaticDomTags.TAG_WARNING, (c: ConnectionsViewObject) => c.connection.hasWarning())
       .classed(
@@ -225,15 +223,16 @@ export class ConnectionsView {
     inputConnection.forEach((connection: Connection) => {
       const node: Node = this.editorView.getNodeFromConnection(connection);
       if (this.displayConnectionFilteredSelectedTrainrun(connection, node)) {
-        connectionsViewObjects.push(
-          new ConnectionsViewObject(
-            this.editorView,
-            connection,
-            node,
-            ConnectionsView.displayConnectionPinPort1(connection, node),
-            ConnectionsView.displayConnectionPinPort2(connection, node),
-          ),
+        const connectionViewObject = new ConnectionsViewObject(
+          this.editorView,
+          connection,
+          node,
+          ConnectionsView.displayConnectionPinPort1(connection, node),
+          ConnectionsView.displayConnectionPinPort2(connection, node),
         );
+        if (this.editorView.doCullCheckPositionsInViewport(connectionViewObject.path)) {
+          connectionsViewObjects.push(connectionViewObject);
+        }
       }
     });
     return connectionsViewObjects;
@@ -255,11 +254,7 @@ export class ConnectionsView {
   }
 
   displayConnections(inputConnections: Connection[]) {
-    const connections = inputConnections.filter(
-      (c) =>
-        this.editorView.doCullCheckPositionsInViewport(c.getPath()) &&
-        this.filterConnectionsToDisplay(c),
-    );
+    const connections = inputConnections.filter((c) => this.filterConnectionsToDisplay(c));
 
     const connectionsGroup = this.connectionsGroup
       .selectAll(StaticDomTags.CONNECTION_ROOT_CONTAINER_DOM_REF)

--- a/src/integration-testing/node.service.test.spec.ts
+++ b/src/integration-testing/node.service.test.spec.ts
@@ -7,6 +7,7 @@ import {Node} from "../app/models/node.model";
 import {TrainrunSection} from "../app/models/trainrunsection.model";
 import {PortAlignment} from "../app/data-structures/technical.data.structures";
 import {ConnectionValidator} from "../app/services/util/connection.validator";
+import {SimpleTrainrunSectionRouter} from "../app/services/util/trainrunsection.routing";
 import {ResourceService} from "../app/services/data/resource.service";
 import {LogService} from "../app/logger/log.service";
 import {LogPublishersService} from "../app/logger/log.publishers.service";
@@ -670,9 +671,12 @@ describe("NodeService Test", () => {
   it("connection test", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
     expect(trainrunSections.length).toBe(8);
-    const con = nodeService.getNodeFromId(2).getConnectionFromId(1);
+    const node = nodeService.getNodeFromId(2);
+    const con = node.getConnectionFromId(1);
     expect(con.getDto().id).toBe(1);
-    expect(con.getPath().length).toBe(4);
+    const port1 = node.getPort(con.getPortId1());
+    const port2 = node.getPort(con.getPortId2());
+    expect(SimpleTrainrunSectionRouter.routeConnection(node, port1, port2).length).toBe(4);
   });
 
   it("remove connection test", () => {


### PR DESCRIPTION
Closes #1223.

`Connection.path` was only ever read by the view layer (`connections.view.ts`, `connectionViewObject.ts`), so it belongs on `ConnectionsViewObject`, the same move already done for `TrainrunSection.path` → `TrainrunSectionViewObject.path`.

`Node.computeConnectionRouting()` is removed along with it. The model no longer computes or stores connection routing; `ConnectionsViewObject` now computes it once in its constructor via `SimpleTrainrunSectionRouter.routeConnection()` and exposes it as `path`. `Node.addConnectionAndComputeRouting()` and `Node.updateConnectionsRouting()` keep their `ConnectionValidator.validateConnection()` calls, which don't depend on the path.

`ConnectionsView.displayConnections()` used to viewport-cull raw `Connection`s via `getPath()` before building view objects. Since the path now only exists once a view object is built, the cull check moved into `createTransitionViewObjects()`, run against the already-computed `path` on each view object right after construction, instead of upfront on the raw connection list. No other behavioral change.

Updated the one test that read `Connection.getPath()` to compute the same routing directly via `SimpleTrainrunSectionRouter.routeConnection()`.

Verified:
- `npx tsc --noEmit`: same pre-existing unrelated errors as a clean `main` checkout (stale `@types/glob`/`minimatch` types, `src/types.ts` `.ts`-extension imports), nothing new.
- `ng lint`: clean on the changed files.
- `ng test -c ci`: full suite, 635 of 635 passing.
- `ng build --configuration=standalone`: clean.