### PR TITLE
fix: avoid ID collision in `createNewTrainrunSectionFromDto()`

### DIFF
--- a/src/app/models/trainrunsection.model.ts
+++ b/src/app/models/trainrunsection.model.ts
@@ -26,6 +26,9 @@ const EMPTY_TEXT_POSITIONS: TrainrunSectionTextPositions = {
   [TrainrunSectionText.TrainrunSectionNumberOfStops]: {x: 0, y: 0},
 };
 
+type TrainrunSectionOptions = Omit<TrainrunSectionDto, "id"> &
+  Partial<Pick<TrainrunSectionDto, "id">>;
+
 export class TrainrunSection {
   private static currentId = 0;
 
@@ -61,7 +64,7 @@ export class TrainrunSection {
 
   constructor(
     {
-      id,
+      id = TrainrunSection.incrementId(),
       sourceNodeId,
       sourcePortId,
       targetNodeId,
@@ -83,8 +86,7 @@ export class TrainrunSection {
         textPositions: {...EMPTY_TEXT_POSITIONS},
       },
       warnings,
-    }: TrainrunSectionDto = {
-      id: TrainrunSection.incrementId(),
+    }: TrainrunSectionOptions = {
       sourceNodeId: 0,
       sourcePortId: 0,
       targetNodeId: 0,

--- a/src/app/services/data/trainrunsection.service.ts
+++ b/src/app/services/data/trainrunsection.service.ts
@@ -1339,7 +1339,10 @@ export class TrainrunSectionService implements OnDestroy {
     const trainrunId = trainrunMap.get(trainrunSection.trainrunId);
     const trainrun = this.trainrunService.getTrainrunFromId(trainrunId);
 
-    const newTrainrunSection: TrainrunSection = new TrainrunSection(trainrunSection);
+    const newTrainrunSection: TrainrunSection = new TrainrunSection({
+      ...trainrunSection,
+      id: undefined,
+    });
     newTrainrunSection.setTrainrun(trainrun);
 
     const sourceNodeId = nodeMap.get(trainrunSection.sourceNodeId);


### PR DESCRIPTION
This function invokes the TrainrunSection constructor with a fixed ID. If the trainrun section service already has another trainrun section with the same ID, we end up with two different sections sharing the same ID.

Avoid this by making the `id` field optional in the constructor, and erasing it in `createNewTrainrunSectionFromDto()`.