### PR TITLE
feat(search): add node and trainrun search navigation

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -48,6 +48,7 @@ import {EditorNodeDetailViewComponent} from "./view/editor-side-view/editor-node
 import {EditorFilterViewComponent} from "./view/editor-filter-view/editor-filter-view.component";
 import {EditorSearchViewComponent} from "./view/editor-search-view/editor-search-view-component";
 import {EditorNodeSearchViewComponent} from "./view/editor-search-view/editor-node-search-view-component/editor-node-search-view-component";
+import {EditorTrainrunSearchViewComponent} from "./view/editor-search-view/editor-trainrun-search-view-component/editor-trainrun-search-view-component";
 import {EditorMenuComponent} from "./view/editor-menu/editor-menu.component";
 import {EditorSideViewComponent} from "./view/editor-side-view/editor-side-view.component";
 import {BaseDataDialogComponent} from "./view/dialogs/basedata-dialog/basedata-dialog.component";
@@ -136,6 +137,7 @@ import {TimeStepperComponent} from "./view/dialogs/trainrun-and-section-dialog/t
     EditorFilterViewComponent,
     EditorSearchViewComponent,
     EditorNodeSearchViewComponent,
+    EditorTrainrunSearchViewComponent,
     BaseDataDialogComponent,
     EditorMenuComponent,
     EditorSideViewComponent,

--- a/src/app/services/data/trainrun.service.ts
+++ b/src/app/services/data/trainrun.service.ts
@@ -32,6 +32,12 @@ import {Connection} from "../../models/connection.model";
 import {Operation, OperationType, TrainrunOperation} from "../../models/operation.model";
 import {TrainrunsectionHelper} from "../util/trainrunsection.helper";
 
+export interface OrderedTrainrunNodeEntry {
+  nodeId: number;
+  trainrunSectionId?: number;
+  hasGapAfter: boolean;
+}
+
 @Injectable({
   providedIn: "root",
 })
@@ -583,6 +589,79 @@ export class TrainrunService {
     const endNode1 = this.getEndNode(sourceNode, trainrunSection);
     const endNode2 = this.getEndNode(targetNode, trainrunSection);
     return {endNode1, endNode2};
+  }
+
+  getOrderedNodeEntriesForTrainrun(trainrun: Trainrun): OrderedTrainrunNodeEntry[] {
+    const entryGroups = this.getAllNodeEntriesForTrainrun(trainrun);
+
+    entryGroups.sort((groupA, groupB) => {
+      const startNodeA = this.nodeService.getNodeFromId(groupA[0].nodeId);
+      const startNodeB = this.nodeService.getNodeFromId(groupB[0].nodeId);
+      if (!startNodeA || !startNodeB) {
+        return 0;
+      }
+
+      const leftOrTopNode = GeneralViewFunctions.getLeftOrTopNode(startNodeA, startNodeB);
+      return leftOrTopNode.getId() === startNodeA.getId() ? -1 : 1;
+    });
+
+    entryGroups.forEach((group, index) => {
+      group[group.length - 1].hasGapAfter = index < entryGroups.length - 1;
+    });
+
+    return entryGroups.flat();
+  }
+
+  getAllNodeEntriesForTrainrun(trainrun: Trainrun): OrderedTrainrunNodeEntry[][] {
+    let allTrainrunSections = this.trainrunSectionService.getAllTrainrunSectionsForTrainrun(
+      trainrun.getId(),
+    );
+    const entryGroups: OrderedTrainrunNodeEntry[][] = [];
+
+    while (allTrainrunSections.length > 0) {
+      const trainrunSection = allTrainrunSections[0];
+      allTrainrunSections = allTrainrunSections.filter(
+        (section) => section.getId() !== trainrunSection.getId(),
+      );
+
+      const bothEndNodes = this.getBothEndNodesFromTrainrunPart(trainrunSection);
+      const startNode = GeneralViewFunctions.getLeftOrTopNode(
+        bothEndNodes.endNode1,
+        bothEndNodes.endNode2,
+      );
+      if (!startNode) {
+        continue;
+      }
+
+      const startSection = startNode.getExtremityTrainrunSection(trainrun.getId());
+      if (!startSection) {
+        return entryGroups;
+      }
+
+      const groupEntries: OrderedTrainrunNodeEntry[] = [
+        {
+          nodeId: startNode.getId(),
+          trainrunSectionId: startSection.getId(),
+          hasGapAfter: false,
+        },
+      ];
+
+      const iterator = this.getIterator(startNode, startSection);
+      while (iterator.hasNext()) {
+        const pair = iterator.next();
+        groupEntries.push({
+          nodeId: pair.node.getId(),
+          trainrunSectionId: pair.trainrunSection.getId(),
+          hasGapAfter: false,
+        });
+        allTrainrunSections = allTrainrunSections.filter(
+          (section) => section.getId() !== pair.trainrunSection.getId(),
+        );
+      }
+
+      entryGroups.push(groupEntries);
+    }
+    return entryGroups;
   }
 
   propagateConsecutiveTimesForTrainrun(trainrunSectionId: number) {

--- a/src/app/view/editor-search-view/editor-node-search-view-component/editor-node-search-view-component.html
+++ b/src/app/view/editor-search-view/editor-node-search-view-component/editor-node-search-view-component.html
@@ -1,6 +1,6 @@
 <sbb-search
   (search)="search()"
-  aria-label="{{ 'app.view.editor-search-view-component.search-node' | translate }}"
+  aria-label="{{ 'app.view.editor-search-view-component.select-node' | translate }}"
 >
   <input
     sbbInput
@@ -17,14 +17,14 @@
 
 @if (searchResults.length > 1) {
 <div
+  #nodeResultsList
   class="search-results-list"
   [class.search-results-overflow]="searchResults.length > 8"
-  [class.search-results-dragging]="isSearchResultsDragging"
-  (mousedown)="onSearchResultsMouseDown($event)"
+  [class.dragging]="isDraggingResults"
+  (mousedown)="onResultListMouseDown($event, nodeResultsList)"
 >
   @for (node of searchResults; track node) {
-  <br />
-  <p class="alignleft" style="line-height: 10px">
+  <div class="search-result-item">
     <span
       class="smallstation"
       [title]="transformNodeName(node)"
@@ -32,7 +32,7 @@
     >
       {{ getNodeSearchValue(node) }}
     </span>
-  </p>
+  </div>
   }
 </div>
 }

--- a/src/app/view/editor-search-view/editor-node-search-view-component/editor-node-search-view-component.scss
+++ b/src/app/view/editor-search-view/editor-node-search-view-component/editor-node-search-view-component.scss
@@ -15,26 +15,22 @@
   overflow-y: auto;
 }
 
