### PR TITLE
refactor:chore: eliminate explicit any

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -50,7 +50,7 @@ export default defineConfig([
           allow: ["private-constructors"],
         },
       ],
-      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-explicit-any": "error",
       "@typescript-eslint/no-unused-expressions": [
         "error",
         {

--- a/src/app/services/data/version-control.service.ts
+++ b/src/app/services/data/version-control.service.ts
@@ -174,11 +174,11 @@ export class VersionControlService implements OnDestroy {
       .subscribe(() => this.reload());
   }
 
-  archiveVariantWithId(variantId: number): Observable<any> {
+  archiveVariantWithId(variantId: number): Observable<void> {
     return this.variantsBackendService.archiveVariant(variantId).pipe(takeUntil(this.destroyed));
   }
 
-  unarchiveVariantWithId(variantId: number): Observable<any> {
+  unarchiveVariantWithId(variantId: number): Observable<void> {
     return this.variantsBackendService.unarchiveVariant(variantId).pipe(takeUntil(this.destroyed));
   }
 

--- a/src/app/utils/form-model.ts
+++ b/src/app/utils/form-model.ts
@@ -44,7 +44,7 @@ export class FormModel<T> {
     this.form.markAllAsTouched();
 
     if (this.form.valid) {
-      const object: {[key: string]: any} = {};
+      const object: {[key: string]: unknown} = {};
       this.keys.forEach((key) => (object[key] = this.controls[key].value));
 
       return object as T;

--- a/src/app/utils/http-error-interceptor.ts
+++ b/src/app/utils/http-error-interceptor.ts
@@ -18,7 +18,7 @@ export class HttpErrorInterceptor implements HttpInterceptor {
     private logService: LogService,
   ) {}
 
-  intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+  intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     return next.handle(request).pipe(
       catchError((error: HttpErrorResponse) => {
         if (error.error instanceof ErrorEvent) {

--- a/src/app/view/dialogs/basedata-dialog/basedata-dialog.component.ts
+++ b/src/app/view/dialogs/basedata-dialog/basedata-dialog.component.ts
@@ -38,7 +38,7 @@ export class BaseDataDialogComponent implements OnDestroy {
     "pos",
     "create",
   ];
-  dataSource: SbbTableDataSource<any>;
+  dataSource: SbbTableDataSource<Record<string, unknown>>;
   private destroyed = new Subject<void>();
 
   constructor(

--- a/src/app/view/dialogs/note-dialog/htmlEditor/html-editor.component.ts
+++ b/src/app/view/dialogs/note-dialog/htmlEditor/html-editor.component.ts
@@ -197,12 +197,12 @@ export class HtmlEditorComponent implements OnInit, OnDestroy {
     );
   }
 
-  private update = (view: any) => {
+  private update = (view: Editor["view"]) => {
     const {state} = view;
     this.textBasedActiveColor = this.getColorActive(state);
   };
 
-  private getColorActive(state: any): string[] {
+  private getColorActive(state: Editor["view"]["state"]): string[] {
     const {schema} = state;
     const type = schema.marks.text_color;
     if (!type) {

--- a/src/app/view/editor-main-view/data-views/d3.utils.ts
+++ b/src/app/view/editor-main-view/data-views/d3.utils.ts
@@ -15,7 +15,7 @@ export class D3Utils {
   static isShortestDistanceRendererEnabled = false;
 
   private static doFastRenderingUpdate = false;
-  private static isOnFront: any;
+  private static isOnFront: SVGElement;
 
   static enableFastRenderingUpdate() {
     D3Utils.doFastRenderingUpdate = true;

--- a/src/app/view/editor-main-view/data-views/trainrunsection.previewline.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsection.previewline.view.ts
@@ -22,7 +22,7 @@ export class DragIntermediateStopInfo {
   constructor(
     public trainrunSection: TrainrunSection,
     public intermediateStopIndex: number,
-    public domRef: any,
+    public domRef: SVGElement,
   ) {}
 }
 
@@ -33,7 +33,7 @@ export class DragTransitionInfo {
     public trainrunSection2: TrainrunSection,
     public transition: Transition,
     public insideNode: boolean,
-    public domRef: any,
+    public domRef: SVGElement,
   ) {}
 
   setInsideNode(flag: boolean) {

--- a/src/app/view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component.html
+++ b/src/app/view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component.html
@@ -14,7 +14,7 @@
       <input
         sbbInput
         [ngModel]="nodeProperties.nodeBetriebspunktName"
-        (change)="onBetriebspunktNameChanged($event)"
+        (change)="onBetriebspunktNameChanged($event.target.value)"
       />
     </sbb-form-field>
     <sbb-form-field
@@ -25,7 +25,7 @@
       <input
         sbbInput
         [ngModel]="nodeProperties.nodeBetriebspunktFullName"
-        (change)="onFullNameChanged($event)"
+        (change)="onFullNameChanged($event.target.value)"
       />
     </sbb-form-field>
     <sbb-form-field

--- a/src/app/view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component.ts
+++ b/src/app/view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component.ts
@@ -89,13 +89,13 @@ export class EditorNodeDetailViewComponent implements OnInit, OnDestroy {
     this.destroyed.complete();
   }
 
-  onBetriebspunktNameChanged(event: any) {
-    this.nodeService.changeNodeBetriebspunktName(this.nodeProperties.nodeId, event.target.value);
+  onBetriebspunktNameChanged(name: string) {
+    this.nodeService.changeNodeBetriebspunktName(this.nodeProperties.nodeId, name);
     this.uiInteractionService.updateNodeBaseData();
   }
 
-  onFullNameChanged(event: any) {
-    this.nodeService.changeNodeFullName(this.nodeProperties.nodeId, event.target.value);
+  onFullNameChanged(name: string) {
+    this.nodeService.changeNodeFullName(this.nodeProperties.nodeId, name);
   }
 
   onConnectionTimeChanged() {

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -80,7 +80,7 @@ export class EditorToolsViewComponent {
     const file = fileInput.files[0];
     const reader = new FileReader();
     reader.onload = () => {
-      let netzgrafikDto: any;
+      let netzgrafikDto: NetzgrafikDto;
       try {
         netzgrafikDto = JSON.parse(reader.result.toString());
       } catch {
@@ -240,7 +240,10 @@ export class EditorToolsViewComponent {
     });
     const url = window.URL.createObjectURL(blob);
 
-    const nav = window.navigator as any;
+    const nav = window.navigator as Navigator & {
+      msSaveOrOpenBlob?: unknown;
+      msSaveBlob?: (blob: Blob, filename: string) => void;
+    };
     if (nav.msSaveOrOpenBlob) {
       nav.msSaveBlob(blob, filename);
     } else {

--- a/src/app/view/navigation-bar/navigation-bar.component.ts
+++ b/src/app/view/navigation-bar/navigation-bar.component.ts
@@ -150,7 +150,7 @@ interface BreadcrumbsDefinition {
 
 interface BreadcrumbDefinition {
   name: Observable<string>;
-  route: any[];
+  route: (string | number)[];
 }
 
 class Param {

--- a/src/app/view/util/download-utils.ts
+++ b/src/app/view/util/download-utils.ts
@@ -1,6 +1,9 @@
 export const downloadBlob = (blob: Blob, fileName: string) => {
   // https://framagit.org/i.kulgu/lufi/commit/a2921150c4289dffaa40b7feddcd900019655938#663e1fb05fc330c70ed7420bccacc19fb45be9b7
-  const nav = window.navigator as any;
+  const nav = window.navigator as Navigator & {
+    msSaveOrOpenBlob?: unknown;
+    msSaveBlob?: (blob: Blob, filename: string) => void;
+  };
   if (nav.msSaveOrOpenBlob) {
     nav.msSaveBlob(blob, fileName);
   } else {

--- a/src/app/view/variant/variants-view/variants-view.component.spec.ts
+++ b/src/app/view/variant/variants-view/variants-view.component.spec.ts
@@ -10,7 +10,7 @@ import {
   VariantControllerBackendService,
   VersionControllerBackendService,
 } from "../../../api/generated";
-import {of} from "rxjs";
+import {Observable, of} from "rxjs";
 import {ActivatedRoute} from "@angular/router";
 import {NavigationService} from "../../../services/ui/navigation.service";
 import {VersionControlService} from "../../../services/data/version-control.service";
@@ -22,8 +22,8 @@ describe("VariantsViewComponent", () => {
   let component: VariantsViewComponent;
   let fixture: ComponentFixture<VariantsViewComponent>;
 
-  let projectControllerBackendService: Partial<ProjectControllerBackendService>;
-  let variantControllerBackendService: Partial<VariantControllerBackendService>;
+  let projectControllerBackendService: {getProject: () => Observable<ProjectDto>};
+  let variantControllerBackendService: {createVariant: () => Observable<number>};
   let activatedRoute: Partial<ActivatedRoute>;
   let versionControlService: Partial<VersionControlService>;
   let versionControllerBackendService: Partial<VersionControllerBackendService>;
@@ -46,7 +46,7 @@ describe("VariantsViewComponent", () => {
           writeUsers: [],
           readUsers: [],
         };
-        return of(project as any);
+        return of(project);
       },
     };
     activatedRoute = {
@@ -56,7 +56,7 @@ describe("VariantsViewComponent", () => {
       }),
     };
     variantControllerBackendService = {
-      createVariant: () => of(10 as any),
+      createVariant: () => of(10),
     };
 
     await TestBed.configureTestingModule({

--- a/src/benchmarks/port-ordering.benchmark.spec.ts
+++ b/src/benchmarks/port-ordering.benchmark.spec.ts
@@ -24,13 +24,14 @@ import {
 } from "../app/services/util/port-ordering.crossings";
 import {countAllSeparations} from "../app/services/util/port-ordering.separations";
 import {Node} from "../app/models/node.model";
+import {NetzgrafikDto} from "../app/data-structures/business.data.structures";
 
 import demoStandaloneGithub from "../app/sample-netzgrafik/netzgrafik_demo_standalone_github.json";
 import demoOlLz from "../app/sample-netzgrafik/Demo_OL_LZ.json";
 
-const DATASETS: {name: string; dto: unknown}[] = [
-  {name: "demo_standalone_github", dto: demoStandaloneGithub},
-  {name: "Demo_OL_LZ", dto: demoOlLz},
+const DATASETS: {name: string; dto: NetzgrafikDto}[] = [
+  {name: "demo_standalone_github", dto: demoStandaloneGithub as NetzgrafikDto},
+  {name: "Demo_OL_LZ", dto: demoOlLz as NetzgrafikDto},
 ];
 
 // Weight setups to compare, each steering the optimizer toward a different clutter trade-off:
@@ -157,9 +158,9 @@ const createServices = (): {dataService: DataService; nodeService: NodeService} 
 const loadAlphabetical = (
   dataService: DataService,
   nodeService: NodeService,
-  dto: unknown,
+  dto: NetzgrafikDto,
 ): Node[] => {
-  dataService.loadNetzgrafikDto(structuredClone(dto) as any);
+  dataService.loadNetzgrafikDto(structuredClone(dto));
   nodeService.initPortOrdering(OrderingAlgorithm.Alphabetical);
   return nodeService.nodesStore.nodes;
 };
@@ -171,7 +172,7 @@ describe("port-ordering benchmark", () => {
 
       // Alphabetical baseline clutter (same order for every setup, only the weighting differs):
       const baseline = measureClutter(loadAlphabetical(dataService, nodeService, dto));
-      const trainruns = (dto as {trainruns?: unknown[]}).trainruns?.length ?? 0;
+      const trainruns = dto.trainruns?.length ?? 0;
       const nodeCount = nodeService.nodesStore.nodes.length;
 
       const rows: BenchmarkRow[] = [];


### PR DESCRIPTION
This PR clean the last occurrences of `any` in the codebase and enable the ts-eslint rule `no-explicit-any`.