### PR TITLE
refactor(model): lower symmetry to trainrun

### DIFF
--- a/src/app/models/trainrun.model.ts
+++ b/src/app/models/trainrun.model.ts
@@ -26,6 +26,8 @@ export class Trainrun {
   private labelIds: number[];
   private direction: Direction;
 
+  private symmetric: boolean = true;
+
   constructor(
     {
       id,
@@ -175,5 +177,13 @@ export class Trainrun {
       labelIds: this.labelIds,
       direction: this.direction,
     };
+  }
+
+  isSymmetric(): boolean {
+    return this.symmetric;
+  }
+
+  setSymmetric(isSymmetric: boolean): void {
+    this.symmetric = isSymmetric;
   }
 }

--- a/src/app/models/trainrunsection.model.ts
+++ b/src/app/models/trainrunsection.model.ts
@@ -254,10 +254,16 @@ export class TrainrunSection {
 
   setSourceSymmetry(sourceSymmetry: boolean) {
     this.sourceSymmetry = sourceSymmetry;
+    if (!sourceSymmetry) {
+      this.trainrun.setSymmetric(false);
+    }
   }
 
   setTargetSymmetry(targetSymmetry: boolean) {
     this.targetSymmetry = targetSymmetry;
+    if (!targetSymmetry) {
+      this.trainrun.setSymmetric(false);
+    }
   }
 
   resetSymmetry() {

--- a/src/app/models/trainrunsection.model.ts
+++ b/src/app/models/trainrunsection.model.ts
@@ -266,14 +266,10 @@ export class TrainrunSection {
     }
   }
 
-  resetSymmetry() {
-    this.sourceSymmetry = true;
-    this.targetSymmetry = true;
-  }
-
   setAsymmetry() {
     this.sourceSymmetry = false;
     this.targetSymmetry = false;
+    this.trainrun.setSymmetric(false);
   }
 
   setSourceArrivalDto(sourceArrivalDto: TimeLockDto) {

--- a/src/app/services/data/trainrun-section-times.service.ts
+++ b/src/app/services/data/trainrun-section-times.service.ts
@@ -595,7 +595,7 @@ export class TrainrunSectionTimesService {
     const {leftSymmetry, rightSymmetry} = this.symmetryStructure;
     leftSection.setTailSymmetry(leftSymmetry);
     rightSection.setHeadSymmetry(rightSymmetry);
-    if (this.areAllSectionsSymmetric()) {
+    if (leftSymmetry && rightSymmetry && this.areAllSectionsSymmetric()) {
       this.selectedTrainrunSection.getTrainrun().setSymmetric(true);
     }
 

--- a/src/app/services/data/trainrun-section-times.service.ts
+++ b/src/app/services/data/trainrun-section-times.service.ts
@@ -595,6 +595,9 @@ export class TrainrunSectionTimesService {
     const {leftSymmetry, rightSymmetry} = this.symmetryStructure;
     leftSection.setTailSymmetry(leftSymmetry);
     rightSection.setHeadSymmetry(rightSymmetry);
+    if (this.areAllSectionsSymmetric()) {
+      this.selectedTrainrunSection.getTrainrun().setSymmetric(true);
+    }
 
     // Asymmetry stops time propagation: if the right side is asymmetric and
     // times are propagated left-to-right, time propagation will stop at the
@@ -611,6 +614,12 @@ export class TrainrunSectionTimesService {
     TrainrunSectionValidator.validateOneSection(rightSection.trainrunSection);
 
     this.trainrunSectionService.trainrunSectionsUpdated();
+  }
+
+  private areAllSectionsSymmetric(): boolean {
+    return this.trainrunSectionService
+      .getAllTrainrunSectionsForTrainrun(this.selectedTrainrunSection.getTrainrun().getId())
+      .every((section) => section.isSymmetric());
   }
 
   /* Buttons in Footer */

--- a/src/app/services/data/trainrunsection.service.ts
+++ b/src/app/services/data/trainrunsection.service.ts
@@ -1120,9 +1120,7 @@ export class TrainrunSectionService implements OnDestroy {
   }
 
   isTrainrunSymmetric(trainrunId: number): boolean {
-    return this.getAllTrainrunSectionsForTrainrun(trainrunId).every((section) =>
-      section.isSymmetric(),
-    );
+    return this.trainrunService.getTrainrunFromId(trainrunId).isSymmetric();
   }
 
   private copyTrainrunSection(

--- a/src/app/services/ui/filter.service.ts
+++ b/src/app/services/ui/filter.service.ts
@@ -393,17 +393,13 @@ export class FilterService implements OnDestroy {
     }
     /* Impelement user defined filtering */
     const filterTrainrunSection = this.checkFilterTrainrunLabels(trainrun.getLabelIds());
-    const trainrunSections = this.dataService.getTrainrunSectionsByTrainrunId(trainrun.getId());
-    const hasAsymmetricalSection = trainrunSections.some(
-      (trainrunSection: TrainrunSection) => !trainrunSection.isSymmetric(),
-    );
     return (
       filterTrainrunSection &&
       this.isFilterTrainrunFrequencyEnabled(trainrun.getTrainrunFrequency()) &&
       this.isFilterTrainrunCategoryEnabled(trainrun.getTrainrunCategory()) &&
       this.isFilterTrainrunTimeCategoryEnabled(trainrun.getTrainrunTimeCategory()) &&
       this.isFilterDirectionEnabled(trainrun.getDirection()) &&
-      this.isFilterSymmetryEnabled(!hasAsymmetricalSection)
+      this.isFilterSymmetryEnabled(trainrun.isSymmetric())
     );
   }
 

--- a/src/app/view/editor-filter-view/editor-filter-view.component.ts
+++ b/src/app/view/editor-filter-view/editor-filter-view.component.ts
@@ -340,8 +340,8 @@ export class EditorFilterViewComponent implements OnInit, OnDestroy {
   }
 
   isAsymmetryActive(): boolean {
-    for (const section of this.dataService.getTrainrunSections()) {
-      if (!section.isSymmetric()) return true;
+    for (const trainrun of this.dataService.getTrainruns()) {
+      if (!trainrun.isSymmetric()) return true;
     }
     return false;
   }


### PR DESCRIPTION
This aims to resolve part of the performance issue addressed here: https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/pull/1248#issuecomment-5206068911

`sourceSymmetry` and `targetSymmetry` are two attributes of a `TrainrunSection` which composes a `Trainrun`. Checking if a `Trainrun` is symmetric implies to iterate over all of its `TrainrunSection`, which can be highly consuming.

This PR brings the symmetry to the `Trainrun` model, allowing to check only one field when one wants to check the symmetry of it.

I'm not sure this is a good pratice, because nothing really avoids the new `Trainrun.symmetric` field to be coherent with the `TrainrunSection.{source/target}Symmetry` of the trainrun.