-.search-results-list:not(.search-results-dragging) {
-  cursor: cursor;
-}
-
-.search-results-list.search-results-dragging {
-  cursor: cursor;
+.search-results-list.dragging {
   user-select: none;
 }
 
-.alignleft {
-  float: left;
-  width: 100%;
-  margin: 0;
+.search-result-item {
+  line-height: 1.15;
+  margin: 2px 0;
 }
 
 span.smallstation {
   cursor: pointer;
-  font-size: 12px;
-  border: 3px solid var(--sbb-color-background);
-  font-weight: lighter;
+  color: var(--sbb-form-input-color);
+  font-size: var(--sbb-font-size);
+  border: 5px solid none;
+  margin-left: 4px;
+  font-weight: light;
   user-select: none;
 }
 

--- a/src/app/view/editor-search-view/editor-node-search-view-component/editor-node-search-view-component.ts
+++ b/src/app/view/editor-search-view/editor-node-search-view-component/editor-node-search-view-component.ts
@@ -1,4 +1,15 @@
-import {Component, ChangeDetectionStrategy, HostListener, OnDestroy, OnInit} from "@angular/core";
+import {
+  Component,
+  EventEmitter,
+  HostListener,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  Output,
+  SimpleChanges,
+} from "@angular/core";
+import {FilterService} from "../../../services/ui/filter.service";
 import {UiInteractionService} from "../../../services/ui/ui.interaction.service";
 import {takeUntil} from "rxjs/operators";
 import {Subject} from "rxjs";
@@ -12,11 +23,13 @@ import {Vec2D} from "../../../utils/vec2D";
   selector: "sbb-editor-node-search-view-component",
   templateUrl: "./editor-node-search-view-component.html",
   styleUrls: ["./editor-node-search-view-component.scss"],
-  changeDetection: ChangeDetectionStrategy.Eager,
   standalone: false,
 })
