### PR TITLE
refactor: enable TypeScript's `strictFunctionTypes` option

### DIFF
--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
@@ -215,7 +215,7 @@ export class OriginDestinationComponent implements OnInit, AfterViewInit, OnDest
       .style("user-select", "none")
       .call((g) =>
         g
-          .selectAll("text")
+          .selectAll<SVGElement, string>("text")
           .attr("data-destination-label", (d: string) => d)
           .style("text-anchor", "start")
           .attr("dx", "-0.8em")
@@ -246,7 +246,9 @@ export class OriginDestinationComponent implements OnInit, AfterViewInit, OnDest
           ),
       )
       .style("user-select", "none")
-      .call((g) => g.selectAll("text").attr("data-origin-label", (d: string) => d))
+      .call((g) =>
+        g.selectAll<SVGElement, string>("text").attr("data-origin-label", (d: string) => d),
+      )
       .select(".domain")
       .remove();
 
@@ -307,7 +309,7 @@ export class OriginDestinationComponent implements OnInit, AfterViewInit, OnDest
 
     const mouseleave = (event: MouseEvent, d: OriginDestination) => {
       tooltip.style("opacity", 0);
-      d3.select(D3Utils.getMouseEventCurrentTarget(event))
+      d3.select<SVGElement, OriginDestination>(D3Utils.getMouseEventCurrentTarget(event))
         .style("stroke", "none")
         .style("opacity", (d: OriginDestination) => (d.originId === d.destinationId ? 0 : 0.8));
 

--- a/src/app/view/dialogs/note-dialog/note-dialog.component.ts
+++ b/src/app/view/dialogs/note-dialog/note-dialog.component.ts
@@ -49,7 +49,7 @@ export class NoteDialogComponent implements OnDestroy {
 
   private destroyed = new Subject<void>();
 
-  private dialogRef: SbbDialogRef<unknown, unknown> = null;
+  private dialogRef: SbbDialogRef<void, unknown> = null;
   private dialogConfig: SbbDialogConfig = null;
   private dialogPos: Record<"top" | "bottom" | "left" | "right", number> = null;
   private dialogMovementLastPosition: Vec2D = undefined;

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component.ts
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component.ts
@@ -69,7 +69,7 @@ export class TrainrunAndSectionDialogComponent implements OnDestroy {
 
   public data: TrainrunDialogParameter = null;
 
-  private dialogRef: SbbDialogRef<unknown, unknown> = null;
+  private dialogRef: SbbDialogRef<void, unknown> = null;
   private dialogConfig: SbbDialogConfig = null;
   private dialogPos: Record<"top" | "bottom" | "left" | "right", number> = null;
   private dialogMovementLastPosition: Vec2D = undefined;

--- a/src/app/view/editor-main-view/data-views/connections.view.ts
+++ b/src/app/view/editor-main-view/data-views/connections.view.ts
@@ -13,7 +13,7 @@ import {LevelOfDetail} from "../../../services/ui/level.of.detail.service";
 type ConnectionDragEvent = d3.D3DragEvent<SVGElement, ConnectionsViewObject, unknown>;
 
 export class ConnectionsView {
-  connectionsGroup: d3.Selection<SVGElement, undefined, Element, undefined>;
+  connectionsGroup: d3.Selection<SVGGElement, undefined, Element, undefined>;
   editorView: EditorView;
   dragDomObj: SVGElement | null = null;
 
@@ -69,7 +69,7 @@ export class ConnectionsView {
     return ts.getPositionAtTargetNode();
   }
 
-  setGroup(connectionsGroup: d3.Selection<SVGElement, undefined, Element, undefined>) {
+  setGroup(connectionsGroup: d3.Selection<SVGGElement, undefined, Element, undefined>) {
     this.connectionsGroup = connectionsGroup;
     this.connectionsGroup.attr("class", "ConnectionsView");
   }
@@ -127,7 +127,7 @@ export class ConnectionsView {
   }
 
   createConnectionCurve(
-    drawingGroup: d3.Selection<SVGElement, ConnectionsViewObject, Element, undefined>,
+    drawingGroup: d3.Selection<SVGGElement, ConnectionsViewObject, Element, undefined>,
   ) {
     drawingGroup
       .append(StaticDomTags.CONNECTION_LINE_SVG)
@@ -152,11 +152,11 @@ export class ConnectionsView {
   }
 
   createConnectionSinglePin(
-    drawingGroup: d3.Selection<SVGElement, ConnectionsViewObject, Element, undefined>,
+    drawingGroup: d3.Selection<SVGGElement, ConnectionsViewObject, Element, undefined>,
     pinPos: Vec2D,
   ) {
     const draggable = d3
-      .drag<SVGElement, ConnectionsViewObject>()
+      .drag<SVGCircleElement, ConnectionsViewObject>()
       .on("start", (event: ConnectionDragEvent) => this.onConnectionPinDragStart(event))
       .on("drag", (event: ConnectionDragEvent) => this.onConnectionPinDragged(event))
       .on("end", (_, cv: ConnectionsViewObject) =>
@@ -193,7 +193,7 @@ export class ConnectionsView {
   }
 
   createConnectionPins(
-    drawingGroup: d3.Selection<SVGElement, ConnectionsViewObject, Element, undefined>,
+    drawingGroup: d3.Selection<SVGGElement, ConnectionsViewObject, Element, undefined>,
   ) {
     const selectedTrainrun = this.editorView.getSelectedTrainrun();
 
@@ -257,7 +257,9 @@ export class ConnectionsView {
     const connections = inputConnections.filter((c) => this.filterConnectionsToDisplay(c));
 
     const connectionsGroup = this.connectionsGroup
-      .selectAll(StaticDomTags.CONNECTION_ROOT_CONTAINER_DOM_REF)
+      .selectAll<SVGGElement, ConnectionsViewObject>(
+        StaticDomTags.CONNECTION_ROOT_CONTAINER_DOM_REF,
+      )
       .data(this.createTransitionViewObjects(connections), (c: ConnectionsViewObject) => c.key);
 
     const grpEnter = connectionsGroup
@@ -277,7 +279,7 @@ export class ConnectionsView {
   }
 
   renderConnectionObject(
-    groupEnter: d3.Selection<SVGElement, ConnectionsViewObject, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, ConnectionsViewObject, Element, undefined>,
   ) {
     switch (this.editorView.getLevelOfDetail()) {
       case LevelOfDetail.LEVEL3: {
@@ -308,27 +310,27 @@ export class ConnectionsView {
   }
 
   makeConnectionLODFull(
-    groupEnter: d3.Selection<SVGElement, ConnectionsViewObject, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, ConnectionsViewObject, Element, undefined>,
   ) {
     this.createConnectionCurve(groupEnter);
     this.createConnectionPins(groupEnter);
   }
 
   makeConnectionLOD3(
-    groupEnter: d3.Selection<SVGElement, ConnectionsViewObject, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, ConnectionsViewObject, Element, undefined>,
   ) {
     this.createConnectionCurve(groupEnter);
     this.createConnectionPins(groupEnter);
   }
 
   makeConnectionLOD2(
-    groupEnter: d3.Selection<SVGElement, ConnectionsViewObject, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, ConnectionsViewObject, Element, undefined>,
   ) {
     this.createConnectionCurve(groupEnter);
   }
 
   makeConnectionLOD1(
-    groupEnter: d3.Selection<SVGElement, ConnectionsViewObject, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, ConnectionsViewObject, Element, undefined>,
   ) {
     this.createConnectionCurve(groupEnter);
   }

--- a/src/app/view/editor-main-view/data-views/d3.utils.ts
+++ b/src/app/view/editor-main-view/data-views/d3.utils.ts
@@ -46,28 +46,28 @@ export class D3Utils {
     bringToFront = true,
     domObj: SVGElement,
   ) {
-    d3.selectAll(StaticDomTags.EDGE_LINE_ARROW_DOM_REF)
+    d3.selectAll<SVGElement, TrainrunSectionViewObject>(StaticDomTags.EDGE_LINE_ARROW_DOM_REF)
       .filter(
         (d: TrainrunSectionViewObject) =>
           d !== undefined && d.trainrunSection.getTrainrunId() === trainrunSection.getTrainrunId(),
       )
       .classed(StaticDomTags.TAG_HOVER, true);
 
-    d3.selectAll(StaticDomTags.EDGE_LINE_DOM_REF)
+    d3.selectAll<SVGElement, TrainrunSectionViewObject>(StaticDomTags.EDGE_LINE_DOM_REF)
       .filter(
         (d: TrainrunSectionViewObject) =>
           d !== undefined && d.trainrunSection.getTrainrunId() === trainrunSection.getTrainrunId(),
       )
       .classed(StaticDomTags.TAG_HOVER, true);
 
-    d3.selectAll(StaticDomTags.EDGE_ROOT_CONTAINER_DOM_REF)
+    d3.selectAll<SVGElement, TrainrunSectionViewObject>(StaticDomTags.EDGE_ROOT_CONTAINER_DOM_REF)
       .filter(
         (d: TrainrunSectionViewObject) =>
           d !== undefined && d.trainrunSection.getTrainrunId() === trainrunSection.getTrainrunId(),
       )
       .classed(StaticDomTags.TAG_HOVER, true);
 
-    d3.selectAll(StaticDomTags.TRANSITION_LINE_DOM_REF)
+    d3.selectAll<SVGElement, TransitionViewObject>(StaticDomTags.TRANSITION_LINE_DOM_REF)
       .filter(
         (d: TransitionViewObject) =>
           d !== undefined && d.transition.getTrainrun().getId() === trainrunSection.getTrainrunId(),
@@ -91,27 +91,27 @@ export class D3Utils {
   }
 
   static unhoverTrainrunSection(trainrunSection: TrainrunSection) {
-    d3.selectAll(StaticDomTags.EDGE_LINE_ARROW_DOM_REF)
+    d3.selectAll<SVGElement, TrainrunSectionViewObject>(StaticDomTags.EDGE_LINE_ARROW_DOM_REF)
       .filter(
         (d: TrainrunSectionViewObject) =>
           d !== undefined && d.trainrunSection.getTrainrunId() === trainrunSection.getTrainrunId(),
       )
       .classed(StaticDomTags.TAG_HOVER, false);
-    d3.selectAll(StaticDomTags.EDGE_LINE_DOM_REF)
-      .filter(
-        (d: TrainrunSectionViewObject) =>
-          d !== undefined && d.trainrunSection.getTrainrunId() === trainrunSection.getTrainrunId(),
-      )
-      .classed(StaticDomTags.TAG_HOVER, false);
-
-    d3.selectAll(StaticDomTags.EDGE_ROOT_CONTAINER_DOM_REF)
+    d3.selectAll<SVGElement, TrainrunSectionViewObject>(StaticDomTags.EDGE_LINE_DOM_REF)
       .filter(
         (d: TrainrunSectionViewObject) =>
           d !== undefined && d.trainrunSection.getTrainrunId() === trainrunSection.getTrainrunId(),
       )
       .classed(StaticDomTags.TAG_HOVER, false);
 
-    d3.selectAll(StaticDomTags.TRANSITION_LINE_DOM_REF)
+    d3.selectAll<SVGElement, TrainrunSectionViewObject>(StaticDomTags.EDGE_ROOT_CONTAINER_DOM_REF)
+      .filter(
+        (d: TrainrunSectionViewObject) =>
+          d !== undefined && d.trainrunSection.getTrainrunId() === trainrunSection.getTrainrunId(),
+      )
+      .classed(StaticDomTags.TAG_HOVER, false);
+
+    d3.selectAll<SVGElement, TransitionViewObject>(StaticDomTags.TRANSITION_LINE_DOM_REF)
       .filter(
         (d: TransitionViewObject) =>
           d !== undefined && d.transition.getTrainrun().getId() === trainrunSection.getTrainrunId(),
@@ -249,13 +249,13 @@ export class D3Utils {
   }
 
   static highlightNode(node: Node) {
-    d3.selectAll(StaticDomTags.NODE_ROOT_DOM_REF)
+    d3.selectAll<SVGElement, NodeViewObject>(StaticDomTags.NODE_ROOT_DOM_REF)
       .filter((n: NodeViewObject) => n.node.getId() === node.getId())
       .classed(StaticDomTags.NODE_HIGHLIGHT, true);
   }
 
   static unhighlightNode(node: Node) {
-    d3.selectAll(StaticDomTags.NODE_ROOT_DOM_REF)
+    d3.selectAll<SVGElement, NodeViewObject>(StaticDomTags.NODE_ROOT_DOM_REF)
       .filter((n: NodeViewObject) => n.node.getId() === node.getId())
       .classed(StaticDomTags.NODE_HIGHLIGHT, false);
   }
@@ -311,7 +311,7 @@ export class D3Utils {
   }
 
   static doGrayoutTransition(transition: Transition) {
-    d3.selectAll(StaticDomTags.TRANSITION_LINE_DOM_REF)
+    d3.selectAll<SVGElement, TransitionViewObject>(StaticDomTags.TRANSITION_LINE_DOM_REF)
       .filter((d: TransitionViewObject) => {
         if (d === undefined) {
           return false;
@@ -323,7 +323,7 @@ export class D3Utils {
       .classed(StaticDomTags.TAG_WARNING, false)
       .classed(StaticDomTags.EDGE_LINE_GRAYEDOUT, true);
 
-    d3.selectAll(StaticDomTags.TRANSITION_BUTTON_DOM_REF)
+    d3.selectAll<SVGElement, TransitionViewObject>(StaticDomTags.TRANSITION_BUTTON_DOM_REF)
       .filter((d: TransitionViewObject) => {
         if (d === undefined) {
           return false;
@@ -337,7 +337,7 @@ export class D3Utils {
   }
 
   static removeGrayoutTransition(transition: Transition) {
-    d3.selectAll(StaticDomTags.TRANSITION_LINE_DOM_REF)
+    d3.selectAll<SVGElement, TransitionViewObject>(StaticDomTags.TRANSITION_LINE_DOM_REF)
       .filter((d: TransitionViewObject) => {
         if (d === undefined) {
           return false;
@@ -349,7 +349,7 @@ export class D3Utils {
       .classed(StaticDomTags.TAG_WARNING, false)
       .classed(StaticDomTags.EDGE_LINE_GRAYEDOUT, false);
 
-    d3.selectAll(StaticDomTags.TRANSITION_BUTTON_DOM_REF)
+    d3.selectAll<SVGElement, TransitionViewObject>(StaticDomTags.TRANSITION_BUTTON_DOM_REF)
       .filter((d: TransitionViewObject) => {
         if (d === undefined) {
           return false;
@@ -363,7 +363,7 @@ export class D3Utils {
   }
 
   static doGrayout(trainrunSection: TrainrunSection, grayoutEdgeLinePinNode: Node = undefined) {
-    d3.selectAll(StaticDomTags.EDGE_LINE_ARROW_DOM_REF)
+    d3.selectAll<SVGElement, TrainrunSectionViewObject>(StaticDomTags.EDGE_LINE_ARROW_DOM_REF)
       .filter((d: TrainrunSectionViewObject) => {
         if (d === undefined) {
           return false;
@@ -375,7 +375,7 @@ export class D3Utils {
       .classed(StaticDomTags.TAG_WARNING, false)
       .classed(StaticDomTags.EDGE_LINE_GRAYEDOUT, true);
 
-    d3.selectAll(StaticDomTags.EDGE_LINE_DOM_REF)
+    d3.selectAll<SVGElement, TrainrunSectionViewObject>(StaticDomTags.EDGE_LINE_DOM_REF)
       .filter((d: TrainrunSectionViewObject) => {
         if (d === undefined) {
           return false;
@@ -387,7 +387,7 @@ export class D3Utils {
       .classed(StaticDomTags.TAG_WARNING, false)
       .classed(StaticDomTags.EDGE_LINE_GRAYEDOUT, true);
 
-    d3.selectAll(StaticDomTags.EDGE_LINE_TEXT_DOM_REF)
+    d3.selectAll<SVGElement, TrainrunSectionViewObject>(StaticDomTags.EDGE_LINE_TEXT_DOM_REF)
       .filter((d: TrainrunSectionViewObject) => {
         if (d === undefined) {
           return false;
@@ -399,7 +399,7 @@ export class D3Utils {
       .classed(StaticDomTags.TAG_WARNING, false)
       .classed(StaticDomTags.EDGE_LINE_GRAYEDOUT, true);
 
-    d3.selectAll(StaticDomTags.EDGE_LINE_STOPS_DOM_REF)
+    d3.selectAll<SVGElement, TrainrunSectionViewObject>(StaticDomTags.EDGE_LINE_STOPS_DOM_REF)
       .filter((d: TrainrunSectionViewObject) => {
         if (d === undefined) {
           return false;
@@ -409,7 +409,9 @@ export class D3Utils {
       .classed(StaticDomTags.EDGE_LINE_GRAYEDOUT, true);
 
     if (grayoutEdgeLinePinNode !== undefined) {
-      d3.selectAll(StaticDomTags.EDGE_LINE_PIN_DOM_REF + "." + StaticDomTags.EDGE_IS_SOURCE)
+      d3.selectAll<SVGElement, TrainrunSectionViewObject>(
+        StaticDomTags.EDGE_LINE_PIN_DOM_REF + "." + StaticDomTags.EDGE_IS_SOURCE,
+      )
         .filter((d: TrainrunSectionViewObject) => {
           if (d === undefined) {
             return false;
@@ -420,7 +422,9 @@ export class D3Utils {
           );
         })
         .classed(StaticDomTags.EDGE_LINE_GRAYEDOUT, true);
-      d3.selectAll(StaticDomTags.EDGE_LINE_PIN_DOM_REF + "." + StaticDomTags.EDGE_IS_TARGET)
+      d3.selectAll<SVGElement, TrainrunSectionViewObject>(
+        StaticDomTags.EDGE_LINE_PIN_DOM_REF + "." + StaticDomTags.EDGE_IS_TARGET,
+      )
         .filter((d: TrainrunSectionViewObject) => {
           if (d === undefined) {
             return false;
@@ -435,7 +439,7 @@ export class D3Utils {
   }
 
   static removeGrayout(trainrunSection: TrainrunSection, grayoutEdgeLinePinNode: Node = undefined) {
-    d3.selectAll(StaticDomTags.EDGE_LINE_ARROW_DOM_REF)
+    d3.selectAll<SVGElement, TrainrunSectionViewObject>(StaticDomTags.EDGE_LINE_ARROW_DOM_REF)
       .filter((d: TrainrunSectionViewObject) => {
         if (d === undefined) {
           return false;
@@ -447,7 +451,7 @@ export class D3Utils {
       .classed(StaticDomTags.TAG_WARNING, false)
       .classed(StaticDomTags.EDGE_LINE_GRAYEDOUT, false);
 
-    d3.selectAll(StaticDomTags.EDGE_LINE_DOM_REF)
+    d3.selectAll<SVGElement, TrainrunSectionViewObject>(StaticDomTags.EDGE_LINE_DOM_REF)
       .filter((d: TrainrunSectionViewObject) => {
         if (d === undefined) {
           return false;
@@ -459,7 +463,7 @@ export class D3Utils {
       .classed(StaticDomTags.TAG_WARNING, false)
       .classed(StaticDomTags.EDGE_LINE_GRAYEDOUT, false);
 
-    d3.selectAll(StaticDomTags.EDGE_LINE_TEXT_DOM_REF)
+    d3.selectAll<SVGElement, TrainrunSectionViewObject>(StaticDomTags.EDGE_LINE_TEXT_DOM_REF)
       .filter((d: TrainrunSectionViewObject) => {
         if (d === undefined) {
           return false;
@@ -471,7 +475,7 @@ export class D3Utils {
       .classed(StaticDomTags.TAG_WARNING, false)
       .classed(StaticDomTags.EDGE_LINE_GRAYEDOUT, false);
 
-    d3.selectAll(StaticDomTags.EDGE_LINE_STOPS_DOM_REF)
+    d3.selectAll<SVGElement, TrainrunSectionViewObject>(StaticDomTags.EDGE_LINE_STOPS_DOM_REF)
       .filter((d: TrainrunSectionViewObject) => {
         if (d === undefined) {
           return false;
@@ -481,7 +485,9 @@ export class D3Utils {
       .classed(StaticDomTags.EDGE_LINE_GRAYEDOUT, false);
 
     if (grayoutEdgeLinePinNode !== undefined) {
-      d3.selectAll(StaticDomTags.EDGE_LINE_PIN_DOM_REF + "." + StaticDomTags.EDGE_IS_SOURCE)
+      d3.selectAll<SVGElement, TrainrunSectionViewObject>(
+        StaticDomTags.EDGE_LINE_PIN_DOM_REF + "." + StaticDomTags.EDGE_IS_SOURCE,
+      )
         .filter((d: TrainrunSectionViewObject) => {
           if (d === undefined) {
             return false;
@@ -492,7 +498,9 @@ export class D3Utils {
           );
         })
         .classed(StaticDomTags.EDGE_LINE_GRAYEDOUT, false);
-      d3.selectAll(StaticDomTags.EDGE_LINE_PIN_DOM_REF + "." + StaticDomTags.EDGE_IS_TARGET)
+      d3.selectAll<SVGElement, TrainrunSectionViewObject>(
+        StaticDomTags.EDGE_LINE_PIN_DOM_REF + "." + StaticDomTags.EDGE_IS_TARGET,
+      )
         .filter((d: TrainrunSectionViewObject) => {
           if (d === undefined) {
             return false;

--- a/src/app/view/editor-main-view/data-views/editor.keyEvents.ts
+++ b/src/app/view/editor-main-view/data-views/editor.keyEvents.ts
@@ -360,46 +360,43 @@ export class EditorKeyEvents {
 
   private getSelectedTrainSectionId(): number {
     let selectedTrainrunSectionId: number = undefined;
-    d3.select(StaticDomTags.EDGE_LINE_DOM_REF + "." + StaticDomTags.TAG_SELECTED).classed(
-      "KeyEventHandling",
-      (tsvo: TrainrunSectionViewObject) => {
-        if (tsvo === undefined) {
-          const trainRun = this.trainrunService.getSelectedTrainrun();
-          if (trainRun !== null) {
-            selectedTrainrunSectionId = trainRun.getId();
-          }
-          return false;
-        }
-        if (tsvo.trainrunSection.getTrainrun().selected()) {
-          selectedTrainrunSectionId = tsvo.trainrunSection.getTrainrunId();
+    d3.select<SVGElement, TrainrunSectionViewObject>(
+      StaticDomTags.EDGE_LINE_DOM_REF + "." + StaticDomTags.TAG_SELECTED,
+    ).classed("KeyEventHandling", (tsvo: TrainrunSectionViewObject) => {
+      if (tsvo === undefined) {
+        const trainRun = this.trainrunService.getSelectedTrainrun();
+        if (trainRun !== null) {
+          selectedTrainrunSectionId = trainRun.getId();
         }
         return false;
-      },
-    );
+      }
+      if (tsvo.trainrunSection.getTrainrun().selected()) {
+        selectedTrainrunSectionId = tsvo.trainrunSection.getTrainrunId();
+      }
+      return false;
+    });
     return selectedTrainrunSectionId;
   }
 
   private getHoveredNoteId(): number {
     let noteHoveredId: number = undefined;
-    d3.select(StaticDomTags.NOTE_ROOT_DOM_REF + "." + StaticDomTags.TAG_HOVER).classed(
-      "KeyEventHandling",
-      (nvo: NoteViewObject) => {
-        noteHoveredId = nvo.note.getId();
-        return false;
-      },
-    );
+    d3.select<SVGElement, NoteViewObject>(
+      StaticDomTags.NOTE_ROOT_DOM_REF + "." + StaticDomTags.TAG_HOVER,
+    ).classed("KeyEventHandling", (nvo: NoteViewObject) => {
+      noteHoveredId = nvo.note.getId();
+      return false;
+    });
     return noteHoveredId;
   }
 
   private getHoveredNodeId(): number {
     let hoveredNodeId: number = undefined;
-    d3.select(StaticDomTags.NODE_ROOT_DOM_REF + "." + StaticDomTags.TAG_HOVER).classed(
-      "KeyEventHandling",
-      (nvo: NodeViewObject) => {
-        hoveredNodeId = nvo.node.getId();
-        return false;
-      },
-    );
+    d3.select<SVGElement, NodeViewObject>(
+      StaticDomTags.NODE_ROOT_DOM_REF + "." + StaticDomTags.TAG_HOVER,
+    ).classed("KeyEventHandling", (nvo: NodeViewObject) => {
+      hoveredNodeId = nvo.node.getId();
+      return false;
+    });
     return hoveredNodeId;
   }
 

--- a/src/app/view/editor-main-view/data-views/editor.view.ts
+++ b/src/app/view/editor-main-view/data-views/editor.view.ts
@@ -51,7 +51,7 @@ export class EditorView implements SVGMouseControllerObserver {
   controller: EditorMainViewComponent;
   svgMouseController: SVGMouseController;
   editorKeyEvents: EditorKeyEvents;
-  rootContainer: d3.Selection<SVGElement, undefined, Element, undefined>;
+  rootContainer: d3.Selection<SVGGElement, undefined, Element, undefined>;
   nodesView: NodesView;
   transitionsView: TransitionsView;
   connectionsView: ConnectionsView;

--- a/src/app/view/editor-main-view/data-views/multiSelectRenderer.ts
+++ b/src/app/view/editor-main-view/data-views/multiSelectRenderer.ts
@@ -5,7 +5,7 @@ import {Vec2D} from "../../../utils/vec2D";
 export class MultiSelectRenderer {
   private isBoxDrawing = false;
 
-  static setGroup(nodeGroup: d3.Selection<SVGElement, undefined, Element, undefined>) {
+  static setGroup(nodeGroup: d3.Selection<SVGGElement, undefined, Element, undefined>) {
     nodeGroup
       .append(StaticDomTags.PREVIEW_MULTISELECT_ROOT_BOX_SVG)
       .attr("class", StaticDomTags.PREVIEW_MULTISELECT_ROOT_BOX_CLASS);

--- a/src/app/view/editor-main-view/data-views/nodes.view.ts
+++ b/src/app/view/editor-main-view/data-views/nodes.view.ts
@@ -27,7 +27,7 @@ type NodeDragEvent = d3.D3DragEvent<SVGElement, NodeViewObject, unknown>;
 
 export class NodesView {
   dragPreviousMousePosition: Vec2D;
-  nodeGroup: d3.Selection<SVGElement, undefined, Element, undefined>;
+  nodeGroup: d3.Selection<SVGGElement, undefined, Element, undefined>;
   draggable: d3.DragBehavior<SVGElement, NodeViewObject, unknown>;
   dragDomObj: SVGElement | null = null;
 
@@ -40,7 +40,7 @@ export class NodesView {
     this.dragPreviousMousePosition = new Vec2D();
   }
 
-  setGroup(nodeGroup: d3.Selection<SVGElement, undefined, Element, undefined>) {
+  setGroup(nodeGroup: d3.Selection<SVGGElement, undefined, Element, undefined>) {
     this.nodeGroup = nodeGroup;
     this.nodeGroup.attr("class", "NodesView");
   }
@@ -116,7 +116,7 @@ export class NodesView {
     );
 
     const group = this.nodeGroup
-      .selectAll(StaticDomTags.NODE_ROOT_CONTAINER_DOM_REF)
+      .selectAll<SVGElement, NodeViewObject>(StaticDomTags.NODE_ROOT_CONTAINER_DOM_REF)
       .data(this.createViewNodeDataObjects(nodes), (n: NodeViewObject) => n.key);
 
     const groupEnter2 = group
@@ -140,7 +140,7 @@ export class NodesView {
     group.exit().remove();
   }
 
-  renderNodeObject(groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>) {
+  renderNodeObject(groupEnter: d3.Selection<SVGGElement, NodeViewObject, Element, undefined>) {
     switch (this.editorView.getLevelOfDetail()) {
       case LevelOfDetail.LEVEL3: {
         //statements;
@@ -169,7 +169,7 @@ export class NodesView {
     }
   }
 
-  adjustTextWithEllipsis(text: d3.Selection<SVGTextElement, unknown, Element, unknown>) {
+  adjustTextWithEllipsis(text: d3.Selection<SVGTextElement, NodeViewObject, Element, unknown>) {
     text.each(function () {
       const text = d3.select(this);
       const chars = text.text().split("");
@@ -191,7 +191,7 @@ export class NodesView {
     });
   }
 
-  makeNodeLODFull(groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>) {
+  makeNodeLODFull(groupEnter: d3.Selection<SVGGElement, NodeViewObject, Element, undefined>) {
     this.makeNodeHoverRoot(groupEnter);
     this.makeNodeRoot(groupEnter);
     this.makeBackground(groupEnter);
@@ -208,7 +208,7 @@ export class NodesView {
     this.makeLabelConnectionText(groupEnter);
   }
 
-  makeNodeLODLevel3(groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>) {
+  makeNodeLODLevel3(groupEnter: d3.Selection<SVGGElement, NodeViewObject, Element, undefined>) {
     this.makeNodeHoverRoot(groupEnter);
     this.makeNodeRoot(groupEnter);
     this.makeBackground(groupEnter);
@@ -221,7 +221,7 @@ export class NodesView {
     this.makeLabelConnectionText(groupEnter);
   }
 
-  makeNodeLODLevel2(groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>) {
+  makeNodeLODLevel2(groupEnter: d3.Selection<SVGGElement, NodeViewObject, Element, undefined>) {
     this.makeNodeHoverRoot(groupEnter);
     this.makeNodeRoot(groupEnter);
     this.makeBackground(groupEnter);
@@ -232,7 +232,7 @@ export class NodesView {
     this.makeLabelConnectionText(groupEnter);
   }
 
-  makeNodeLODLevel1(groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>) {
+  makeNodeLODLevel1(groupEnter: d3.Selection<SVGGElement, NodeViewObject, Element, undefined>) {
     this.makeNodeHoverRoot(groupEnter);
     this.makeBackground(groupEnter);
     this.makeNodeDockable(groupEnter);
@@ -240,14 +240,14 @@ export class NodesView {
     this.makeLabelText(groupEnter);
   }
 
-  makeNodeLODLevel0(groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>) {
+  makeNodeLODLevel0(groupEnter: d3.Selection<SVGGElement, NodeViewObject, Element, undefined>) {
     this.makeNodeHoverRoot(groupEnter);
     this.makeNodeDockable(groupEnter);
     this.makeAnalyticsArea(groupEnter);
   }
 
   private makeNodeHoverRoot(
-    groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, NodeViewObject, Element, undefined>,
   ) {
     groupEnter
       .append(StaticDomTags.NODE_HOVER_ROOT_SVG)
@@ -277,7 +277,7 @@ export class NodesView {
       );
   }
 
-  private makeNodeRoot(groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>) {
+  private makeNodeRoot(groupEnter: d3.Selection<SVGGElement, NodeViewObject, Element, undefined>) {
     groupEnter
       .append(StaticDomTags.NODE_ROOT_SVG)
       .attr("class", StaticDomTags.NODE_ROOT_CLASS)
@@ -306,7 +306,9 @@ export class NodesView {
       );
   }
 
-  private makeBackground(groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>) {
+  private makeBackground(
+    groupEnter: d3.Selection<SVGGElement, NodeViewObject, Element, undefined>,
+  ) {
     groupEnter
       .append(StaticDomTags.NODE_BACKGROUND_SVG)
       .attr("class", StaticDomTags.NODE_BACKGROUND_CLASS)
@@ -335,7 +337,7 @@ export class NodesView {
       );
   }
 
-  private makeLabelArea(groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>) {
+  private makeLabelArea(groupEnter: d3.Selection<SVGGElement, NodeViewObject, Element, undefined>) {
     groupEnter
       .append(StaticDomTags.NODE_LABELAREA_SVG)
       .attr("class", StaticDomTags.NODE_LABELAREA_CLASS)
@@ -363,9 +365,9 @@ export class NodesView {
   }
 
   private makeHoverDragBackground(
-    groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, NodeViewObject, Element, undefined>,
   ) {
-    const added = groupEnter.append(StaticDomTags.NODE_HOVER_DRAG_AREA_BACKGROUND_SVG);
+    const added = groupEnter.append<SVGElement>(StaticDomTags.NODE_HOVER_DRAG_AREA_BACKGROUND_SVG);
     added
       .attr("class", StaticDomTags.NODE_HOVER_DRAG_AREA_BACKGROUND_CLASS)
       .classed(StaticDomTags.TAG_SELECTED, (n: NodeViewObject) => n.node.selected())
@@ -396,13 +398,13 @@ export class NodesView {
   }
 
   private makeHoverDragRoot(
-    groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, NodeViewObject, Element, undefined>,
   ) {
     if (!this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable()) {
       return;
     }
     groupEnter
-      .append(StaticDomTags.NODE_HOVER_DRAG_AREA_SVG)
+      .append<SVGElement>(StaticDomTags.NODE_HOVER_DRAG_AREA_SVG)
       .attr("class", StaticDomTags.NODE_HOVER_DRAG_AREA_CLASS)
       .classed(StaticDomTags.TAG_SELECTED, (n: NodeViewObject) => n.node.selected())
       .attr(StaticDomTags.NODE_ID, (n: NodeViewObject) => n.node.getId())
@@ -432,7 +434,7 @@ export class NodesView {
   }
 
   private makeEditButtonBackground(
-    groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, NodeViewObject, Element, undefined>,
   ) {
     groupEnter
       .append(StaticDomTags.NODE_EDIT_AREA_BACKGROUND_SVG)
@@ -455,7 +457,9 @@ export class NodesView {
       .on("mouseup", (event: MouseEvent, n: NodeViewObject) => this.onNodeMouseup(event, n.node));
   }
 
-  private makeEditButton(groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>) {
+  private makeEditButton(
+    groupEnter: d3.Selection<SVGGElement, NodeViewObject, Element, undefined>,
+  ) {
     groupEnter
       .append(StaticDomTags.NODE_EDIT_AREA_SVG)
       .attr("class", StaticDomTags.NODE_EDIT_AREA_CLASS)
@@ -492,7 +496,7 @@ export class NodesView {
   }
 
   private makeNodeDockable(
-    groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, NodeViewObject, Element, undefined>,
   ) {
     groupEnter
       .append(StaticDomTags.NODE_DOCKABLE_SVG)
@@ -528,7 +532,7 @@ export class NodesView {
   }
 
   private makeAnalyticsArea(
-    groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, NodeViewObject, Element, undefined>,
   ) {
     groupEnter
       .append(StaticDomTags.NODE_ANALYTICSAREA_SVG)
@@ -562,7 +566,7 @@ export class NodesView {
   }
 
   private makeAnalyticsTextLeftArea(
-    groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, NodeViewObject, Element, undefined>,
   ) {
     groupEnter
       .append(StaticDomTags.NODE_ANALYTICSAREA_TEXT_LEFT_SVG)
@@ -580,7 +584,7 @@ export class NodesView {
   }
 
   private makeAnalyticsTextRightArea(
-    groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, NodeViewObject, Element, undefined>,
   ) {
     groupEnter
       .append(StaticDomTags.NODE_ANALYTICSAREA_TEXT_RIGHT_SVG)
@@ -597,7 +601,7 @@ export class NodesView {
       .attr(StaticDomTags.NODE_ID, (n: NodeViewObject) => n.node.getId());
   }
 
-  private makeLabelText(groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>) {
+  private makeLabelText(groupEnter: d3.Selection<SVGGElement, NodeViewObject, Element, undefined>) {
     const added = groupEnter.append(StaticDomTags.NODE_LABELAREA_TEXT_SVG);
     added
       .attr("class", `${StaticDomTags.NODE_LABELAREA_TEXT_CLASS} node_name_text`)
@@ -626,7 +630,10 @@ export class NodesView {
       return;
     }
 
+    // Note, an awkward filter() call is required here to generalize the
+    // selection type and make TypeScript happy
     added
+      .filter<SVGElement>(() => true)
       .call(this.draggable)
       .on("mouseover", (event: MouseEvent, n: NodeViewObject) =>
         this.onNodeLabelAreaMouseover(event, n.node, {raise: true}),
@@ -639,7 +646,7 @@ export class NodesView {
   }
 
   private makeLabelConnectionText(
-    groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, NodeViewObject, Element, undefined>,
   ) {
     groupEnter
       .append(StaticDomTags.NODE_CONNECTIONTIME_TEXT_SVG)
@@ -694,10 +701,10 @@ export class NodesView {
 
   onNodeLabelAreaMouseover(event: MouseEvent, node: Node, options?: {raise?: boolean}) {
     this.hoverNode(event, node, options);
-    d3.selectAll(StaticDomTags.NODE_HOVER_DRAG_AREA_DOM_REF)
+    d3.selectAll<SVGElement, NodeViewObject>(StaticDomTags.NODE_HOVER_DRAG_AREA_DOM_REF)
       .filter((n: NodeViewObject) => n.node.getId() === node.getId())
       .classed(StaticDomTags.TAG_MUTED, true);
-    d3.selectAll(StaticDomTags.NODE_EDIT_AREA_DOM_REF)
+    d3.selectAll<SVGElement, NodeViewObject>(StaticDomTags.NODE_EDIT_AREA_DOM_REF)
       .filter((n: NodeViewObject) => n.node.getId() === node.getId())
       .classed(StaticDomTags.TAG_MUTED, true);
   }
@@ -708,13 +715,13 @@ export class NodesView {
 
   onNodeMouseoverEditButton(event: MouseEvent, node: Node) {
     this.hoverNode(event, node, {raise: true});
-    d3.selectAll(StaticDomTags.NODE_EDIT_AREA_DOM_REF)
+    d3.selectAll<SVGElement, NodeViewObject>(StaticDomTags.NODE_EDIT_AREA_DOM_REF)
       .filter((n: NodeViewObject) => n.node.getId() === node.getId())
       .classed(StaticDomTags.TAG_HOVER, true);
   }
 
   onNodeMouseoutEditButton(event: MouseEvent, node: Node) {
-    d3.selectAll(StaticDomTags.NODE_EDIT_AREA_DOM_REF)
+    d3.selectAll<SVGElement, NodeViewObject>(StaticDomTags.NODE_EDIT_AREA_DOM_REF)
       .filter((n: NodeViewObject) => n.node.getId() === node.getId())
       .classed(StaticDomTags.TAG_HOVER, false);
     this.unhoverNode(event, node, {raise: true});
@@ -722,13 +729,13 @@ export class NodesView {
 
   onNodeMouseoverDragButton(event: MouseEvent, node: Node) {
     this.hoverNode(event, node, {raise: true});
-    d3.selectAll(StaticDomTags.NODE_HOVER_DRAG_AREA_DOM_REF)
+    d3.selectAll<SVGElement, NodeViewObject>(StaticDomTags.NODE_HOVER_DRAG_AREA_DOM_REF)
       .filter((n: NodeViewObject) => n.node.getId() === node.getId())
       .classed(StaticDomTags.TAG_HOVER, true);
   }
 
   onNodeMouseoutDragButton(event: MouseEvent, node: Node) {
-    d3.selectAll(StaticDomTags.NODE_HOVER_DRAG_AREA_DOM_REF)
+    d3.selectAll<SVGElement, NodeViewObject>(StaticDomTags.NODE_HOVER_DRAG_AREA_DOM_REF)
       .filter((n: NodeViewObject) => n.node.getId() === node.getId())
       .classed(StaticDomTags.TAG_HOVER, false);
     this.unhoverNode(event, node, {raise: true});
@@ -802,7 +809,7 @@ export class NodesView {
 
   isNodeHovered(node: Node): boolean {
     return d3
-      .selectAll(StaticDomTags.NODE_ROOT_DOM_REF)
+      .selectAll<SVGElement, NodeViewObject>(StaticDomTags.NODE_ROOT_DOM_REF)
       .filter((n: NodeViewObject) => n.node.getId() === node.getId())
       .classed(StaticDomTags.TAG_HOVER);
   }
@@ -812,7 +819,7 @@ export class NodesView {
       const domObj = D3Utils.getMouseEventCurrentTarget(event);
       d3.select(domObj).raise().classed(StaticDomTags.TAG_HOVER, true);
     }
-    d3.selectAll(StaticDomTags.NODE_ROOT_DOM_REF)
+    d3.selectAll<SVGElement, NodeViewObject>(StaticDomTags.NODE_ROOT_DOM_REF)
       .filter((n: NodeViewObject) => n.node.getId() === node.getId())
       .classed(StaticDomTags.TAG_HOVER, true);
 
@@ -824,13 +831,13 @@ export class NodesView {
       const domObj = D3Utils.getMouseEventCurrentTarget(event);
       d3.select(domObj).raise().classed(StaticDomTags.TAG_HOVER, false);
     }
-    d3.selectAll(StaticDomTags.NODE_ROOT_DOM_REF)
+    d3.selectAll<SVGElement, NodeViewObject>(StaticDomTags.NODE_ROOT_DOM_REF)
       .filter((n: NodeViewObject) => n.node.getId() === node.getId())
       .classed(StaticDomTags.TAG_HOVER, false);
-    d3.selectAll(StaticDomTags.NODE_HOVER_DRAG_AREA_DOM_REF)
+    d3.selectAll<SVGElement, NodeViewObject>(StaticDomTags.NODE_HOVER_DRAG_AREA_DOM_REF)
       .filter((n: NodeViewObject) => n.node.getId() === node.getId())
       .classed(StaticDomTags.TAG_MUTED, false);
-    d3.selectAll(StaticDomTags.NODE_EDIT_AREA_DOM_REF)
+    d3.selectAll<SVGElement, NodeViewObject>(StaticDomTags.NODE_EDIT_AREA_DOM_REF)
       .filter((n: NodeViewObject) => n.node.getId() === node.getId())
       .classed(StaticDomTags.TAG_MUTED, false);
 
@@ -838,14 +845,14 @@ export class NodesView {
   }
 
   hoverNodeDockable(event: MouseEvent, node: Node, options?: {raise?: boolean}) {
-    d3.selectAll(StaticDomTags.NODE_DOCKABLE_DOM_REF)
+    d3.selectAll<SVGElement, NodeViewObject>(StaticDomTags.NODE_DOCKABLE_DOM_REF)
       .filter((n: NodeViewObject) => n.node.getId() === node.getId())
       .classed(StaticDomTags.TAG_HOVER, true);
     this.hoverNode(event, node, options);
   }
 
   unhoverNodeDockable(event: MouseEvent, node: Node, options?: {raise?: boolean}) {
-    d3.selectAll(StaticDomTags.NODE_DOCKABLE_DOM_REF)
+    d3.selectAll<SVGElement, NodeViewObject>(StaticDomTags.NODE_DOCKABLE_DOM_REF)
       .filter((n: NodeViewObject) => n.node.getId() === node.getId())
       .classed(StaticDomTags.TAG_HOVER, false);
     this.unhoverNode(event, node, options);

--- a/src/app/view/editor-main-view/data-views/notes.view.ts
+++ b/src/app/view/editor-main-view/data-views/notes.view.ts
@@ -22,7 +22,7 @@ type NoteDragEvent = d3.D3DragEvent<SVGElement, NodeViewObject, unknown>;
 
 export class NotesView {
   dragPreviousMousePosition: Vec2D;
-  notesGroup: d3.Selection<SVGElement, undefined, Element, undefined>;
+  notesGroup: d3.Selection<SVGGElement, undefined, Element, undefined>;
   draggable: d3.DragBehavior<SVGElement, NoteViewObject, unknown>;
   dragDomObj: SVGElement | null = null;
 
@@ -90,7 +90,7 @@ export class NotesView {
     return Math.max(n.getWidth(), maxLen * NOTE_TEXT_LEFT_SPACING) + NOTE_TEXT_LEFT_SPACING;
   }
 
-  setGroup(connectionsGroup: d3.Selection<SVGElement, undefined, Element, undefined>) {
+  setGroup(connectionsGroup: d3.Selection<SVGGElement, undefined, Element, undefined>) {
     this.notesGroup = connectionsGroup;
     this.notesGroup.attr("class", "NotesView");
   }
@@ -119,8 +119,8 @@ export class NotesView {
     );
 
     const group = this.notesGroup
-      .selectAll(StaticDomTags.NOTE_ROOT_CONTAINER_DOM_REF)
-      .data(this.createViewNoteDataObjects(notes), (n: NodeViewObject) => n.key);
+      .selectAll<SVGElement, NoteViewObject>(StaticDomTags.NOTE_ROOT_CONTAINER_DOM_REF)
+      .data(this.createViewNoteDataObjects(notes), (n: NoteViewObject) => n.key);
 
     const groupEnter2 = group
       .enter()
@@ -142,7 +142,7 @@ export class NotesView {
     group.exit().remove();
   }
 
-  renderNoteObject(groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>) {
+  renderNoteObject(groupEnter: d3.Selection<SVGGElement, NoteViewObject, Element, undefined>) {
     switch (this.editorView.getLevelOfDetail()) {
       case LevelOfDetail.LEVEL3: {
         //statements;
@@ -171,7 +171,7 @@ export class NotesView {
     }
   }
 
-  makeNodeLODFull(groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>) {
+  makeNodeLODFull(groupEnter: d3.Selection<SVGGElement, NoteViewObject, Element, undefined>) {
     this.makeNoteHoverRoot(groupEnter);
     this.makeNoteRoot(groupEnter);
     this.makeNoteTitleArea(groupEnter);
@@ -182,7 +182,7 @@ export class NotesView {
     this.makeNoteDragArea(groupEnter);
   }
 
-  makeNoteLODLevel3(groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>) {
+  makeNoteLODLevel3(groupEnter: d3.Selection<SVGGElement, NoteViewObject, Element, undefined>) {
     this.makeNoteHoverRoot(groupEnter);
     this.makeNoteRoot(groupEnter);
     this.makeNoteTitleArea(groupEnter);
@@ -191,26 +191,26 @@ export class NotesView {
     this.makeNoteText(groupEnter);
   }
 
-  makeNoteLODLevel2(groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>) {
+  makeNoteLODLevel2(groupEnter: d3.Selection<SVGGElement, NoteViewObject, Element, undefined>) {
     this.makeNoteRoot(groupEnter);
     this.makeNoteTitleAreaText(groupEnter);
     this.makeNoteText(groupEnter);
   }
 
-  makeNoteLODLevel1(groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>) {
+  makeNoteLODLevel1(groupEnter: d3.Selection<SVGGElement, NoteViewObject, Element, undefined>) {
     this.makeNoteRoot(groupEnter);
     this.makeNoteTitleAreaText(groupEnter);
   }
 
-  makeNoteLODLevel0(groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>) {
+  makeNoteLODLevel0(groupEnter: d3.Selection<SVGGElement, NoteViewObject, Element, undefined>) {
     this.makeNoteRoot(groupEnter);
     this.makeNoteTitleAreaText(groupEnter);
   }
 
   private makeNoteHoverRoot(
-    groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, NoteViewObject, Element, undefined>,
   ) {
-    const added = groupEnter.append(StaticDomTags.NOTE_HOVER_ROOT_SVG);
+    const added = groupEnter.append<SVGElement>(StaticDomTags.NOTE_HOVER_ROOT_SVG);
     added
       .attr("class", StaticDomTags.NOTE_HOVER_ROOT_CLASS)
       .attr(StaticDomTags.NOTE_ID, (n: NoteViewObject) => n.note.getId())
@@ -229,7 +229,7 @@ export class NotesView {
       .on("mouseover", (_, n: NoteViewObject) => this.onNoteMouseover(n.note));
   }
 
-  private makeNoteRoot(groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>) {
+  private makeNoteRoot(groupEnter: d3.Selection<SVGGElement, NoteViewObject, Element, undefined>) {
     groupEnter
       .append(StaticDomTags.NOTE_ROOT_SVG)
       .attr("class", StaticDomTags.NOTE_ROOT_CLASS)
@@ -252,7 +252,7 @@ export class NotesView {
   }
 
   private makeNoteTitleArea(
-    groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, NoteViewObject, Element, undefined>,
   ) {
     groupEnter
       .append(StaticDomTags.NOTE_TITELAREA_SVG)
@@ -276,7 +276,7 @@ export class NotesView {
   }
 
   private makeNoteTextArea(
-    groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, NoteViewObject, Element, undefined>,
   ) {
     groupEnter
       .append(StaticDomTags.NOTE_TEXTAREA_SVG)
@@ -303,7 +303,7 @@ export class NotesView {
   }
 
   private makeNoteTitleAreaText(
-    groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, NoteViewObject, Element, undefined>,
   ) {
     groupEnter
       .append(StaticDomTags.NOTE_TITELAREA_TEXT_SVG)
@@ -319,7 +319,7 @@ export class NotesView {
       .on("mouseover", (_, n: NoteViewObject) => this.onNoteMouseover(n.note));
   }
 
-  private makeNoteText(groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>) {
+  private makeNoteText(groupEnter: d3.Selection<SVGGElement, NoteViewObject, Element, undefined>) {
     groupEnter
       .append(StaticDomTags.NOTE_TEXT_SVG)
       .attr("class", StaticDomTags.NOTE_TEXT_CLASS)
@@ -335,9 +335,9 @@ export class NotesView {
   }
 
   private makeNoteDragAreaBackground(
-    groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, NoteViewObject, Element, undefined>,
   ) {
-    const added = groupEnter.append(StaticDomTags.NOTE_HOVER_DRAG_AREA_BACKGROUND_SVG);
+    const added = groupEnter.append<SVGElement>(StaticDomTags.NOTE_HOVER_DRAG_AREA_BACKGROUND_SVG);
 
     added
       .attr("class", StaticDomTags.NOTE_HOVER_DRAG_AREA_BACKGROUND_CLASS)
@@ -360,13 +360,13 @@ export class NotesView {
   }
 
   private makeNoteDragArea(
-    groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, NoteViewObject, Element, undefined>,
   ) {
     if (!this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable()) {
       return;
     }
     groupEnter
-      .append(StaticDomTags.NOTE_HOVER_DRAG_AREA_SVG)
+      .append<SVGElement>(StaticDomTags.NOTE_HOVER_DRAG_AREA_SVG)
       .attr("class", StaticDomTags.NOTE_HOVER_DRAG_AREA_CLASS)
       .classed(StaticDomTags.TAG_SELECTED, (n: NoteViewObject) => n.note.selected())
       .attr(StaticDomTags.NOTE_ID, (n: NoteViewObject) => n.note.getId())
@@ -452,32 +452,32 @@ export class NotesView {
 
   onNoteMouseoverDragButton(note: Note) {
     this.onNoteMouseover(note);
-    d3.selectAll(StaticDomTags.NOTE_HOVER_DRAG_AREA_DOM_REF)
+    d3.selectAll<SVGElement, NoteViewObject>(StaticDomTags.NOTE_HOVER_DRAG_AREA_DOM_REF)
       .filter((n: NoteViewObject) => n.note.getId() === note.getId())
       .classed(StaticDomTags.TAG_HOVER, true);
   }
 
   onNoteMouseoutDragButton(note: Note) {
-    d3.selectAll(StaticDomTags.NOTE_HOVER_DRAG_AREA_DOM_REF)
+    d3.selectAll<SVGElement, NoteViewObject>(StaticDomTags.NOTE_HOVER_DRAG_AREA_DOM_REF)
       .filter((n: NoteViewObject) => n.note.getId() === note.getId())
       .classed(StaticDomTags.TAG_HOVER, false);
     this.onNoteMouseout(note);
   }
 
   hoverNote(note: Note) {
-    d3.selectAll(StaticDomTags.NOTE_HOVER_DRAG_AREA_DOM_REF)
+    d3.selectAll<SVGElement, NoteViewObject>(StaticDomTags.NOTE_HOVER_DRAG_AREA_DOM_REF)
       .filter((n: NoteViewObject) => n.note.getId() === note.getId())
       .classed(StaticDomTags.TAG_MUTED, true);
-    d3.selectAll(StaticDomTags.NOTE_ROOT_DOM_REF)
+    d3.selectAll<SVGElement, NoteViewObject>(StaticDomTags.NOTE_ROOT_DOM_REF)
       .filter((n: NoteViewObject) => n.note.getId() === note.getId())
       .classed(StaticDomTags.TAG_HOVER, true);
   }
 
   unhoverNote(note: Note) {
-    d3.selectAll(StaticDomTags.NOTE_HOVER_DRAG_AREA_DOM_REF)
+    d3.selectAll<SVGElement, NoteViewObject>(StaticDomTags.NOTE_HOVER_DRAG_AREA_DOM_REF)
       .filter((n: NoteViewObject) => n.note.getId() === note.getId())
       .classed(StaticDomTags.TAG_MUTED, false);
-    d3.selectAll(StaticDomTags.NOTE_ROOT_DOM_REF)
+    d3.selectAll<SVGElement, NoteViewObject>(StaticDomTags.NOTE_ROOT_DOM_REF)
       .filter((n: NoteViewObject) => n.note.getId() === note.getId())
       .classed(StaticDomTags.TAG_HOVER, false);
   }

--- a/src/app/view/editor-main-view/data-views/trainrunsection.previewline.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsection.previewline.view.ts
@@ -59,13 +59,13 @@ export class TrainrunSectionPreviewLineView {
     private versionControlService: VersionControlService,
   ) {}
 
-  static setGroup(nodeGroup: d3.Selection<SVGElement, undefined, Element, undefined>) {
+  static setGroup(nodeGroup: d3.Selection<SVGGElement, undefined, Element, undefined>) {
     nodeGroup
       .append(StaticDomTags.PREVIEW_LINE_ROOT_SVG)
       .attr("class", StaticDomTags.PREVIEW_LINE_ROOT_CLASS);
   }
 
-  static setConnectionGroup(nodeGroup: d3.Selection<SVGElement, undefined, Element, undefined>) {
+  static setConnectionGroup(nodeGroup: d3.Selection<SVGGElement, undefined, Element, undefined>) {
     nodeGroup
       .append(StaticDomTags.PREVIEW_CONNECTION_LINE_ROOT_SVG)
       .attr("class", StaticDomTags.PREVIEW_CONNECTION_LINE_ROOT_CLASS);

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -33,7 +33,7 @@ import {LinePatternRefs} from "../../../data-structures/business.data.structures
 import {TrainrunsectionHelper} from "src/app/services/util/trainrunsection.helper";
 
 export class TrainrunSectionsView {
-  trainrunSectionGroup: d3.Selection<SVGElement, undefined, Element, undefined>;
+  trainrunSectionGroup: d3.Selection<SVGGElement, undefined, Element, undefined>;
 
   constructor(private editorView: EditorView) {}
 
@@ -968,7 +968,7 @@ export class TrainrunSectionsView {
     }
   }
 
-  setGroup(trainrunSectionGroup: d3.Selection<SVGElement, undefined, Element, undefined>) {
+  setGroup(trainrunSectionGroup: d3.Selection<SVGGElement, undefined, Element, undefined>) {
     trainrunSectionGroup.attr("class", "TrainrunSectionsView");
     this.trainrunSectionGroup = trainrunSectionGroup
       .append(StaticDomTags.GROUP_SVG)
@@ -976,7 +976,7 @@ export class TrainrunSectionsView {
   }
 
   createTrainrunSectionTextBackgrounds(
-    groupEnter: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, TrainrunSectionViewObject, Element, undefined>,
     lineTextElement: TrainrunSectionText,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
@@ -1101,7 +1101,7 @@ export class TrainrunSectionsView {
    * @param enableEvents - Optional flag to enable or disable mouse event handlers on the arrows. Defaults to true.
    */
   createDirectionArrows(
-    groupLinesEnter: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
+    groupLinesEnter: d3.Selection<SVGGElement, TrainrunSectionViewObject, Element, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
     enableEvents = true,
@@ -1162,7 +1162,7 @@ export class TrainrunSectionsView {
   }
 
   createAsymmetryArrows(
-    groupLinesEnter: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
+    groupLinesEnter: d3.Selection<SVGGElement, TrainrunSectionViewObject, Element, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
     enableEvents = true,
@@ -1237,7 +1237,7 @@ export class TrainrunSectionsView {
   }
 
   createTrainrunSection(
-    groupEnter: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, TrainrunSectionViewObject, Element, undefined>,
     classRef: string,
     levelFreqFilter: LinePatternRefs[],
     selectedTrainrun: Trainrun,
@@ -1293,7 +1293,7 @@ export class TrainrunSectionsView {
   }
 
   createTrainrunsectionSemicircleAtNode(
-    groupEnter: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, TrainrunSectionViewObject, Element, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
     atSource: boolean,
@@ -1359,7 +1359,7 @@ export class TrainrunSectionsView {
   }
 
   createTrainrunsectionSemicircles(
-    groupEnter: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, TrainrunSectionViewObject, Element, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
   ) {
@@ -1384,7 +1384,7 @@ export class TrainrunSectionsView {
   }
 
   createPinOnTrainrunsection(
-    groupEnter: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, TrainrunSectionViewObject, Element, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
     atSource: boolean,
@@ -1468,7 +1468,7 @@ export class TrainrunSectionsView {
   }
 
   private createInternTrainrunSectionElementFilteringWarningElements(
-    groupEnter: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, TrainrunSectionViewObject, Element, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
     textElement: TrainrunSectionText,
@@ -1579,7 +1579,7 @@ export class TrainrunSectionsView {
   }
 
   createTrainrunSectionElement(
-    groupEnter: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, TrainrunSectionViewObject, Element, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
     textElement: TrainrunSectionText,
@@ -1607,7 +1607,7 @@ export class TrainrunSectionsView {
   }
 
   createTrainrunSectionGotoInfoElement(
-    groupEnter: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, TrainrunSectionViewObject, Element, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
     atSource: boolean,
@@ -1662,7 +1662,7 @@ export class TrainrunSectionsView {
   }
 
   createNumberOfStopsTextElement(
-    groupEnter: d3.Selection<SVGElement, undefined, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, undefined, Element, undefined>,
     trainrunSection: TrainrunSection,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
@@ -1707,7 +1707,7 @@ export class TrainrunSectionsView {
   }
 
   createIntermediateStops(
-    groupEnter: d3.Selection<SVGElement, undefined, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, undefined, Element, undefined>,
     trainrunSection: TrainrunSection,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
@@ -1811,7 +1811,7 @@ export class TrainrunSectionsView {
     );
 
     const group = this.trainrunSectionGroup
-      .selectAll(StaticDomTags.EDGE_ROOT_CONTAINER_DOM_REF)
+      .selectAll<SVGElement, TrainrunSectionViewObject>(StaticDomTags.EDGE_ROOT_CONTAINER_DOM_REF)
       .data(
         this.createViewTrainrunSectionDataObjects(this.editorView, filteredTrainrunSections),
         (d: TrainrunSectionViewObject) => d.key,
@@ -2066,7 +2066,7 @@ export class TrainrunSectionsView {
       return;
     }
     const obj = d3
-      .selectAll(
+      .selectAll<SVGElement, TrainrunSectionViewObject>(
         StaticDomTags.EDGE_LINE_PIN_DOM_REF +
           "." +
           (atSource ? StaticDomTags.EDGE_IS_TARGET : StaticDomTags.EDGE_IS_SOURCE),
@@ -2327,10 +2327,10 @@ export class TrainrunSectionsView {
   }
 
   private oneNodeHiddenTrainrunSectionsRendering(
-    inGroupLines: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
+    inGroupLines: d3.Selection<SVGGElement, TrainrunSectionViewObject, Element, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
-    inGroupLabels: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
+    inGroupLabels: d3.Selection<SVGGElement, TrainrunSectionViewObject, Element, undefined>,
   ) {
     const groupLines = inGroupLines.filter(
       (d: TrainrunSectionViewObject) =>
@@ -2446,7 +2446,7 @@ export class TrainrunSectionsView {
   }
 
   private defaultTrainrunSectionsRendering(
-    inGroupLines: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
+    inGroupLines: d3.Selection<SVGGElement, TrainrunSectionViewObject, Element, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
     inGroupLabels: d3.Selection<SVGGElement, TrainrunSectionViewObject, Element, undefined>,
@@ -2602,7 +2602,7 @@ export class TrainrunSectionsView {
   }
 
   make4LayerTrainrunSectionLines(
-    groupLines: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
+    groupLines: d3.Selection<SVGGElement, TrainrunSectionViewObject, Element, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
     enableEvents: boolean,
@@ -2646,7 +2646,7 @@ export class TrainrunSectionsView {
     lineOrientationVector: Vec2D,
     stopIndex: number,
     drawNumberOfStops: number,
-    groupEnter: d3.Selection<SVGElement, undefined, Element, undefined>,
+    groupEnter: d3.Selection<SVGGElement, undefined, Element, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
     numberOfStops: number,

--- a/src/app/view/editor-main-view/data-views/transitions.view.ts
+++ b/src/app/view/editor-main-view/data-views/transitions.view.ts
@@ -11,8 +11,8 @@ import {TransitionViewObject} from "./transitionViewObject";
 import {LinePatternRefs} from "../../../data-structures/business.data.structures";
 
 export class TransitionsView {
-  transitionsGroup: d3.Selection<SVGElement, undefined, Element, undefined>;
-  selectedTransitionsGroup: d3.Selection<SVGElement, undefined, Element, undefined>;
+  transitionsGroup: d3.Selection<SVGGElement, undefined, Element, undefined>;
+  selectedTransitionsGroup: d3.Selection<SVGGElement, undefined, Element, undefined>;
   editorView: EditorView;
 
   constructor(editorView: EditorView) {
@@ -82,7 +82,7 @@ export class TransitionsView {
   }
 
   static createTransitionLineLayer(
-    grpEnter: d3.Selection<SVGElement, TransitionViewObject, Element, undefined>,
+    grpEnter: d3.Selection<SVGGElement, TransitionViewObject, Element, undefined>,
     classRef: string,
     levelFreqFilter: LinePatternRefs[],
     selectedTrainrun: Trainrun,
@@ -122,7 +122,7 @@ export class TransitionsView {
   }
 
   createNonStopToggle(
-    grpEnter: d3.Selection<SVGElement, TransitionViewObject, Element, undefined>,
+    grpEnter: d3.Selection<SVGGElement, TransitionViewObject, Element, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
   ) {
@@ -166,7 +166,7 @@ export class TransitionsView {
       );
   }
 
-  setGroup(transitionsGroup: d3.Selection<SVGElement, undefined, Element, undefined>) {
+  setGroup(transitionsGroup: d3.Selection<SVGGElement, undefined, Element, undefined>) {
     transitionsGroup.attr("class", "TransitionsView");
     this.transitionsGroup = transitionsGroup.append(StaticDomTags.GROUP_SVG);
     this.transitionsGroup.attr("class", "transitions");
@@ -220,7 +220,7 @@ export class TransitionsView {
     }
 
     const transitionsGroup = rootGroup
-      .selectAll(StaticDomTags.TRANSITION_ROOT_CONTAINER_DOM_REF)
+      .selectAll<SVGElement, TransitionViewObject>(StaticDomTags.TRANSITION_ROOT_CONTAINER_DOM_REF)
       .data(
         TransitionsView.createTransitionViewObjects(
           this.editorView,

--- a/src/app/view/project/project-dialog/project-form/project-form.component.ts
+++ b/src/app/view/project/project-dialog/project-form/project-form.component.ts
@@ -1,5 +1,5 @@
 import {Component, Input, OnInit, ChangeDetectionStrategy} from "@angular/core";
-import {UntypedFormControl, Validators} from "@angular/forms";
+import {Validators, ValidatorFn} from "@angular/forms";
 import {FormModel} from "../../../../utils/form-model";
 import {COMMA, ENTER} from "@angular/cdk/keycodes";
 
@@ -46,7 +46,7 @@ export class ProjectFormComponent implements OnInit {
   }
 }
 
-export const userIdsAsEmailValidator = (control: UntypedFormControl) => {
+export const userIdsAsEmailValidator: ValidatorFn = (control) => {
   if (!control) {
     return null;
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,6 @@
     "useDefineForClassFields": false,
     "strict": true,
     "strictNullChecks": false,
-    "strictFunctionTypes": false,
     "noImplicitAny": true,
     "noUnusedParameters": true
   },


### PR DESCRIPTION
This option enables more checks around function parameters: https://www.typescriptlang.org/tsconfig/#strictFunctionTypes

d3 is the main error culprit. Some types need to be narrowed down (e.g. switched from `SVGElement` to `SVGGElement`, notice the extra "G"). `selectAll()` can't guess what the type of the element and datum will be, so we need to explicitly specify these.

Unfortunately, `d3.Selection` cannot be easily converted from a more precise type to a more general type. This requires us to sometimes use a more general type in `append()`, and for one call we need a dummy `filter()` call to switch the element type.

References: https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/issues/1289