### PR TITLE
Fix cumulative travel time display for non-stop sections with collapsed nodes

### DIFF
--- a/src/app/services/data/trainrun.service.ts
+++ b/src/app/services/data/trainrun.service.ts
@@ -757,32 +757,18 @@ export class TrainrunService {
     return iterator.current().trainrunSection;
   }
 
+  // Note: this includes stop time at intermediate collapsed nodes
   getCumulativeTravelTime(
     trainrunSection: TrainrunSection,
     direction: "sourceToTarget" | "targetToSource",
   ): number {
-    let iterator = this.getNextExpandedStopIterator(
-      trainrunSection.getSourceNode(),
+    const extendedGroup = this.trainrunSectionService.getTrainrunSectionGroupForSection(
       trainrunSection,
+      true,
     );
-    while (iterator.hasNext()) {
-      iterator.next();
-    }
-
-    iterator = this.getNextExpandedStopIterator(
-      iterator.current().node,
-      iterator.current().trainrunSection,
-    );
-    let summedTravelTime = 0;
-    while (iterator.hasNext()) {
-      const nextPair = iterator.next();
-      if (direction === "sourceToTarget") {
-        summedTravelTime += nextPair.trainrunSection.getTravelTime();
-      } else {
-        summedTravelTime += nextPair.trainrunSection.getBackwardTravelTime();
-      }
-    }
-    return summedTravelTime;
+    return direction === "sourceToTarget"
+      ? TrainrunsectionHelper.getTravelTimeForSectionGroup(extendedGroup)
+      : TrainrunsectionHelper.getBackwardTravelTimeForSectionGroup(extendedGroup);
   }
 
   getCumulativeTravelTimeAndNodePath(

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.spec.ts
@@ -1334,56 +1334,72 @@ describe("TrainrunSection-View", () => {
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
 
     const v0 = TrainrunSectionsView.extractTravelTime(
-      trainrunSectionService.getTrainrunSectionFromId(0),
+      new TrainrunSectionViewObject(editorView, [
+        trainrunSectionService.getTrainrunSectionFromId(0),
+      ]),
       editorView,
       "sourceToTarget",
     );
     expect(v0).toBe("10'");
 
     const v1 = TrainrunSectionsView.extractTravelTime(
-      trainrunSectionService.getTrainrunSectionFromId(1),
+      new TrainrunSectionViewObject(editorView, [
+        trainrunSectionService.getTrainrunSectionFromId(1),
+      ]),
       editorView,
       "sourceToTarget",
     );
     expect(v1).toBe("10'");
 
     const v2 = TrainrunSectionsView.extractTravelTime(
-      trainrunSectionService.getTrainrunSectionFromId(2),
+      new TrainrunSectionViewObject(editorView, [
+        trainrunSectionService.getTrainrunSectionFromId(2),
+      ]),
       editorView,
       "sourceToTarget",
     );
     expect(v2).toBe("20'");
 
     const v3 = TrainrunSectionsView.extractTravelTime(
-      trainrunSectionService.getTrainrunSectionFromId(3),
+      new TrainrunSectionViewObject(editorView, [
+        trainrunSectionService.getTrainrunSectionFromId(3),
+      ]),
       editorView,
       "sourceToTarget",
     );
     expect(v3).toBe("49' (39')");
 
     const v4 = TrainrunSectionsView.extractTravelTime(
-      trainrunSectionService.getTrainrunSectionFromId(4),
+      new TrainrunSectionViewObject(editorView, [
+        trainrunSectionService.getTrainrunSectionFromId(4),
+      ]),
       editorView,
       "sourceToTarget",
     );
     expect(v4).toBe("49' (10')");
 
     const v5 = TrainrunSectionsView.extractTravelTime(
-      trainrunSectionService.getTrainrunSectionFromId(5),
+      new TrainrunSectionViewObject(editorView, [
+        trainrunSectionService.getTrainrunSectionFromId(5),
+      ]),
       editorView,
       "sourceToTarget",
     );
     expect(v5).toBe("51'");
 
     const v6 = TrainrunSectionsView.extractTravelTime(
-      trainrunSectionService.getTrainrunSectionFromId(6),
+      new TrainrunSectionViewObject(editorView, [
+        trainrunSectionService.getTrainrunSectionFromId(6),
+      ]),
       editorView,
       "sourceToTarget",
     );
     expect(v6).toBe("10'");
 
     const v7 = TrainrunSectionsView.extractTravelTime(
-      trainrunSectionService.getTrainrunSectionFromId(7),
+      new TrainrunSectionViewObject(editorView, [
+        trainrunSectionService.getTrainrunSectionFromId(7),
+      ]),
       editorView,
       "sourceToTarget",
     );
@@ -1399,7 +1415,11 @@ describe("TrainrunSection-View", () => {
     const t2 = n2.getTransition(ts.getId());
     t1.setIsNonStopTransit(true);
     t2.setIsNonStopTransit(true);
-    const v0 = TrainrunSectionsView.extractTravelTime(ts, editorView, "sourceToTarget");
+    const v0 = TrainrunSectionsView.extractTravelTime(
+      new TrainrunSectionViewObject(editorView, [ts]),
+      editorView,
+      "sourceToTarget",
+    );
     expect(v0).toBe("(10')");
   });
 

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -492,21 +492,28 @@ export class TrainrunSectionsView {
   }
 
   static extractTravelTime(
-    trainrunSection: TrainrunSection,
+    viewObject: TrainrunSectionViewObject,
     editorView: EditorView,
     direction: "sourceToTarget" | "targetToSource",
   ): string {
+    const srcNode = viewObject.firstSection.getSourceNode();
+    const trgNode = viewObject.lastSection.getTargetNode();
     const travelTime =
-      direction === "targetToSource"
-        ? trainrunSection.getBackwardTravelTime()
-        : trainrunSection.getTravelTime();
+      direction === "sourceToTarget"
+        ? viewObject.getTravelTime()
+        : viewObject.getBackwardTravelTime();
     const cumTravelTimeData = editorView.getCumulativeTravelTimeAndNodePath(
-      trainrunSection,
+      direction === "sourceToTarget" ? viewObject.firstSection : viewObject.lastSection,
       direction,
     );
-    const cumulativeTravelTime = cumTravelTimeData[cumTravelTimeData.length - 1].sumTravelTime;
+    const cumulativeTravelTime = editorView.getCumulativeTravelTime(
+      direction === "sourceToTarget" ? viewObject.firstSection : viewObject.lastSection,
+      direction,
+    );
+    const bothSideNonStop =
+      srcNode.isNonStop(viewObject.firstSection) && trgNode.isNonStop(viewObject.lastSection);
     if (
-      trainrunSection.getTrainrun().selected() === true ||
+      viewObject.getTrainrun().selected() === true ||
       editorView.isFilterShowNonStopTimeEnabled() ||
       editorView.isTemporaryDisableFilteringOfItemsInViewEnabled()
     ) {
@@ -519,14 +526,12 @@ export class TrainrunSectionsView {
         // special case - with non stops
         if (!editorView.isTemporaryDisableFilteringOfItemsInViewEnabled()) {
           // might is filtering active
-          const srcNonStopNode = editorView.checkFilterNonStopNode(trainrunSection.getSourceNode());
-          const trgNonStopNode = editorView.checkFilterNonStopNode(trainrunSection.getTargetNode());
-          const srcJunction = editorView.isJunctionNode(trainrunSection.getSourceNode());
-          const trgJunction = editorView.isJunctionNode(trainrunSection.getTargetNode());
-          const srcNode = TrainrunSectionsView.getNode(trainrunSection, true);
-          const trgNode = TrainrunSectionsView.getNode(trainrunSection, false);
+          const srcNonStopNode = editorView.checkFilterNonStopNode(srcNode);
+          const trgNonStopNode = editorView.checkFilterNonStopNode(trgNode);
+          const srcJunction = editorView.isJunctionNode(srcNode);
+          const trgJunction = editorView.isJunctionNode(trgNode);
 
-          if (TrainrunSectionsView.isBothSideNonStop(trainrunSection)) {
+          if (bothSideNonStop) {
             // trainrun section has on both side a non stop (transition)
             if (!srcNonStopNode && !srcJunction && !trgNonStopNode && !trgJunction) {
               return "";
@@ -589,7 +594,7 @@ export class TrainrunSectionsView {
           } else {
             // trainrun section has on non stop (transition) only on one side
             // is non-stop at source ?
-            if (srcNode.isNonStop(trainrunSection)) {
+            if (srcNode.isNonStop(viewObject.firstSection)) {
               if (!srcNonStopNode && !srcJunction) {
                 const info = TrainrunSectionsView.calcVirtualSectionTimeForHiddenJunctions(
                   cumTravelTimeData,
@@ -620,7 +625,7 @@ export class TrainrunSectionsView {
               }
             }
             // is non-stop at target ?
-            if (trgNode.isNonStop(trainrunSection)) {
+            if (trgNode.isNonStop(viewObject.lastSection)) {
               if (!trgNonStopNode && !trgJunction) {
                 const info = TrainrunSectionsView.calcVirtualSectionTimeForHiddenJunctions(
                   cumTravelTimeData,
@@ -653,7 +658,7 @@ export class TrainrunSectionsView {
           }
         }
 
-        if (TrainrunSectionsView.isBothSideNonStop(trainrunSection)) {
+        if (bothSideNonStop) {
           return "(" + TrainrunSectionsView.formatTime(travelTime, 1) + "')";
         }
         // default case for non stops
@@ -801,17 +806,8 @@ export class TrainrunSectionsView {
         if (data !== undefined) {
           return data;
         }
-        // Special case for multiple sections: calculate total time including stop times at intermediate nodes
-        if (viewObject.trainrunSections.length > 1) {
-          return (
-            TrainrunSectionsView.formatTime(
-              isForward ? viewObject.getTravelTime() : viewObject.getBackwardTravelTime(),
-              editorView.getTimeDisplayPrecision(),
-            ) + "'"
-          );
-        }
         return TrainrunSectionsView.extractTravelTime(
-          viewObject.firstSection,
+          viewObject,
           editorView,
           isForward ? "sourceToTarget" : "targetToSource",
         );


### PR DESCRIPTION
Only the last commit has to be reviewed: `fix: correctly display cumulative travel time for non-stop sections with collasped nodes`

Goes after https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/pull/1324