### PR TITLE
Move Transition.path to TransitionViewObject.path

### DIFF
--- a/src/app/models/node.model.ts
+++ b/src/app/models/node.model.ts
@@ -12,7 +12,6 @@ import {
 import {Port} from "./port.model";
 import {TrainrunSection} from "./trainrunsection.model";
 import {Transition} from "./transition.model";
-import {SimpleTrainrunSectionRouter} from "../services/util/trainrunsection.routing";
 import {Trainrun} from "./trainrun.model";
 import {
   PortAlignment,
@@ -104,7 +103,6 @@ export class Node {
 
     DataMigration.migrateNodeLabelIds(this);
 
-    this.updateTransitionsRouting();
     this.validateConnections();
   }
 
@@ -320,12 +318,6 @@ export class Node {
       }
     });
     return currentMaxIndex;
-  }
-
-  computeTransitionRouting(transition: Transition) {
-    const port1 = this.getPort(transition.getPortId1());
-    const port2 = this.getPort(transition.getPortId2());
-    transition.setPath(SimpleTrainrunSectionRouter.routeTransition(this, port1, port2));
   }
 
   addPort(alignment: PortAlignment, trainrunSection: TrainrunSection): number {
@@ -552,12 +544,7 @@ export class Node {
     return this.ports.find((port) => port.getTrainrunSectionId() === trainrunSectionId);
   }
 
-  addTransitionAndComputeRouting(
-    port1: Port,
-    port2: Port,
-    trainrun: Trainrun,
-    isNonStop = false,
-  ): Transition {
+  addTransition(port1: Port, port2: Port, trainrun: Trainrun, isNonStop = false): Transition {
     const transition: Transition = new Transition();
     transition.setPort1Id(port1.getId());
     transition.setPort2Id(port2.getId());
@@ -567,7 +554,6 @@ export class Node {
         : this.trainrunCategoryHaltezeiten[trainrun.getTrainrunCategory().fachCategory].no_halt,
     );
     transition.setTrainrun(trainrun);
-    this.computeTransitionRouting(transition);
     this.transitions.push(transition);
     return transition;
   }
@@ -584,14 +570,7 @@ export class Node {
     orderingType: OrderingAlgorithm = OrderingAlgorithm.Alphabetical,
   ) {
     this.reorderAllPorts(orderingType);
-    this.updateTransitionsRouting();
     this.validateConnections();
-  }
-
-  updateTransitionsRouting() {
-    this.transitions.forEach((transition) => {
-      this.computeTransitionRouting(transition);
-    });
   }
 
   validateConnections() {

--- a/src/app/models/trainrunsection.model.spec.ts
+++ b/src/app/models/trainrunsection.model.spec.ts
@@ -518,7 +518,7 @@ describe("TrainrunSection Model Test", () => {
 
     const port1 = node2.addPort(PortAlignment.Left, ts1);
     const port2 = node2.addPort(PortAlignment.Right, ts2);
-    node2.addTransitionAndComputeRouting(node2.getPort(port1), node2.getPort(port2), tr, true);
+    node2.addTransition(node2.getPort(port1), node2.getPort(port2), tr, true);
 
     const t1 = node1.getTransition(ts1.getId());
     const t2 = node1.getTransition(ts2.getId());
@@ -557,7 +557,7 @@ describe("TrainrunSection Model Test", () => {
 
     const port1 = node2.addPort(PortAlignment.Left, ts1);
     const port2 = node2.addPort(PortAlignment.Right, ts2);
-    node2.addTransitionAndComputeRouting(node2.getPort(port1), node2.getPort(port2), tr, true);
+    node2.addTransition(node2.getPort(port1), node2.getPort(port2), tr, true);
 
     const e1 = node1.isEndNode(ts1);
     const e2 = node1.isEndNode(ts2);
@@ -588,7 +588,7 @@ describe("TrainrunSection Model Test", () => {
 
     const port1 = node2.addPort(PortAlignment.Left, ts1);
     const port2 = node2.addPort(PortAlignment.Right, ts2);
-    node2.addTransitionAndComputeRouting(node2.getPort(port1), node2.getPort(port2), tr, true);
+    node2.addTransition(node2.getPort(port1), node2.getPort(port2), tr, true);
 
     const ts001 = node1.getExtremityTrainrunSection(tr.getId());
     const ts002 = node2.getExtremityTrainrunSection(tr.getId());

--- a/src/app/models/transition.model.ts
+++ b/src/app/models/transition.model.ts
@@ -1,5 +1,4 @@
 import {TransitionDto} from "../data-structures/technical.data.structures";
-import {Vec2D} from "../utils/vec2D";
 import {Trainrun} from "./trainrun.model";
 
 export class Transition {
@@ -11,7 +10,6 @@ export class Transition {
   private isNonStopTransit: boolean;
 
   private trainrun: Trainrun;
-  private path: Vec2D[];
 
   constructor(
     {id, port1Id, port2Id, isNonStopTransit}: TransitionDto = {
@@ -77,14 +75,6 @@ export class Transition {
 
   setTrainrun(trainrun: Trainrun) {
     this.trainrun = trainrun;
-  }
-
-  setPath(path: Vec2D[]) {
-    this.path = path;
-  }
-
-  getPath(): Vec2D[] {
-    return this.path;
   }
 
   getDto(): TransitionDto {

--- a/src/app/services/data/node.service.ts
+++ b/src/app/services/data/node.service.ts
@@ -200,7 +200,6 @@ export class NodeService implements OnDestroy {
     if (this.usesOptimizePorts()) {
       optimizePorts(this.nodesStore.nodes, this.getClutterWeights());
       this.nodesStore.nodes.forEach((node) => {
-        node.updateTransitionsRouting();
         node.validateConnections();
         this.trainrunSectionService.updateTrainrunSectionRouting(node, false);
       });
@@ -613,20 +612,20 @@ export class NodeService implements OnDestroy {
     return !checkPort1 || !checkPort2;
   }
 
-  addTransitionAndComputeRoutingFromFreePorts(node: Node, trainrun: Trainrun, isNonStop = false) {
+  addTransition(node: Node, trainrun: Trainrun, isNonStop = false) {
     const freePorts = node.getFreePortsForTrainrun(trainrun.getId());
     if (freePorts.length <= 1) {
       return;
     }
     if (this.checkExistsNoCycleTrainrunAfterFreePortsConnecting(freePorts[0], freePorts[1])) {
-      node.addTransitionAndComputeRouting(freePorts[0], freePorts[1], trainrun, isNonStop);
+      node.addTransition(freePorts[0], freePorts[1], trainrun, isNonStop);
     } else {
       if (freePorts.length === 3) {
         if (this.checkExistsNoCycleTrainrunAfterFreePortsConnecting(freePorts[0], freePorts[2])) {
-          node.addTransitionAndComputeRouting(freePorts[0], freePorts[2], trainrun, isNonStop);
+          node.addTransition(freePorts[0], freePorts[2], trainrun, isNonStop);
         } else {
           if (this.checkExistsNoCycleTrainrunAfterFreePortsConnecting(freePorts[1], freePorts[2])) {
-            node.addTransitionAndComputeRouting(freePorts[1], freePorts[2], trainrun, isNonStop);
+            node.addTransition(freePorts[1], freePorts[2], trainrun, isNonStop);
           }
         }
       }
@@ -641,7 +640,7 @@ export class NodeService implements OnDestroy {
     const node = this.getNodeFromId(nodeId);
     const port1 = node.getPortOfTrainrunSection(trainrunSection1.getId());
     const port2 = node.getPortOfTrainrunSection(trainrunSection2.getId());
-    node.addTransitionAndComputeRouting(port1, port2, trainrunSection1.getTrainrun());
+    node.addTransition(port1, port2, trainrunSection1.getTrainrun());
   }
 
   addTransitionToNodes(
@@ -652,18 +651,10 @@ export class NodeService implements OnDestroy {
     targetIsNonStop = false,
   ) {
     const sourceNode = this.getNodeFromId(sourceNodeId);
-    this.addTransitionAndComputeRoutingFromFreePorts(
-      sourceNode,
-      trainrunSection.getTrainrun(),
-      sourceIsNonStop,
-    );
+    this.addTransition(sourceNode, trainrunSection.getTrainrun(), sourceIsNonStop);
 
     const targetNode = this.getNodeFromId(targetNodeId);
-    this.addTransitionAndComputeRoutingFromFreePorts(
-      targetNode,
-      trainrunSection.getTrainrun(),
-      targetIsNonStop,
-    );
+    this.addTransition(targetNode, trainrunSection.getTrainrun(), targetIsNonStop);
   }
 
   isConditionToAddTransitionFullfilled(node: Node, trainrunSection: TrainrunSection): boolean {
@@ -1086,12 +1077,12 @@ export class NodeService implements OnDestroy {
     }
     // source node
     if (this.isConditionToAddTransitionFullfilled(sourceNode, trainrunSection)) {
-      this.addTransitionAndComputeRoutingFromFreePorts(sourceNode, trainrun);
+      this.addTransition(sourceNode, trainrun);
     }
 
     // target node
     if (this.isConditionToAddTransitionFullfilled(targetNode, trainrunSection)) {
-      this.addTransitionAndComputeRoutingFromFreePorts(targetNode, trainrun);
+      this.addTransition(targetNode, trainrun);
     }
     if (enforceUpdate) {
       this.transitionsUpdated();
@@ -1235,7 +1226,6 @@ export class NodeService implements OnDestroy {
       if (this.usesOptimizePorts()) {
         optimizePorts(this.nodesStore.nodes, this.getClutterWeights());
         this.nodesStore.nodes.forEach((n) => {
-          n.updateTransitionsRouting();
           n.validateConnections();
           this.trainrunSectionService.updateTrainrunSectionRouting(n, enforceUpdate);
         });
@@ -1250,7 +1240,6 @@ export class NodeService implements OnDestroy {
       this.operation.emit(new NodeOperation(OperationType.update, node));
     }
 
-    node.updateTransitionsRouting();
     node.validateConnections();
     this.trainrunSectionService.updateTrainrunSectionRouting(node, enforceUpdate);
   }

--- a/src/app/services/data/trainrun.service.ts
+++ b/src/app/services/data/trainrun.service.ts
@@ -451,7 +451,7 @@ export class TrainrunService {
     const trans1 = node.getTransitionFromPortId(port1.getId());
     const trans2 = node.getTransitionFromPortId(port2.getId());
     if (trans1 === undefined && trans2 === undefined) {
-      const trans = node.addTransitionAndComputeRouting(port1, port2, trainrun1);
+      const trans = node.addTransition(port1, port2, trainrun1);
       if (60 + arrivalTimeAtNode === departTimeAtNode + frequencyOffset) {
         trans.setIsNonStopTransit(true);
       } else {

--- a/src/app/services/data/trainrunsection.service.ts
+++ b/src/app/services/data/trainrunsection.service.ts
@@ -692,10 +692,7 @@ export class TrainrunSectionService implements OnDestroy {
     const orderingType = this.nodeService.getCurrentOrderingAlgorithm();
     nodeToNew.addPortWithRespectToOppositeNode(nodeFrom, trainrunSection, orderingType);
     if (this.nodeService.isConditionToAddTransitionFullfilled(nodeToNew, trainrunSection)) {
-      this.nodeService.addTransitionAndComputeRoutingFromFreePorts(
-        nodeToNew,
-        trainrunSection.getTrainrun(),
-      );
+      this.nodeService.addTransition(nodeToNew, trainrunSection.getTrainrun());
     }
     nodeFrom.reAlignPortWithRespectToOppositeNode(nodeToNew, trainrunSection, orderingType);
 

--- a/src/app/services/util/port-ordering.test-helpers.ts
+++ b/src/app/services/util/port-ordering.test-helpers.ts
@@ -64,7 +64,7 @@ export function buildNetwork(def: {
       const node = nodesMap.get(path[i]);
       const port1 = node.getPort(portIds.get(path[i]).get(path[i - 1]));
       const port2 = node.getPort(portIds.get(path[i]).get(path[i + 1]));
-      node.addTransitionAndComputeRouting(port1, port2, trainrun, true);
+      node.addTransition(port1, port2, trainrun, true);
     }
   }
 

--- a/src/app/view/editor-main-view/data-views/trainrunsection.previewline.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsection.previewline.view.ts
@@ -194,8 +194,13 @@ export class TrainrunSectionPreviewLineView {
       this.hideConnectionPreviewLine();
       this.displayTrainrunSectionPreviewLine();
       if (this.dragTransitionInfo.insideNode) {
-        const startPos = this.dragTransitionInfo.transition.getPath()[0];
-        const endPos = this.dragTransitionInfo.transition.getPath()[3];
+        const node = this.dragTransitionInfo.node;
+        const transition = this.dragTransitionInfo.transition;
+        const port1 = node.getPort(transition.getPortId1());
+        const port2 = node.getPort(transition.getPortId2());
+        const path = SimpleTrainrunSectionRouter.routeTransition(node, port1, port2);
+        const startPos = path[0];
+        const endPos = path[3];
         D3Utils.updateIntermediateStopOrTransitionPreviewLine(event, startPos, endPos);
       } else {
         const node1 =

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -26,11 +26,11 @@ import {Trainrun} from "../../../models/trainrun.model";
 import {TrainrunSectionViewObject} from "./trainrunSectionViewObject";
 import {Node} from "../../../models/node.model";
 import {EditorMode} from "../../editor-menu/editor-mode";
-import {Transition} from "../../../models/transition.model";
 import {InformSelectedTrainrunClick} from "../../../services/data/trainrunsection.service";
 import {LevelOfDetail} from "../../../services/ui/level.of.detail.service";
 import {LinePatternRefs} from "../../../data-structures/business.data.structures";
 import {TrainrunsectionHelper} from "src/app/services/util/trainrunsection.helper";
+import {TransitionViewObject} from "./transitionViewObject";
 
 export class TrainrunSectionsView {
   trainrunSectionGroup: d3.Selection<SVGElement, undefined, Element, undefined>;
@@ -2220,9 +2220,12 @@ export class TrainrunSectionsView {
       );
       transformedPath = transformedPath.reverse();
 
-      const transitionObject: Transition = srcNode.getTransition(ts.getId());
+      const transitionObject = new TransitionViewObject(
+        this.editorView,
+        srcNode.getTransition(ts.getId()),
+      );
       if (transitionObject !== undefined) {
-        const tPath = Object.assign([], transitionObject.getPath());
+        const tPath = Object.assign([], transitionObject.path);
         const n0 = Vec2D.norm(Vec2D.sub(element, tPath[0]));
         const n1 = Vec2D.norm(Vec2D.sub(element, tPath[3]));
         if (n0 <= n1) {
@@ -2261,9 +2264,12 @@ export class TrainrunSectionsView {
         transformedPath,
       );
 
-      const transitionObject: Transition = trgNode.getTransition(ts.getId());
+      const transitionObject = new TransitionViewObject(
+        this.editorView,
+        trgNode.getTransition(ts.getId()),
+      );
       if (transitionObject !== undefined) {
-        const tPath = Object.assign([], transitionObject.getPath());
+        const tPath = Object.assign([], transitionObject.path);
         const n0 = Vec2D.norm(Vec2D.sub(element, tPath[0]));
         const n1 = Vec2D.norm(Vec2D.sub(element, tPath[3]));
         if (n0 <= n1) {

--- a/src/app/view/editor-main-view/data-views/transitionViewObject.ts
+++ b/src/app/view/editor-main-view/data-views/transitionViewObject.ts
@@ -1,53 +1,60 @@
+import {Vec2D} from "src/app/utils/vec2D";
 import {Transition} from "../../../models/transition.model";
 import {EditorView} from "./editor.view";
+import {SimpleTrainrunSectionRouter} from "src/app/services/util/trainrunsection.routing";
 
 export class TransitionViewObject {
   key: string;
+  readonly path: Vec2D[];
 
   constructor(
-    editorView: EditorView,
+    private editorView: EditorView,
     public transition: Transition,
-    isMuted: boolean,
+    private isMuted: boolean = false,
   ) {
-    this.key = TransitionViewObject.generateKey(editorView, transition, isMuted);
+    const node = editorView.getNodeFromTransition(transition);
+    const port1 = node.getPort(transition.getPortId1());
+    const port2 = node.getPort(transition.getPortId2());
+    this.path = SimpleTrainrunSectionRouter.routeTransition(node, port1, port2);
+    this.key = this.generateKey();
   }
 
-  static generateKey(editorView: EditorView, transition: Transition, isMuted: boolean): string {
+  private generateKey(): string {
     let key =
       "#" +
-      transition.getId() +
+      this.transition.getId() +
       "@" +
-      transition.getIsNonStopTransit() +
+      this.transition.getIsNonStopTransit() +
       "_" +
-      transition.getTrainrun().selected() +
+      this.transition.getTrainrun().selected() +
       "_" +
-      transition.getTrainrun().getTrainrunCategory().shortName +
+      this.transition.getTrainrun().getTrainrunCategory().shortName +
       "_" +
-      transition.getTrainrun().getTrainrunFrequency().shortName +
+      this.transition.getTrainrun().getTrainrunFrequency().shortName +
       "_" +
-      transition.getTrainrun().getTrainrunTimeCategory().shortName +
+      this.transition.getTrainrun().getTrainrunTimeCategory().shortName +
       "_" +
-      transition.getTrainrun().getTrainrunCategory().id +
+      this.transition.getTrainrun().getTrainrunCategory().id +
       "_" +
-      transition.getTrainrun().getTrainrunFrequency().id +
+      this.transition.getTrainrun().getTrainrunFrequency().id +
       "_" +
-      transition.getTrainrun().getTrainrunTimeCategory().id +
+      this.transition.getTrainrun().getTrainrunTimeCategory().id +
       "_" +
-      transition.getTrainrun().getTrainrunCategory().colorRef +
+      this.transition.getTrainrun().getTrainrunCategory().colorRef +
       "_" +
-      transition.getTrainrun().getTrainrunFrequency().linePatternRef +
+      this.transition.getTrainrun().getTrainrunFrequency().linePatternRef +
       "_" +
-      transition.getTrainrun().getTrainrunTimeCategory().linePatternRef +
+      this.transition.getTrainrun().getTrainrunTimeCategory().linePatternRef +
       "_" +
-      transition.getTrainrun().getTrainrunFrequency().frequency +
+      this.transition.getTrainrun().getTrainrunFrequency().frequency +
       "_" +
-      editorView.isTemporaryDisableFilteringOfItemsInViewEnabled() +
+      this.editorView.isTemporaryDisableFilteringOfItemsInViewEnabled() +
       "_" +
-      isMuted +
+      this.isMuted +
       "_" +
-      editorView.trainrunSectionPreviewLineView.getVariantIsWritable();
+      this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable();
 
-    transition.getPath().forEach((p) => {
+    this.path.forEach((p) => {
       key += p.toString();
     });
     return key;

--- a/src/app/view/editor-main-view/data-views/transitions.view.ts
+++ b/src/app/view/editor-main-view/data-views/transitions.view.ts
@@ -118,7 +118,7 @@ export class TransitionsView {
       .classed(StaticDomTags.TAG_SELECTED, (t: TransitionViewObject) =>
         t.transition.getTrainrun().selected(),
       )
-      .attr("d", (t: TransitionViewObject) => D3Utils.getPathAsSVGString(t.transition.getPath()));
+      .attr("d", (t: TransitionViewObject) => D3Utils.getPathAsSVGString(t.path));
   }
 
   createNonStopToggle(
@@ -147,7 +147,7 @@ export class TransitionsView {
       )
       .attr("points", (t: TransitionViewObject) =>
         D3Utils.makeHexagonSVGPoints(
-          Vec2D.scale(Vec2D.add(t.transition.getPath()[1], t.transition.getPath()[2]), 0.5),
+          Vec2D.scale(Vec2D.add(t.path[1], t.path[2]), 0.5),
           StaticDomTags.TRANSITION_BUTTON_SIZE,
         ),
       )
@@ -196,8 +196,9 @@ export class TransitionsView {
 
     const transitions = inputTransitions.filter(
       (t) =>
-        this.editorView.doCullCheckPositionsInViewport(t.getPath()) &&
-        this.filtertransitionToDisplay(t, t.getTrainrun()),
+        this.editorView.doCullCheckPositionsInViewport(
+          new TransitionViewObject(this.editorView, t).path,
+        ) && this.filtertransitionToDisplay(t, t.getTrainrun()),
     );
 
     this.createTransitions(transitions, selectedTrainrun, connectedTrainIds, true);

--- a/src/integration-testing/node.service.test.spec.ts
+++ b/src/integration-testing/node.service.test.spec.ts
@@ -281,7 +281,9 @@ describe("NodeService Test", () => {
     expect(transition3.getDto().id).toBe(3);
     expect(transition4.getDto().id).toBe(4);
 
-    const transitionPath1 = transition1.getPath();
+    const port1 = nodeOL.getPort(transition1.getPortId1());
+    const port2 = nodeOL.getPort(transition1.getPortId1());
+    const transitionPath1 = SimpleTrainrunSectionRouter.routeTransition(nodeOL, port1, port2);
     expect(transitionPath1.length).toBe(4);
 
     const trainrun1 = transition1.getTrainrun();


### PR DESCRIPTION
This PR removes the path information from the `Transition` class and moves it to `TransitionViewObject` .

You can inspect commits one by one, linting at the end