### PR TITLE
ci: deploy github pages only in main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
           push: false
 
   deploy-github-pages:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build-standalonedemo
     permissions:
       pages: write


### PR DESCRIPTION
This disables the job when merging PR into other branches than main, for instance for feature branches.

This should fix this for instance: https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/actions/runs/33763890042/job/100677510824