### PR TITLE
chore(typescript): enable `strict` mode without `strict{NullChecks,FunctionTypes}`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,9 @@
     "lib": ["es2023", "dom"],
     "resolveJsonModule": true,
     "useDefineForClassFields": false,
+    "strict": true,
+    "strictNullChecks": false,
+    "strictFunctionTypes": false,
     "noImplicitAny": true,
     "noUnusedParameters": true
   },


### PR DESCRIPTION
The `strict` option enables a range of checks: https://www.typescriptlang.org/tsconfig/#strict

Enable everything except `strictNullChecks` and `strictFunctionTypes` because these trigger a few hundred errors. We should fix these two incrementally.

References: https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/issues/1289