### PR TITLE
chore: explicitly import jasmine types for test files

### DIFF
--- a/src/test.ts
+++ b/src/test.ts
@@ -3,6 +3,7 @@
 import "zone.js/testing";
 import {getTestBed} from "@angular/core/testing";
 import {BrowserTestingModule, platformBrowserTesting} from "@angular/platform-browser/testing";
+import type {} from "jasmine";
 
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(BrowserTestingModule, platformBrowserTesting(), {


### PR DESCRIPTION
The jasmine types (`describe/it/expect`) were not provided by the former config, resulting in error in IDEs.

This solves the missing types from jasmin in my IDE. I don't know if there is an alternative.

Before:
<img width="930" height="481" alt="image" src="https://github.com/user-attachments/assets/414e64d6-9700-4bef-92e5-0e5180f07617" />

After:
<img width="1033" height="629" alt="image" src="https://github.com/user-attachments/assets/3f92e10a-39e7-48d1-b7ab-b03e92c36879" />
