### PR TITLE
Implement iteration protocol in TrainrunIterator

### DIFF
--- a/src/app/perlenkette/service/load-perlenkette.service.ts
+++ b/src/app/perlenkette/service/load-perlenkette.service.ts
@@ -148,8 +148,7 @@ export class LoadPerlenketteService implements OnDestroy {
         );
 
         let firstSection = true;
-        while (iterator.hasNext()) {
-          const currentTrainrunSectionNodePair = iterator.next();
+        for (const currentTrainrunSectionNodePair of iterator) {
           const trainrunSection = currentTrainrunSectionNodePair.trainrunSection;
           const node = currentTrainrunSectionNodePair.node;
           // Section X

--- a/src/app/services/data/node.service.ts
+++ b/src/app/services/data/node.service.ts
@@ -540,9 +540,8 @@ export class NodeService implements OnDestroy {
 
   hasPathAnyDepartureOrArrivalTimeLock(node: Node, trainrunSection: TrainrunSection): boolean {
     const iterator = this.trainrunService.getIterator(node, trainrunSection);
-    while (iterator.hasNext()) {
-      iterator.next();
-      const currentTrainrunSection = iterator.current().trainrunSection;
+    for (const pair of iterator) {
+      const currentTrainrunSection = pair.trainrunSection;
       if (
         currentTrainrunSection.getSourceDepartureLock() ||
         currentTrainrunSection.getTargetArrivalLock()

--- a/src/app/services/data/trainrun.service.ts
+++ b/src/app/services/data/trainrun.service.ts
@@ -367,15 +367,12 @@ export class TrainrunService {
 
     trainrunSection2.setTrainrun(newTrainrun);
     const iterator = this.getIterator(node, trainrunSection2);
-    while (iterator.hasNext()) {
-      iterator.next();
-      const trans = iterator
-        .current()
-        .node.getTransition(iterator.current().trainrunSection.getId());
+    for (const pair of iterator) {
+      const trans = pair.node.getTransition(pair.trainrunSection.getId());
       if (trans) {
         trans.setTrainrun(newTrainrun);
       }
-      iterator.current().trainrunSection.setTrainrun(newTrainrun);
+      pair.trainrunSection.setTrainrun(newTrainrun);
     }
 
     this.nodeService.checkAndFixMissingTransitions(
@@ -428,21 +425,16 @@ export class TrainrunService {
     const trainrunSection = port2.getTrainrunSection();
     trainrunSection.setTrainrun(trainrun1);
     const iterator = this.getIterator(node, trainrunSection);
-    while (iterator.hasNext()) {
-      iterator.next();
-      const trans = iterator
-        .current()
-        .node.getTransition(iterator.current().trainrunSection.getId());
+    for (const pair of iterator) {
+      const trans = pair.node.getTransition(pair.trainrunSection.getId());
       if (trans) {
         trans.setTrainrun(trainrun1);
       }
-      iterator.current().trainrunSection.setTrainrun(trainrun1);
-      iterator
-        .current()
-        .trainrunSection.shiftAllTimes(
-          frequencyOffset,
-          node.getId() === port2.getTrainrunSection().getSourceNodeId(),
-        );
+      pair.trainrunSection.setTrainrun(trainrun1);
+      pair.trainrunSection.shiftAllTimes(
+        frequencyOffset,
+        node.getId() === port2.getTrainrunSection().getSourceNodeId(),
+      );
     }
 
     // Enforce updating all transitions. If the train run has "holes," we must also update
@@ -680,9 +672,8 @@ export class TrainrunService {
   getNodePathToEnd(node: Node, trainrunSection: TrainrunSection): Node[] {
     const path: Node[] = [node];
     const iterator = this.getIterator(node, trainrunSection);
-    while (iterator.hasNext()) {
-      iterator.next();
-      path.push(iterator.current().node);
+    for (const pair of iterator) {
+      path.push(pair.node);
     }
     return path;
   }

--- a/src/app/services/data/trainrunsection.service.ts
+++ b/src/app/services/data/trainrunsection.service.ts
@@ -366,10 +366,9 @@ export class TrainrunSectionService implements OnDestroy {
     stopNodeId: number,
   ) {
     const iterator = this.trainrunService.getNonStopIterator(node, trainrunSection);
-    while (iterator.hasNext()) {
-      iterator.next();
-      if (iterator.current().node.getId() === stopNodeId) {
-        return iterator.current().trainrunSection.getId();
+    for (const pair of iterator) {
+      if (pair.node.getId() === stopNodeId) {
+        return pair.trainrunSection.getId();
       }
     }
     return undefined;
@@ -512,9 +511,7 @@ export class TrainrunSectionService implements OnDestroy {
 
     TrainrunSectionValidator.validateOneSection(previousPair.trainrunSection);
 
-    while (iterator.hasNext()) {
-      const pair = iterator.next();
-
+    for (const pair of iterator) {
       const previousSection = previousPair.getDirectedTrainrunSectionProxy();
       const section = pair.getDirectedTrainrunSectionProxy();
       this.propagateTrainrunSectionTime(previousSection, section);
@@ -905,8 +902,7 @@ export class TrainrunSectionService implements OnDestroy {
     });
 
     const iterator = this.trainrunService.getNonStopIterator(firstSourceNode, firstTrainrunSection);
-    while (iterator.hasNext()) {
-      const pair = iterator.next();
+    for (const pair of iterator) {
       this.trainrunSectionTimesUpdated(pair.trainrunSection);
     }
 
@@ -931,8 +927,7 @@ export class TrainrunSectionService implements OnDestroy {
     const travelTimeFactor = chainTravelTime / totalCumulativeTravelTime;
     let departureTime = chainDepartureTime;
     let summedTravelTime = 0;
-    while (iterator.hasNext()) {
-      const pair = iterator.next();
+    for (const pair of iterator) {
       const section = pair.getDirectedTrainrunSectionProxy();
 
       const travelTime = TrainrunsectionHelper.getTravelTime(

--- a/src/app/services/util/trainrun.iterator.ts
+++ b/src/app/services/util/trainrun.iterator.ts
@@ -258,6 +258,10 @@ export class TrainrunIterator {
     return this.currentElement;
   }
 
+  public [Symbol.iterator](): Iterator<TrainrunSectionNodePair> {
+    return new TrainrunIteratorIterator(this);
+  }
+
   /**
    * Throws an exception if called after the end of the iteration.
    * Check for `this.hasNext()` before.
@@ -377,5 +381,13 @@ export class BackwardNonStopTrainrunIterator extends BackwardTrainrunIterator {
       return this.currentElement;
     }
     return super.next();
+  }
+}
+
+class TrainrunIteratorIterator implements Iterator<TrainrunSectionNodePair> {
+  constructor(private iterator: TrainrunIterator) {}
+
+  public next(): IteratorResult<TrainrunSectionNodePair> {
+    return this.iterator.hasNext() ? {value: this.iterator.next()} : {done: true, value: undefined};
   }
 }

--- a/src/app/services/util/trainrun.iterator.ts
+++ b/src/app/services/util/trainrun.iterator.ts
@@ -234,17 +234,20 @@ export class DirectedTrainrunSectionProxy {
  */
 export class TrainrunIterator {
   protected currentElement: TrainrunSectionNodePair;
-  protected pointerElement: TrainrunSectionNodePair;
+  protected pointerElement: TrainrunSectionNodePair | undefined;
 
   protected visitedNodes: TrainrunSectionNodePair[] = [];
 
+  /**
+   * Throws an exception if `startNode` isn't part of `startTrainrunSection`.
+   */
   constructor(
     protected logService: LogService,
     private startNode: Node,
     private startTrainrunSection: TrainrunSection,
   ) {
     this.pointerElement = new TrainrunSectionNodePair(
-      this.startNode.getOppositeNode(this.startTrainrunSection),
+      this.startNode.getOppositeNode(this.startTrainrunSection)!,
       this.startTrainrunSection,
     );
     this.currentElement = this.pointerElement;
@@ -255,18 +258,22 @@ export class TrainrunIterator {
     return this.currentElement;
   }
 
+  /**
+   * Throws an exception if called after the end of the iteration.
+   * Check for `this.hasNext()` before.
+   */
   public next(): TrainrunSectionNodePair {
-    this.currentElement = this.pointerElement;
-    const trainrunSection = this.pointerElement.node.getNextTrainrunSection(
-      this.pointerElement.trainrunSection,
+    this.currentElement = this.pointerElement!;
+    const trainrunSection = this.currentElement.node.getNextTrainrunSection(
+      this.currentElement.trainrunSection,
     );
 
     if (trainrunSection === undefined) {
-      this.pointerElement = new TrainrunSectionNodePair(undefined, undefined);
+      this.pointerElement = undefined;
       return this.currentElement;
     }
 
-    const node = this.pointerElement.node.getOppositeNode(trainrunSection);
+    const node = this.currentElement.node.getOppositeNode(trainrunSection)!;
     this.pointerElement = new TrainrunSectionNodePair(node, trainrunSection);
 
     if (
@@ -278,7 +285,7 @@ export class TrainrunIterator {
     ) {
       // The trainrun has a loop -> early break the avoid unfinitiy iterating
       this.currentElement = this.pointerElement;
-      this.pointerElement = new TrainrunSectionNodePair(undefined, undefined);
+      this.pointerElement = undefined;
       // log the issue
       this.logService.error(
         $localize`:@@app.services.util.trainrun-iteration.error.infinity-loop:Iterator has detected an infinity loop. The iteration terminated early!`,
@@ -292,24 +299,28 @@ export class TrainrunIterator {
   }
 
   public hasNext(): boolean {
-    return this.pointerElement.trainrunSection !== undefined;
+    return this.pointerElement !== undefined;
   }
 }
 
 export class BackwardTrainrunIterator extends TrainrunIterator {
+  /**
+   * Throws an exception if called after the end of the iteration.
+   * Check for `this.hasNext()` before.
+   */
   public next(): TrainrunSectionNodePair {
-    const currentElement = this.pointerElement;
-    const trainrunSection = this.pointerElement.node.getPreviousTrainrunSection(
-      this.pointerElement.trainrunSection,
+    const currentElement = this.pointerElement!;
+    const trainrunSection = currentElement.node.getPreviousTrainrunSection(
+      currentElement.trainrunSection,
     );
 
     if (trainrunSection === undefined) {
-      this.pointerElement = new TrainrunSectionNodePair(undefined, undefined);
+      this.pointerElement = undefined;
       this.currentElement = currentElement;
       return this.currentElement;
     }
 
-    const node = this.pointerElement.node.getOppositeNode(trainrunSection);
+    const node = currentElement.node.getOppositeNode(trainrunSection)!;
     this.pointerElement = new TrainrunSectionNodePair(node, trainrunSection);
 
     if (
@@ -321,7 +332,7 @@ export class BackwardTrainrunIterator extends TrainrunIterator {
     ) {
       // The trainrun has a loop -> early break the avoid unfinitiy iterating
       this.currentElement = this.pointerElement;
-      this.pointerElement = new TrainrunSectionNodePair(undefined, undefined);
+      this.pointerElement = undefined;
       // log the issue
       this.logService.error(
         $localize`:@@app.services.util.trainrun-iteration.error.infinity-loop:Iterator has detected an infinity loop. The iteration terminated early!`,
@@ -336,11 +347,16 @@ export class BackwardTrainrunIterator extends TrainrunIterator {
 }
 
 export class NonStopTrainrunIterator extends TrainrunIterator {
+  /**
+   * Throws an exception if called after the end of the iteration.
+   * Check for `this.hasNext()` before.
+   */
   public next(): TrainrunSectionNodePair {
-    if (!this.pointerElement.node.isNonStop(this.pointerElement.trainrunSection)) {
+    const currentElement = this.pointerElement!;
+    if (!currentElement.node.isNonStop(currentElement.trainrunSection)) {
       // The trainrun has a stop and break the forward iteration
-      this.currentElement = this.pointerElement;
-      this.pointerElement = new TrainrunSectionNodePair(undefined, undefined);
+      this.currentElement = currentElement;
+      this.pointerElement = undefined;
       return this.currentElement;
     }
     return super.next();
@@ -348,11 +364,16 @@ export class NonStopTrainrunIterator extends TrainrunIterator {
 }
 
 export class BackwardNonStopTrainrunIterator extends BackwardTrainrunIterator {
+  /**
+   * Throws an exception if called after the end of the iteration.
+   * Check for `this.hasNext()` before.
+   */
   public next(): TrainrunSectionNodePair {
-    if (!this.pointerElement.node.isNonStop(this.pointerElement.trainrunSection)) {
+    const currentElement = this.pointerElement!;
+    if (!currentElement.node.isNonStop(currentElement.trainrunSection)) {
       // The trainrun has a stop and break the backward iteration
-      this.currentElement = this.pointerElement;
-      this.pointerElement = new TrainrunSectionNodePair(undefined, undefined);
+      this.currentElement = currentElement;
+      this.pointerElement = undefined;
       return this.currentElement;
     }
     return super.next();

--- a/src/app/services/util/trainrun.iterator.ts
+++ b/src/app/services/util/trainrun.iterator.ts
@@ -233,8 +233,8 @@ export class DirectedTrainrunSectionProxy {
  *     (n₁, ts₁)
  */
 export class TrainrunIterator {
-  protected currentElement: TrainrunSectionNodePair = null;
-  protected pointerElement: TrainrunSectionNodePair = null;
+  protected currentElement: TrainrunSectionNodePair;
+  protected pointerElement: TrainrunSectionNodePair;
 
   protected visitedNodes: TrainrunSectionNodePair[] = [];
 

--- a/src/app/streckengrafik/services/sg-1-load-trainrun-item.service.ts
+++ b/src/app/streckengrafik/services/sg-1-load-trainrun-item.service.ts
@@ -1135,8 +1135,7 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
     }
     const iterator: TrainrunIterator = this.trainrunService.getIterator(node, startTrainrunSection);
     visitedTrainrunSections.push(startTrainrunSection);
-    while (iterator.hasNext()) {
-      const currentTrainrunSectionNodePair = iterator.next();
+    for (const currentTrainrunSectionNodePair of iterator) {
       visitedTrainrunSections.push(currentTrainrunSectionNodePair.trainrunSection);
 
       if (trainrunSectionGroup) {

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrunsection-tab/trainrun-section-tab.component.ts
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrunsection-tab/trainrun-section-tab.component.ts
@@ -97,8 +97,7 @@ export class TrainrunSectionTabComponent implements AfterViewInit, OnDestroy {
       firstTrainrunSection.getSourceNode(),
       firstTrainrunSection,
     );
-    while (iterator.hasNext()) {
-      const nextPair = iterator.next();
+    for (const nextPair of iterator) {
       if (!nextPair.trainrunSection.isSymmetric()) {
         return true;
       }

--- a/src/app/view/util/origin-destination-graph.ts
+++ b/src/app/view/util/origin-destination-graph.ts
@@ -315,16 +315,15 @@ const buildSectionEdgesFromIterator = (
   let nonStopV1TsId = -1;
   let nonStopTsIds: number[] = [];
   let previousTsId = -1;
-  while (tsIterator.hasNext()) {
-    tsIterator.next();
-    const ts = tsIterator.current().trainrunSection;
+  for (const pair of tsIterator) {
+    const ts = pair.trainrunSection;
     let tsId = ts.getId();
     const trainrunId = reverseIterator
       ? // Minus 1 so we don't conflate 0 with -0.
         -ts.getTrainrunId() - 1
       : ts.getTrainrunId();
 
-    const reverseSection = tsIterator.current().node.getId() !== ts.getTargetNodeId();
+    const reverseSection = pair.node.getId() !== ts.getTargetNodeId();
 
     const v1Time = reverseSection
       ? ts.getTargetDepartureDto().consecutiveTime

--- a/src/integration-testing/trainIterator.test.spec.ts
+++ b/src/integration-testing/trainIterator.test.spec.ts
@@ -87,8 +87,7 @@ describe("TrainrunSection Service Test", () => {
       node1,
       node1.getTrainrunSection(startingTrainrunSection.getTrainrun()),
     );
-    while (itr.hasNext()) {
-      const iteratorObject = itr.next();
+    for (const iteratorObject of itr) {
       expect(iteratorObject.node.getId()).toBe(iteratorNodeIds.shift());
     }
     expect(itr.current().node.getId()).toBe(node2.getId());
@@ -119,8 +118,7 @@ describe("TrainrunSection Service Test", () => {
       node2,
       node2.getTrainrunSection(startingTrainrunSection.getTrainrun()),
     );
-    while (itr.hasNext()) {
-      const iteratorObject = itr.next();
+    for (const iteratorObject of itr) {
       expect(iteratorObject.node.getId()).toBe(iteratorNodeIds.shift());
     }
     expect(itr.current().node.getId()).toBe(node1.getId());
@@ -151,8 +149,7 @@ describe("TrainrunSection Service Test", () => {
       node2,
       node2.getTrainrunSection(startingTrainrunSection.getTrainrun()),
     );
-    while (itr.hasNext()) {
-      const iteratorObject = itr.next();
+    for (const iteratorObject of itr) {
       expect(iteratorObject.node.getId()).toBe(iteratorNodeIds.shift());
     }
     expect(itr.current().node.getId()).toBe(2);


### PR DESCRIPTION
Allows writing `for (const pair of iterator){ ... }` instead of `while (iterator.hasNext()) {...}`

the first 2 commits fix strictNullChecks from the file, the third commit does the thing and the last commit changes while loops to for loops.

There are a bunch of while loops in `trainrun.service.ts` that are meant to find the last pair of the iterator, i haven't changed those. Maybe it's better to have a `ìterator.last()` method for this use case.

Closes #883