-export class EditorNodeSearchViewComponent implements OnInit, OnDestroy {
+export class EditorNodeSearchViewComponent implements OnInit, OnDestroy, OnChanges {
   private static readonly FILTER_PANEL_ID = "cd-layout-filter";
+
+  @Input() resetSignal = 0;
+  @Output() isEmptyChange = new EventEmitter<boolean>();
 
   searchControl = new FormControl<string | Node | null>("");
   searchResults: Node[] = [];
@@ -26,21 +39,32 @@ export class EditorNodeSearchViewComponent implements OnInit, OnDestroy {
   private destroyed = new Subject<void>();
   allSearchableNodes: Node[] = [];
   filteredNodes: Node[] = [];
-  isSearchResultsDragging = false;
-  private searchResultsElement: HTMLElement | null = null;
-  private searchResultsDragStartY = 0;
-  private searchResultsDragStartScrollTop = 0;
+  isDraggingResults = false;
+
+  private dragStartY = 0;
+  private dragStartScrollTop = 0;
+  private activeResultsList: HTMLElement | null = null;
 
   constructor(
     private uiInteractionService: UiInteractionService,
     private nodeService: NodeService,
+    private filterService: FilterService,
   ) {
     this.nodeService.nodes.pipe(takeUntil(this.destroyed)).subscribe((nodes: Node[]) => {
-      this.allSearchableNodes = nodes;
+      this.allSearchableNodes = nodes.filter((node) => this.filterService.filterNode(node));
       this.updateFilteredNodes(this.searchControl.value);
     });
 
-    this.allSearchableNodes = this.nodeService.getNodes();
+    this.filterService.filter.pipe(takeUntil(this.destroyed)).subscribe(() => {
+      this.allSearchableNodes = this.nodeService
+        .getNodes()
+        .filter((node) => this.filterService.filterNode(node));
+      this.updateFilteredNodes(this.searchControl.value);
+    });
+
+    this.allSearchableNodes = this.nodeService
+      .getNodes()
+      .filter((node) => this.filterService.filterNode(node));
     this.updateFilteredNodes(this.searchControl.value);
   }
 
@@ -58,15 +82,58 @@ export class EditorNodeSearchViewComponent implements OnInit, OnDestroy {
 
     this.searchControl.valueChanges.pipe(takeUntil(this.destroyed)).subscribe((value) => {
       this.updateFilteredNodes(value);
+      this.emitIsEmptyState();
     });
+
+    this.emitIsEmptyState();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes["resetSignal"] && !changes["resetSignal"].firstChange) {
+      this.clearSearch();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.stopDragScroll();
+    this.destroyed.next();
+    this.destroyed.complete();
+  }
+
+  onResultListMouseDown(event: MouseEvent, listElement: HTMLElement): void {
+    if (event.button !== 0) {
+      return;
+    }
+
+    // Dragging is enabled only if the list can actually scroll.
+    if (listElement.scrollHeight <= listElement.clientHeight) {
+      return;
+    }
+
+    this.isDraggingResults = true;
+    this.activeResultsList = listElement;
+    this.dragStartY = event.clientY;
+    this.dragStartScrollTop = listElement.scrollTop;
+    event.preventDefault();
+  }
+
+  @HostListener("document:mousemove", ["$event"])
+  onDocumentMouseMove(event: MouseEvent): void {
+    if (!this.isDraggingResults || !this.activeResultsList) {
+      return;
+    }
+
+    const deltaY = event.clientY - this.dragStartY;
+    this.activeResultsList.scrollTop = this.dragStartScrollTop + deltaY;
+  }
+
+  @HostListener("document:mouseup")
+  onDocumentMouseUp(): void {
+    this.stopDragScroll();
   }
 
   get isNetzgrafikMode(): boolean {
     return this.mainViewMode === MainViewMode.Netzgrafik;
-  }
-  ngOnDestroy(): void {
-    this.destroyed.next();
-    this.destroyed.complete();
   }
 
   search() {
@@ -88,45 +155,6 @@ export class EditorNodeSearchViewComponent implements OnInit, OnDestroy {
       EditorNodeSearchViewComponent.FILTER_PANEL_ID,
     );
     this.uiInteractionService.gotoNode(node, offset);
-  }
-
-  canResetSearch(): boolean {
-    return this.searchResults.length > 0 || this.getSearchTerm(this.searchControl.value) !== "";
-  }
-
-  resetSearch(): void {
-    this.searchResults = [];
-    this.onSearchResultsMouseUp();
-    this.searchControl.setValue("");
-  }
-
-  onSearchResultsMouseDown(event: MouseEvent): void {
-    if (event.button !== 0 || (event.target as HTMLElement).closest(".smallstation") !== null) {
-      return;
-    }
-
-    this.searchResultsElement = event.currentTarget as HTMLElement;
-    this.searchResultsDragStartY = event.clientY;
-    this.searchResultsDragStartScrollTop = this.searchResultsElement.scrollTop;
-    this.isSearchResultsDragging = true;
-    event.preventDefault();
-  }
-
-  @HostListener("document:mousemove", ["$event"])
-  onSearchResultsMouseMove(event: MouseEvent): void {
-    if (!this.isSearchResultsDragging || this.searchResultsElement === null) {
-      return;
-    }
-
-    this.searchResultsElement.scrollTop =
-      this.searchResultsDragStartScrollTop + (event.clientY - this.searchResultsDragStartY);
-    event.preventDefault();
-  }
-
-  @HostListener("document:mouseup")
-  onSearchResultsMouseUp(): void {
-    this.isSearchResultsDragging = false;
-    this.searchResultsElement = null;
   }
 
   getNodeSearchValue(node: Node): string {
@@ -205,5 +233,24 @@ export class EditorNodeSearchViewComponent implements OnInit, OnDestroy {
     const element = document.getElementById(elementId);
     const offsetXPx = element?.getBoundingClientRect().right ?? 0;
     return this.uiInteractionService.getNetzgrafikOffsetFromScreenPx(offsetXPx, 0);
+  }
+
+  private clearSearch(): void {
+    this.stopDragScroll();
+    this.searchControl.setValue("");
+    this.searchResults = [];
+    this.updateFilteredNodes(this.searchControl.value);
+    this.emitIsEmptyState();
+  }
+
+  private emitIsEmptyState(): void {
+    const value = this.searchControl.value;
+    const isEmpty = value === null || (typeof value === "string" && value.trim() === "");
+    this.isEmptyChange.emit(isEmpty);
+  }
+
+  private stopDragScroll(): void {
+    this.isDraggingResults = false;
+    this.activeResultsList = null;
   }
 }

--- a/src/app/view/editor-search-view/editor-search-view-component.html
+++ b/src/app/view/editor-search-view/editor-search-view-component.html
@@ -6,17 +6,35 @@
       >{{ "app.view.editor-search-view-component.goto" | translate }}</sbb-expansion-panel-header
     >
 
-    <sbb-editor-node-search-view-component #nodeSearch></sbb-editor-node-search-view-component>
+    <sbb-label>{{ "app.view.editor-search-view-component.select-node" | translate }}</sbb-label>
+    <sbb-editor-node-search-view-component
+      [resetSignal]="resetSignal"
+      (isEmptyChange)="onNodeSearchEmptyChange($event)"
+    ></sbb-editor-node-search-view-component>
+  </sbb-expansion-panel>
 
-    <button
-      sbb-secondary-button
-      class="sbb-mt-m"
-      type="button"
-      [disabled]="!nodeSearch.canResetSearch()"
-      [title]="'app.view.editor-search-view-component.reset' | translate"
-      (click)="nodeSearch.resetSearch()"
+  <sbb-expansion-panel [expanded]="true">
+    <sbb-expansion-panel-header
+      >{{ "app.view.editor-search-view-component.navigate" | translate
+      }}</sbb-expansion-panel-header
     >
-      {{ "app.view.editor-search-view-component.reset" | translate }}
-    </button>
+
+    <sbb-label>{{ "app.view.editor-search-view-component.select-trainrun" | translate }}</sbb-label>
+    <sbb-editor-trainrun-search-view-component
+      [resetSignal]="resetSignal"
+      (isEmptyChange)="onTrainrunSearchEmptyChange($event)"
+    ></sbb-editor-trainrun-search-view-component>
   </sbb-expansion-panel>
 </sbb-accordion>
+
+<div style="transform: translate(24px, 10px)">
+  <button
+    sbb-secondary-button
+    class="sbb-mt-m"
+    [disabled]="allSearchFieldsEmpty()"
+    [title]="'app.view.editor-search-view-component.clear-all-search-fields' | translate"
+    (click)="onResetAllSearchFields()"
+  >
+    {{ "app.view.editor-search-view-component.clear-all-search-fields" | translate }}
+  </button>
+</div>

--- a/src/app/view/editor-search-view/editor-search-view-component.scss
+++ b/src/app/view/editor-search-view/editor-search-view-component.scss
@@ -1,3 +1,8 @@
 @use "../../../variables" as *;
 @use "./../../view/editor-filter-view/editor-filter-view.component.scss";
 @use "../rastering/definitions" as *;
+
+:host {
+  overflow-x: hidden;
+  overflow-y: hidden;
+}

--- a/src/app/view/editor-search-view/editor-search-view-component.ts
+++ b/src/app/view/editor-search-view/editor-search-view-component.ts
@@ -1,12 +1,31 @@
-import {Component, ChangeDetectionStrategy} from "@angular/core";
+import {Component} from "@angular/core";
 
 @Component({
   selector: "sbb-editor-search-view-component",
   templateUrl: "./editor-search-view-component.html",
   styleUrls: ["./editor-search-view-component.scss"],
-  changeDetection: ChangeDetectionStrategy.Eager,
   standalone: false,
 })
 export class EditorSearchViewComponent {
+  resetSignal = 0;
+  nodeSearchEmpty = true;
+  trainrunSearchEmpty = true;
+
   constructor() {}
+
+  allSearchFieldsEmpty(): boolean {
+    return this.nodeSearchEmpty && this.trainrunSearchEmpty;
+  }
+
+  onResetAllSearchFields(): void {
+    this.resetSignal += 1;
+  }
+
+  onNodeSearchEmptyChange(isEmpty: boolean): void {
+    this.nodeSearchEmpty = isEmpty;
+  }
+
+  onTrainrunSearchEmptyChange(isEmpty: boolean): void {
+    this.trainrunSearchEmpty = isEmpty;
+  }
 }

--- a/src/app/view/editor-search-view/editor-trainrun-search-view-component/editor-trainrun-search-view-component.html
+++ b/src/app/view/editor-search-view/editor-trainrun-search-view-component/editor-trainrun-search-view-component.html
@@ -1,0 +1,47 @@
+<sbb-search
+  (search)="onSearch()"
+  aria-label="{{ 'app.view.editor-search-view-component.select-trainrun' | translate }}"
+>
+  <input
+    sbbInput
+    [placeholder]="'app.view.editor-search-view-component.search-trainrun' | translate"
+    [formControl]="searchControl"
+    [sbbAutocomplete]="auto"
+  />
+</sbb-search>
+<sbb-autocomplete #auto="sbbAutocomplete" [displayWith]="displayTrainrun">
+  @for (option of filteredTrainruns; track option) {
+  <sbb-option [value]="option">{{ transformTrainrunName(option) }}</sbb-option>
+  }
+</sbb-autocomplete>
+
+@if (searchResults.length === 1 && orderedNodeEntries.length > 0) {
+<div
+  #trainrunResultsList
+  class="search-results-list"
+  [class.dragging]="isDraggingResults"
+  (mousedown)="onResultListMouseDown($event, trainrunResultsList)"
+>
+  @for (entry of orderedNodeEntries; track $index; let last = $last) {
+  <div class="timeline-row">
+    <div class="timeline-marker-column">
+      <span class="pearl"></span>
+    </div>
+    <span
+      class="smallstation"
+      [title]="transformNodeEntryName(entry)"
+      (click)="onOrderedNodeClick(entry)"
+    >
+      {{ transformNodeEntryName(entry) }}
+    </span>
+  </div>
+
+  @if (!last && !entry.hasGapAfter) {
+  <div class="connector-row">
+    <span class="connector"></span>
+  </div>
+  } @else if (entry.hasGapAfter) {
+  <div class="timeline-gap"></div>
+  } }
+</div>
+}

--- a/src/app/view/editor-search-view/editor-trainrun-search-view-component/editor-trainrun-search-view-component.scss
+++ b/src/app/view/editor-search-view/editor-trainrun-search-view-component/editor-trainrun-search-view-component.scss
@@ -1,0 +1,76 @@
+@use "../../../../variables" as *;
+@use "./../../../view/editor-filter-view/editor-filter-view.component.scss";
+@use "../../rastering/definitions" as *;
+
+.search-results-list {
+  margin-top: 0.5rem;
+  max-height: 405px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-top: 4px;
+}
+
+.search-results-list.dragging {
+  user-select: none;
+}
+
+.timeline-row {
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+  min-height: 18px;
+}
+
+.timeline-marker-column {
+  width: 9px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 9px;
+}
+
+.connector-row {
+  width: 9px;
+  display: flex;
+  justify-content: center;
+  margin-left: 0;
+  height: 4px;
+  transform: translateY(-5px);
+}
+
+span.smallstation {
+  cursor: pointer;
+  color: var(--sbb-form-input-color);
+  font-size: var(--sbb-font-size);
+  border: 5px solid none;
+  margin-left: 4px;
+  font-weight: light;
+  user-select: none;
+}
+
+span.smallstation:hover {
+  font-weight: bolder;
+  color: var(--COLOR_Edit);
+}
+
+.pearl {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--sbb-color-granite);
+}
+
+.connector {
+  display: inline-block;
+  width: 2px;
+  height: 32px;
+  background: var(--sbb-color-granite);
+  transform: translateY(-8px);
+}
+
+.timeline-gap {
+  height: 6px;
+}

--- a/src/app/view/editor-search-view/editor-trainrun-search-view-component/editor-trainrun-search-view-component.ts
+++ b/src/app/view/editor-search-view/editor-trainrun-search-view-component/editor-trainrun-search-view-component.ts
@@ -1,0 +1,352 @@
+import {
+  Component,
+  EventEmitter,
+  HostListener,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  Output,
+  SimpleChanges,
+} from "@angular/core";
+import {FilterService} from "../../../services/ui/filter.service";
+import {takeUntil} from "rxjs/operators";
+import {Subject} from "rxjs";
+import {Trainrun} from "../../../models/trainrun.model";
+import {TrainrunService} from "../../../services/data/trainrun.service";
+import {
+  InformSelectedTrainrunClick,
+  TrainrunSectionService,
+} from "../../../services/data/trainrunsection.service";
+import {UiInteractionService} from "../../../services/ui/ui.interaction.service";
+import {FormControl} from "@angular/forms";
+import {OrderedTrainrunNodeEntry} from "../../../services/data/trainrun.service";
+import {Node} from "../../../models/node.model";
+import {NodeService} from "../../../services/data/node.service";
+import {Vec2D} from "../../../utils/vec2D";
+
+@Component({
+  selector: "sbb-editor-trainrun-search-view-component",
+  templateUrl: "./editor-trainrun-search-view-component.html",
+  styleUrls: ["./editor-trainrun-search-view-component.scss"],
+  standalone: false,
+})
+export class EditorTrainrunSearchViewComponent implements OnInit, OnDestroy, OnChanges {
+  private static readonly FILTER_PANEL_ID = "cd-layout-filter";
+
+  @Input() resetSignal = 0;
+  @Output() isEmptyChange = new EventEmitter<boolean>();
+
+  searchControl = new FormControl<string | Trainrun | null>("");
+  searchResults: Trainrun[] = [];
+  orderedNodeEntries: OrderedTrainrunNodeEntry[] = [];
+  readonly displayTrainrun = (value: string | Trainrun | null): string =>
+    this.getDisplayValue(value);
+
+  private destroyed = new Subject<void>();
+  allSearchableTrainruns: Trainrun[] = [];
+  filteredTrainruns: Trainrun[] = [];
+  isDraggingResults = false;
+
+  private dragStartY = 0;
+  private dragStartScrollTop = 0;
+  private activeResultsList: HTMLElement | null = null;
+
+  constructor(
+    private trainrunService: TrainrunService,
+    private trainrunSectionService: TrainrunSectionService,
+    private uiInteractionService: UiInteractionService,
+    private filterService: FilterService,
+    private nodeService: NodeService,
+  ) {
+    this.allSearchableTrainruns = this.trainrunService
+      .getTrainruns()
+      .filter((trainrun) => this.filterService.filterTrainrun(trainrun));
+    this.filteredTrainruns = this.filterTrainruns(this.searchControl.value).sort((a, b) =>
+      this.getTrainrunSearchValue(a).localeCompare(this.getTrainrunSearchValue(b)),
+    );
+  }
+
+  ngOnInit(): void {
+    this.trainrunService.trainruns
+      .pipe(takeUntil(this.destroyed))
+      .subscribe((trainruns: Trainrun[]) => {
+        this.allSearchableTrainruns = trainruns.filter((trainrun) =>
+          this.filterService.filterTrainrun(trainrun),
+        );
+        this.filteredTrainruns = this.filterTrainruns(this.searchControl.value).sort((a, b) =>
+          this.getTrainrunSearchValue(a).localeCompare(this.getTrainrunSearchValue(b)),
+        );
+        this.orderedNodeEntries = this.updateOrderedNodeEntries();
+        if (!this.trainrunService.getSelectedTrainrun()) {
+          this.searchControl.setValue(null);
+        } else {
+          const currentValue = this.searchControl.value;
+          if (currentValue instanceof Trainrun) {
+            if (this.trainrunService.getSelectedTrainrun().getId() !== currentValue.getId()) {
+              this.searchControl.setValue(this.trainrunService.getSelectedTrainrun());
+              this.search();
+            }
+          } else {
+            this.searchControl.setValue(this.trainrunService.getSelectedTrainrun());
+            this.search();
+          }
+        }
+      });
+
+    this.trainrunSectionService.trainrunSections.pipe(takeUntil(this.destroyed)).subscribe(() => {
+      this.allSearchableTrainruns = this.trainrunService
+        .getTrainruns()
+        .filter((trainrun) => this.filterService.filterTrainrun(trainrun));
+      this.filteredTrainruns = this.filterTrainruns(this.searchControl.value).sort((a, b) =>
+        this.getTrainrunSearchValue(a).localeCompare(this.getTrainrunSearchValue(b)),
+      );
+      this.orderedNodeEntries = this.updateOrderedNodeEntries();
+    });
+
+    this.filterService.filter.pipe(takeUntil(this.destroyed)).subscribe(() => {
+      this.allSearchableTrainruns = this.trainrunService
+        .getTrainruns()
+        .filter((trainrun) => this.filterService.filterTrainrun(trainrun));
+      this.filteredTrainruns = this.filterTrainruns(this.searchControl.value).sort((a, b) =>
+        this.getTrainrunSearchValue(a).localeCompare(this.getTrainrunSearchValue(b)),
+      );
+      this.orderedNodeEntries = this.updateOrderedNodeEntries();
+    });
+
+    this.searchControl.valueChanges.pipe(takeUntil(this.destroyed)).subscribe((value) => {
+      this.filteredTrainruns = this.filterTrainruns(value).sort((a, b) =>
+        this.getTrainrunSearchValue(a).localeCompare(this.getTrainrunSearchValue(b)),
+      );
+      this.emitIsEmptyState();
+    });
+
+    this.emitIsEmptyState();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes["resetSignal"] && !changes["resetSignal"].firstChange) {
+      this.clearSearch();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.stopDragScroll();
+    this.destroyed.next();
+    this.destroyed.complete();
+  }
+
+  onResultListMouseDown(event: MouseEvent, listElement: HTMLElement): void {
+    if (event.button !== 0) {
+      return;
+    }
+
+    // Dragging is enabled only if the list can actually scroll.
+    if (listElement.scrollHeight <= listElement.clientHeight) {
+      return;
+    }
+
+    this.isDraggingResults = true;
+    this.activeResultsList = listElement;
+    this.dragStartY = event.clientY;
+    this.dragStartScrollTop = listElement.scrollTop;
+    event.preventDefault();
+  }
+
+  @HostListener("document:mousemove", ["$event"])
+  onDocumentMouseMove(event: MouseEvent): void {
+    if (!this.isDraggingResults || !this.activeResultsList) {
+      return;
+    }
+
+    const deltaY = event.clientY - this.dragStartY;
+    this.activeResultsList.scrollTop = this.dragStartScrollTop + deltaY;
+  }
+
+  @HostListener("document:mouseup")
+  onDocumentMouseUp(): void {
+    this.stopDragScroll();
+  }
+
+  onSearch() {
+    this.search();
+    if (this.searchResults.length === 1) {
+      this.onSearchResultClick(this.searchControl.value as Trainrun);
+    }
+  }
+
+  onSearchResultClick(trainrun: Trainrun): void {
+    this.trainrunService.setTrainrunAsSelected(trainrun.getId());
+    this.orderedNodeEntries = this.updateOrderedNodeEntries();
+    if (this.orderedNodeEntries.length === 0) {
+      return;
+    }
+    const firstEntry = this.orderedNodeEntries.at(0);
+    if (firstEntry) {
+      this.onOrderedNodeClick(firstEntry);
+    }
+  }
+
+  updateOrderedNodeEntries() {
+    if (this.trainrunService.getSelectedTrainrun()) {
+      const data = this.trainrunService.getOrderedNodeEntriesForTrainrun(
+        this.trainrunService.getSelectedTrainrun(),
+      );
+      console.log("Ordered Node Entries for Trainrun:", data);
+      return data;
+    }
+    return [];
+  }
+
+  private gotoTrainrunSection(sectionId: number): void {
+    const ts = this.trainrunService.getSelectedTrainrun();
+    const trainrunSection = this.trainrunSectionService.getTrainrunSectionFromId(sectionId);
+    if (!trainrunSection) {
+      return;
+    }
+
+    if (ts.getId() !== trainrunSection.getTrainrunId()) {
+      this.trainrunService.setTrainrunAsSelected(trainrunSection.getTrainrunId());
+    }
+    const param: InformSelectedTrainrunClick = {
+      trainrunSectionId: trainrunSection.getId(),
+      open: false,
+    };
+    this.trainrunSectionService.clickSelectedTrainrunSection(param);
+  }
+
+  onOrderedNodeClick(entry: OrderedTrainrunNodeEntry): void {
+    const node = this.nodeService.getNodeFromId(entry.nodeId);
+    if (!node) {
+      return;
+    }
+
+    if (entry.trainrunSectionId !== undefined) {
+      this.gotoTrainrunSection(entry.trainrunSectionId);
+    }
+
+    const offset = this.getNetzgrafikOffsetForElementRightEdge(
+      EditorTrainrunSearchViewComponent.FILTER_PANEL_ID,
+    );
+    this.uiInteractionService.gotoNode(node, offset);
+  }
+
+  getTrainrunSearchValue(trainrun: Trainrun): string {
+    if (trainrun) {
+      const category = trainrun.getCategoryShortName() ?? "";
+      const title = trainrun.getTitle() ?? "";
+
+      return `${category}${title}`.trim();
+    }
+
+    return "";
+  }
+
+  transformTrainrunName(trainrun: Trainrun): string {
+    return this.getTrainrunSearchValue(trainrun);
+  }
+
+  transformNodeName(node: Node): string {
+    const betriebspunktName = node.getBetriebspunktName() ?? "";
+    const fullName = node.getFullName() ?? "";
+    return `${betriebspunktName} (${fullName})`;
+  }
+
+  transformNodeEntryName(entry: OrderedTrainrunNodeEntry): string {
+    const node = this.nodeService.getNodeFromId(entry.nodeId);
+    if (!node) {
+      return `${entry.nodeId}`;
+    }
+    return this.transformNodeName(node);
+  }
+
+  private search() {
+    if (this.searchControl.value instanceof Trainrun) {
+      this.searchResults = [this.searchControl.value];
+      this.trainrunService.setTrainrunAsSelected(this.searchResults[0].getId());
+      this.orderedNodeEntries = this.updateOrderedNodeEntries();
+      return;
+    }
+
+    this.searchResults = this.filterTrainruns(this.searchControl.value).sort((a, b) =>
+      this.getTrainrunSearchValue(a).localeCompare(this.getTrainrunSearchValue(b)),
+    );
+
+    if (this.searchResults.length === 1) {
+      const trainrun = this.searchResults[0];
+      this.trainrunService.setTrainrunAsSelected(trainrun.getId());
+      this.orderedNodeEntries = this.updateOrderedNodeEntries();
+    }
+  }
+
+  private filterTrainruns(value: string | Trainrun | null): Trainrun[] {
+    const searchTerm = this.getSearchTerm(value);
+    if (!searchTerm) {
+      return this.allSearchableTrainruns.slice(0, 10);
+    }
+
+    return this.allSearchableTrainruns.filter((trainrun) =>
+      this.matchesTrainrun(trainrun, searchTerm),
+    );
+  }
+
+  private getSearchTerm(value: string | Trainrun | null): string {
+    if (typeof value === "string") {
+      return value.trim().toLocaleUpperCase();
+    }
+
+    if (value instanceof Trainrun) {
+      return this.getTrainrunSearchValue(value).toLocaleUpperCase();
+    }
+
+    return "";
+  }
+
+  private getDisplayValue(value: string | Trainrun | null): string {
+    if (value instanceof Trainrun) {
+      return this.getTrainrunSearchValue(value);
+    }
+
+    return value ?? "";
+  }
+
+  private matchesTrainrun(trainrun: Trainrun, searchTerm: string): boolean {
+    const category = (trainrun.getCategoryShortName() ?? "").toLocaleUpperCase();
+    const title = (trainrun.getTitle() ?? "").toLocaleUpperCase();
+    const compactLabel = this.getTrainrunSearchValue(trainrun).toLocaleUpperCase();
+
+    return (
+      category.includes(searchTerm) ||
+      title.includes(searchTerm) ||
+      compactLabel.includes(searchTerm)
+    );
+  }
+
+  private getNetzgrafikOffsetForElementRightEdge(elementId: string): Vec2D {
+    const element = document.getElementById(elementId);
+    const offsetXPx = element?.getBoundingClientRect().right ?? 0;
+    return this.uiInteractionService.getNetzgrafikOffsetFromScreenPx(offsetXPx, 0);
+  }
+
+  private clearSearch(): void {
+    this.searchControl.setValue("");
+    this.searchResults = [];
+    this.orderedNodeEntries = [];
+    this.trainrunService.unselectAllTrainruns();
+    this.filteredTrainruns = this.filterTrainruns(this.searchControl.value).sort((a, b) =>
+      this.getTrainrunSearchValue(a).localeCompare(this.getTrainrunSearchValue(b)),
+    );
+    this.emitIsEmptyState();
+  }
+
+  private emitIsEmptyState(): void {
+    const value = this.searchControl.value;
+    const isEmpty = value === null || (typeof value === "string" && value.trim() === "");
+    this.isEmptyChange.emit(isEmpty);
+  }
+
+  private stopDragScroll(): void {
+    this.isDraggingResults = false;
+    this.activeResultsList = null;
+  }
+}

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -347,8 +347,6 @@
         "alphabeticalOrderingTooltip": "Ports anhand der Zugkategorien alphabetisch anordnen.",
         "crossingAwareOrdering": "Kreuzungsbewusst",
         "crossingAwareOrderingTooltip": "Minimiert Kreuzungen von Zugfahrten innerhalb der Knoten.",
-        "crossingAwarePushOrdering": "Kreuzungsbewusst (Kreuzungen in die Knoten verschieben)",
-        "crossingAwarePushOrderingTooltip": "Minimiert Kreuzungen von Zugfahrten und verschiebt sie in die Knoten, damit parallele Zugfahrten gebündelt bleiben.",
         "delete": "Löschen",
         "on-clear-delete-all-non-visible-elements": "Sollen alle nicht sichtbare Elemente aus der Netzgrafik definitiv gelöscht werden?",
         "on-clear-delete-all-visible-elements": "Sollen alle sichtbare Elemente aus der Netzgrafik definitiv gelöscht werden?",
@@ -430,6 +428,11 @@
         "search": "Suchen",
         "goto": "Gehe zu",
         "search-node": "Suche nach Knoten",
+        "navigate": "Navigieren",
+        "select-node": "Knoten auswählen",
+        "search-trainrun": "Suche nach Zugfahrten",
+        "select-trainrun": "Zugfahrt auswählen",
+        "clear-all-search-fields": "Alle Suchfelder zurücksetzen",
         "reset": "Suche zurücksetzen"
       },
       "editor-menu": {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -347,8 +347,6 @@
         "alphabeticalOrderingTooltip": "Order ports alphabetically by train categories.",
         "crossingAwareOrdering": "Crossing aware",
         "crossingAwareOrderingTooltip": "Minimizes crossings of trainruns within the nodes.",
-        "crossingAwarePushOrdering": "Crossing aware (push crossings into nodes)",
-        "crossingAwarePushOrderingTooltip": "Minimizes crossings of trainruns, moving them into the nodes to keep parallel trainruns bundled.",
         "delete": "Delete",
         "on-clear-delete-all-non-visible-elements": "Should all non-visible elements be permanently deleted from the netzgrafik?",
         "on-clear-delete-all-visible-elements": "Should all visible elements be permanently deleted from the netzgrafik?",
@@ -430,6 +428,11 @@
         "search": "Search",
         "goto": "Goto",
         "search-node": "Search node",
+        "navigate": "Navigate",
+        "select-node": "Select node",
+        "search-trainrun": "Search trainrun",
+        "select-trainrun": "Select trainrun",
+        "clear-all-search-fields": "Reset all search fields",
         "reset": "Reset search"
       },
       "editor-menu": {

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -347,8 +347,6 @@
         "alphabeticalOrderingTooltip": "Ordonne les ports par ordre alphabétique des catégories de train.",
         "crossingAwareOrdering": "Réduction des croisements",
         "crossingAwareOrderingTooltip": "Minimise les croisements des trajets à l'intérieur des noeuds.",
-        "crossingAwarePushOrdering": "Réduction des croisements (concentrés dans les noeuds)",
-        "crossingAwarePushOrderingTooltip": "Minimise les croisements des trajets en les concentrant dans les noeuds pour garder les trajets parallèles groupés.",
         "delete": "Supprimer",
         "on-clear-delete-all-non-visible-elements": "Tous les éléments non visibles doivent-ils être définitivement supprimés du réticulaire ?",
         "on-clear-delete-all-visible-elements": "Tous les éléments visibles doivent-ils être définitivement supprimés du réticulaire ?",
@@ -430,6 +428,11 @@
         "search": "Rechercher",
         "goto": "Aller à",
         "search-node": "Rechercher un noeud",
+        "navigate": "Naviguer",
+        "select-node": "Sélectionner un noeud",
+        "search-trainrun": "Rechercher un trajet de train",
+        "select-trainrun": "Sélectionner un trajet de train",
+        "clear-all-search-fields": "Effacer tous les champs de recherche",
         "reset": "Réinitialiser la recherche"
       },
       "editor-menu": {

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -425,15 +425,15 @@
         }
       },
       "editor-search-view-component": {
-        "search": "Rechercher",
-        "goto": "Aller à",
-        "search-node": "Rechercher un noeud",
-        "navigate": "Naviguer",
-        "select-node": "Sélectionner un noeud",
-        "search-trainrun": "Rechercher un trajet de train",
-        "select-trainrun": "Sélectionner un trajet de train",
-        "clear-all-search-fields": "Effacer tous les champs de recherche",
-        "reset": "Réinitialiser la recherche"
+        "search": "Search",
+        "goto": "Goto",
+        "search-node": "Search node",
+        "navigate": "Navigate",
+        "select-node": "Select node",
+        "search-trainrun": "Search trainrun",
+        "select-trainrun": "Select trainrun",
+        "clear-all-search-fields": "Reset all search fields",
+        "reset": "Reset search"
       },
       "editor-menu": {
         "save-changes": "Enregistrer les modifications",


### PR DESCRIPTION
This new feature allows user to navigate very quickly throught the Netzgrafik-Editor. The user can either search for  a trainrun.

Adds a new trainrun search-component to the left-side search panel  

This PR replaces https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/pull/1264 and extends https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/pull/1287. 